### PR TITLE
Update link to main blog to use patrick.lioi.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <div id="main_content_wrap" class="outer">
       <section id="main_content" class="inner">
         <h3>Articles about Fixie</h3>
-          <aside class="callout">Keep up with the latest on <a href="http://www.headspring.com/author/patrick/">Patrick's blog</a>.</aside>
+          <aside class="callout">Keep up with the latest on <a href="http://patrick.lioi.net/">Patrick's blog</a>.</aside>
 
           <article>
               <h4><a href="https://github.com/plioi/fixie#fixie">Fixie's ReadMe</a></h4>


### PR DESCRIPTION
The "Keep up with the latest" link at the top also needed to be updated to the new url.
