### PR TITLE
Repeatable shuffled test runs

### DIFF
--- a/src/Fixie.Samples/Fixie.Samples.csproj
+++ b/src/Fixie.Samples/Fixie.Samples.csproj
@@ -59,6 +59,8 @@
     <Compile Include="NUnitStyle\CustomConvention.cs" />
     <Compile Include="NUnitStyle\Attributes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Samples\CustomConvention.cs" />
+    <Compile Include="Samples\OrderTests.cs" />
     <Compile Include="StringBuilderExtensions.cs" />
     <Compile Include="xUnitStyle\CalculatorTests.cs" />
     <Compile Include="xUnitStyle\CustomConvention.cs" />

--- a/src/Fixie.Samples/Samples/CustomConvention.cs
+++ b/src/Fixie.Samples/Samples/CustomConvention.cs
@@ -1,0 +1,28 @@
+﻿using Fixie.Conventions;
+using System;
+using System.Linq;
+
+namespace Fixie.Samples.Samples
+{
+    public class CustomConvention : Convention
+    {
+        public CustomConvention(RunContext runContext)
+        {
+            var customSeed = runContext.Options["seed"].LastOrDefault();
+            int seed = Environment.TickCount;
+            if (customSeed != null)
+            {
+                seed = Int32.Parse(customSeed);
+            }
+            Console.WriteLine("Running shuffled tests using seed: {0}", seed);
+
+            Classes
+                .Where(type => type.IsInNamespace(GetType().Namespace));
+
+            Cases
+                .Where(method => method.IsVoid());
+
+            ClassExecution.ShuffleCases(new Random(seed));
+        }
+    }
+}

--- a/src/Fixie.Samples/Samples/OrderTests.cs
+++ b/src/Fixie.Samples/Samples/OrderTests.cs
@@ -1,0 +1,15 @@
+﻿namespace Fixie.Samples.Samples
+{
+    public class OrderTests
+    {
+        public void TestA() { }
+        public void TestB() { }
+        public void TestC() { }
+        public void TestD() { }
+        public void TestE() { }
+        public void TestF() { }
+        public void TestG() { }
+        public void TestH() { }
+        public void TestI() { }
+    }
+}


### PR DESCRIPTION
Running tests in a randomized order is a good way to expose inadvertent dependencies between tests. However, when a test-order related issue is suspected, it is important to be able to repeat that exact test run that had a failure.

When using the `ShuffleCases` instruction in your convention, you will almost always want to know the seed that was used to initialize the randomizer. You will also want to be able to re-run a test-suite with a given seed, when a failure is found.

I figured at the very least, a sample should be provided to demonstrate this approach. However, I think it makes sense to add some built-in support for this additional functionality, since it will likely be used by anyone that cares about the `ShuffleCases` feature. At this point, I'm not as familiar with the codebase to know how communication with the user (which seed was used) should be handled.

> Note: to really demonstrate this sample, you need a `Listener` that shows the name of passing tests, so that you can see the order is repeatable. Changing `ConsoleListener` seemed out of scope for this PR, so I did not include that change.
