### PR TITLE
Create a way to modify case's naming convention

### DIFF
--- a/src/Fixie.Samples/ChangeCaseName/CalculatorTests.cs
+++ b/src/Fixie.Samples/ChangeCaseName/CalculatorTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Should;
+
+namespace Fixie.Samples.ChangeCaseName
+{
+    public class CalculatorTests
+    {
+        readonly Calculator calculator;
+        string test;
+
+        public CalculatorTests()
+        {
+            calculator = new Calculator();
+        }
+
+        public void ShouldAdd()
+        {
+            test.ShouldBeNull();
+            test = "ShouldAdd";
+
+            calculator.Add(2, 3).ShouldEqual(5);
+        }
+
+    }
+}

--- a/src/Fixie.Samples/ChangeCaseName/CustomCaseBuilder.cs
+++ b/src/Fixie.Samples/ChangeCaseName/CustomCaseBuilder.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Fixie.Conventions;
+
+namespace Fixie.Samples.ChangeCaseName
+{
+    public class CustomCaseBuilder : ICaseBuilder
+    {
+        public Case Build(Type testClass, MethodInfo caseMethod, object[] parameters)
+        {
+            return new CustomCase(testClass, caseMethod, parameters);
+        }
+
+        public class CustomCase : Case
+        {
+            public CustomCase(Type testClass, MethodInfo caseMethod, params object[] parameters):
+                base(testClass, caseMethod, parameters)
+            {
+
+            }
+
+            /// <summary>
+            /// Try naively to remove "tests" or "test" in the case's name
+            /// </summary>
+            /// <returns></returns>
+            protected override string GetName()
+            {
+                return base.GetName().Replace("Tests", "").Replace("Test", "");
+            }
+        }
+
+    }
+}

--- a/src/Fixie.Samples/ChangeCaseName/CustomConvention.cs
+++ b/src/Fixie.Samples/ChangeCaseName/CustomConvention.cs
@@ -1,0 +1,22 @@
+﻿using Fixie.Conventions;
+
+namespace Fixie.Samples.ChangeCaseName
+{
+    public class CustomConvention : Convention
+    {
+        public CustomConvention(RunContext runContext)
+        {
+            CaseBuilder = new CustomCaseBuilder();
+            
+            Classes
+                .Where(type => type.IsInNamespace(GetType().Namespace))
+                .NameEndsWith("Tests");
+
+            Methods
+                .Where(method => method.IsVoid());
+
+            ClassExecution
+                .CreateInstancePerTestClass();
+        }
+    }
+}

--- a/src/Fixie.Samples/Fixie.Samples.csproj
+++ b/src/Fixie.Samples/Fixie.Samples.csproj
@@ -46,6 +46,9 @@
     <Compile Include="Categories\CalculatorTests.cs" />
     <Compile Include="Categories\CustomConvention.cs" />
     <Compile Include="Categories\Attributes.cs" />
+    <Compile Include="ChangeCaseName\CalculatorTests.cs" />
+    <Compile Include="ChangeCaseName\CustomCaseBuilder.cs" />
+    <Compile Include="ChangeCaseName\CustomConvention.cs" />
     <Compile Include="Explicit\CalculatorTests.cs" />
     <Compile Include="Explicit\CustomConvention.cs" />
     <Compile Include="Explicit\ExplicitAttribute.cs" />

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -23,7 +23,7 @@ namespace Fixie
             Name = GetName();
         }
 
-        string GetName()
+        protected virtual string GetName()
         {
             var name = Class.FullName + "." + Method.Name;
 

--- a/src/Fixie/Conventions/Convention.cs
+++ b/src/Fixie/Conventions/Convention.cs
@@ -13,6 +13,7 @@ namespace Fixie.Conventions
         {
             Classes = new ClassFilter().Where(type => !type.IsSubclassOf(typeof(Convention)));
             Methods = new MethodFilter().Where(m => !m.IsDispose());
+            CaseBuilder = new DefaultCaseBuilder();
             CaseExecution = new CaseBehaviorBuilder();
             InstanceExecution = new InstanceBehaviorBuilder();
             ClassExecution = new TypeBehaviorBuilder().CreateInstancePerCase();
@@ -22,6 +23,7 @@ namespace Fixie.Conventions
 
         public ClassFilter Classes { get; private set; }
         public MethodFilter Methods { get; private set; }
+        public ICaseBuilder CaseBuilder { get; protected set; }
         public CaseBehaviorBuilder CaseExecution { get; private set; }
         public InstanceBehaviorBuilder InstanceExecution { get; private set; }
         public TypeBehaviorBuilder ClassExecution { get; private set; }
@@ -39,7 +41,7 @@ namespace Fixie.Conventions
 
                 var cases = methods.SelectMany(method =>
                     methodCallParameterBuilder(method).Select(parameters =>
-                        new Case(testClass, method, parameters))).ToArray();
+                        CaseBuilder.Build(testClass, method, parameters))).ToArray();
 
                 ClassExecution.Behavior.Execute(testClass, this, cases);
 

--- a/src/Fixie/Conventions/DefaultCaseBuilder.cs
+++ b/src/Fixie/Conventions/DefaultCaseBuilder.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fixie.Conventions
+{
+    internal class DefaultCaseBuilder : ICaseBuilder
+    {
+        public Case Build(Type testClass, MethodInfo method, object[] parameters)
+        {
+            return new Case(testClass, method, parameters);
+        }
+    }
+}

--- a/src/Fixie/Conventions/ICaseBuilder.cs
+++ b/src/Fixie/Conventions/ICaseBuilder.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Fixie.Conventions
+{
+    public interface ICaseBuilder
+    {
+        Case Build(Type type, MethodInfo method, object[] parameters);
+    }
+}

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -48,7 +48,9 @@
     <Compile Include="ConsoleListener.cs" />
     <Compile Include="ConsoleRunner.cs" />
     <Compile Include="Conventions\Convention.cs" />
+    <Compile Include="Conventions\DefaultCaseBuilder.cs" />
     <Compile Include="Conventions\DefaultConvention.cs" />
+    <Compile Include="Conventions\ICaseBuilder.cs" />
     <Compile Include="Conventions\InstanceBehaviorBuilder.cs" />
     <Compile Include="Conventions\CaseBehaviorBuilder.cs" />
     <Compile Include="Conventions\SelfTestConvention.cs" />


### PR DESCRIPTION
At the start, just wanted to take a look to the core of your framework. But finally I've added a small feature. Feel free to reject it.
