### PR TITLE
Add support for generic arguments on test methods

### DIFF
--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Behaviors\InstanceBehavior.cs" />
     <Compile Include="CaseExecution.cs" />
     <Compile Include="CaseResult.cs" />
+    <Compile Include="GenericArgumentResolver.cs" />
     <Compile Include="RedirectedConsole.cs" />
     <Compile Include="Behaviors\TypeBehavior.cs" />
     <Compile Include="Case.cs" />

--- a/src/Fixie/GenericArgumentResolver.cs
+++ b/src/Fixie/GenericArgumentResolver.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Fixie
+{
+    public class GenericArgumentResolver
+    {
+        public static Type[] ResolveTypeArguments(MethodInfo method, object[] parameters)
+        {
+            Type[] genericArguments = method.GetGenericArguments();
+            Dictionary<Type, Type> typeMapping = new Dictionary<Type, Type>();
+            List<Type> parameterTypes = method.GetParameters().Select(p => p.ParameterType).ToList();
+
+            foreach (Type genericArgument in genericArguments)
+            {
+                typeMapping.Add(genericArgument, GetArgumentType(genericArgument, parameterTypes, parameters));
+            }
+
+            Type[] typeParameters = new Type[genericArguments.Length];
+            for (int i = 0; i < typeParameters.Length; i++)
+                typeParameters[i] = typeMapping[genericArguments[i]];
+            return typeParameters;
+        }
+
+
+        private static Type GetArgumentType(Type genericArgumentType, IList<Type> parameterTypes, object[] parameterValues)
+        {
+            List<int> matchingArguments = new List<int>();
+            for (int i = 0; i < parameterTypes.Count; i++)
+            {
+                if (parameterTypes[i] == genericArgumentType)
+                    matchingArguments.Add(i);
+            }
+            if (matchingArguments.Count == 0)
+                return typeof(object);
+
+            if (matchingArguments.Count == 1)
+                return parameterValues[matchingArguments[0]] == null ? typeof(object) : parameterValues[matchingArguments[0]].GetType();
+
+            object result = Combine(parameterValues[matchingArguments[0]], parameterValues[matchingArguments[1]]);
+
+            result = matchingArguments.Skip(2).Select(a => parameterValues[a]).Aggregate(result, Combine);
+            return result == null ? typeof(object) : result.GetType();
+        }
+
+        private static object Combine(object a, object b)
+        {
+            if (a == null)
+                return b == null ? null : b.GetType().IsValueType ? null : b;
+            if (b == null)
+                return a.GetType().IsValueType ? null : a;
+            if (a.GetType() == b.GetType())
+                return a;
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
I haven't found any prior art to look at, tried looking quickly at xUnit but didn't find the type resolution code. I used the same heuristics outlined in this post http://bradwilson.typepad.com/blog/2012/01/xunit19.html

The type parameter resolution is currently hard coded, but a possible improvement could be passing in a strategy similar to how the parameter values work.

I did bump into some issues in testing:
- There are 3 test failures coming from the OrderBy(methodName) being the wrong way(?)
- One can't trust the order of reflection over attributes, so using the [Input] attribute and then comparing the log entries seems brittle as they may reorder. I settled for checking "contains" in the log entries.
