### PR TITLE
add cli option to opt out of TeamCityListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,11 @@ In addition to identifying the types which make up your assertion library of cho
 
 When the console runner is invoked by TeamCity, the console output is formatted so that TeamCity can detect individual test results for display.
 
-When running under other CI tools, you can generate familiar NUnit- or xUnit-style XML reports by including an extra command line argument:
+To opt-out from TeamCity output and use an xml result file instead, first use the extra command line argument:
+
+    Fixie.Console.exe path/to/your/test/project.dll --fixie:OptOutTeamcity true
+
+When running under other CI tools, or when you opted out of the Teamcity output,  you can generate familiar NUnit- or xUnit-style XML reports by including an extra command line argument:
 
     Fixie.Console.exe path/to/your/test/project.dll --fixie:NUnitXml TestResult.xml
     

--- a/src/Fixie/CommandLineOption.cs
+++ b/src/Fixie/CommandLineOption.cs
@@ -4,5 +4,6 @@
     {
         public const string NUnitXml = "fixie:NUnitXml";
         public const string XUnitXml = "fixie:XUnitXml";
+        public const string OptOutTeamCity = "fixie:OptOutTeamcity";
     }
 }

--- a/src/Fixie/ConsoleRunner.cs
+++ b/src/Fixie/ConsoleRunner.cs
@@ -12,16 +12,16 @@ namespace Fixie
             var assembly = Assembly.Load(AssemblyName.GetAssemblyName(assemblyFullPath));
 
             var options = new CommandLineParser(args).Options;
-
-            var runner = new Runner(CreateListener(), options);
+            var optOutTeamcity = options.Contains(CommandLineOption.OptOutTeamCity);
+            var runner = new Runner(CreateListener(optOutTeamcity), options);
             return runner.RunAssembly(assembly);
         }
 
-        static Listener CreateListener()
+        static Listener CreateListener(bool optOutTeamcity)
         {
             var runningUnderTeamCity = Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null;
 
-            if (runningUnderTeamCity)
+            if (!optOutTeamcity && runningUnderTeamCity)
                 return new TeamCityListener();
 
             return new ConsoleListener();


### PR DESCRIPTION
This adds the option to opt out of the built-in `TeamcityListener` and use the regular `ConsoleListener` instead. This is needed because Teamcity can't handle the duplicate reporting when one is using xml output.

For now, you have to pass `--fixie:OptOutTeamcity true` as the `CommandLineParser` forces the arguments to always be pairs, ideally I'd like to be able to pass only `--fixie:OptOutTeamcity` as a flag. I didn't want to make this change now as it makes things a bit more complicated for parsing cli arguments.

@plioi, if you decide to merge this, please let me know when you plan to publish it to nuget, so that I can update our project.

Ah, and thanks for creating this awesome tool. fixie is awesome.
