### PR TITLE
Add ability to set the case name

### DIFF
--- a/src/Fixie.Tests/Cases/CustomNameCaseTests.cs
+++ b/src/Fixie.Tests/Cases/CustomNameCaseTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Should;
+
+namespace Fixie.Tests.Cases
+{
+    public class CustomNameCaseTests : CaseTests
+    {
+        public void ShouldSetTheCustomName()
+        {
+            Convention.CaseExecution.Name(@case =>
+            {
+                return @case.Method.Name + ".Custom";
+            });
+
+            Run<NameTestClass>();
+
+            Listener.Entries.ShouldEqual(
+                "Fail.Custom failed: 'Fail' failed!",
+                "Pass.Custom passed.");
+        }
+
+        public void ShouldFailWithClearExplanationWhenCustomNameThrows()
+        {
+            Convention.CaseExecution
+                .Name(@case => { throw new Exception("Unsafe name generator threw!"); });
+
+            Action attemptFaultyName = Run<NameTestClass>;
+
+            var exception = attemptFaultyName.ShouldThrow<Exception>(
+                "Exception thrown while attempting to get a custom case name. " +
+                "Check the inner exception for more details.");
+
+            exception.InnerException.Message.ShouldEqual("Unsafe name generator threw!");
+        }
+
+        public void ShouldSortByCustomName()
+        {
+            Convention.CaseExecution
+                .Name(@case =>
+                {
+                    switch (@case.Method.Name)
+                    {
+                        case "Pass":
+                            return "A";
+                        case "Fail":
+                            return "B";
+                        default:
+                            throw new Exception();
+                    }
+                });
+            Convention.ClassExecution.SortCases((a, b) =>
+            {
+                return a.Name.CompareTo(b.Name);
+            });
+
+            Run<NameTestClass>();
+
+            Listener.Entries.ElementAt(0).ShouldStartWith("A passed");
+            Listener.Entries.ElementAt(1).ShouldStartWith("B failed");
+        }
+
+        class NameTestClass
+        {
+            public void Fail() { throw new FailureException(); }
+
+            public void Pass() { }
+        }
+    }
+}

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="AssertionLibraryFilteringTests.cs" />
     <Compile Include="Assertions.cs" />
+    <Compile Include="Cases\CustomNameCaseTests.cs" />
     <Compile Include="MethodGroupTests.cs" />
     <Compile Include="Internal\ParameterDiscovererTests.cs" />
     <Compile Include="Execution\AppDomainCommunicationAssertions.cs" />

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -45,7 +45,7 @@ namespace Fixie
         /// <summary>
         /// Gets the name of the test case, including any input parameters.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; internal set; }
 
         /// <summary>
         /// Gets the test class in which this test case is defined.

--- a/src/Fixie/Conventions/CaseBehaviorExpression.cs
+++ b/src/Fixie/Conventions/CaseBehaviorExpression.cs
@@ -76,6 +76,15 @@ namespace Fixie.Conventions
             return this;
         }
 
+        /// <summary>
+        /// Allows customizing the name of a given case.
+        /// </summary>
+        public CaseBehaviorExpression Name(Func<Case, string> getCaseName)
+        {
+            config.GetCaseName = getCaseName;
+            return this;
+        }
+
         class LambdaBehavior : CaseBehavior
         {
             readonly CaseBehaviorAction execute;

--- a/src/Fixie/Internal/Configuration.cs
+++ b/src/Fixie/Internal/Configuration.cs
@@ -22,6 +22,7 @@ namespace Fixie.Internal
             TestClassFactory = UseDefaultConstructor;
             SkipCase = @case => false;
             GetSkipReason = @case => null;
+            GetCaseName = @case => null;
 
             testClassConditions = new List<Func<Type, bool>>
             {
@@ -43,6 +44,7 @@ namespace Fixie.Internal
             assertionLibraryTypes = new List<Type>();
         }
 
+        public Func<Case, string> GetCaseName { get; set; }
         public Action<Case[]> OrderCases { get; set; }
         public ConstructionFrequency ConstructionFrequency { get; set; }
         public Func<Type, object> TestClassFactory { get; set; }


### PR DESCRIPTION
Sometimes, it's nice to change the name of the case (e.g. removing `+` for nested classes, replacing underscores with spaces, or specifying a `[Name]` attribute etc). I've added the ability to override the case name.

I've added a configuration property `GetCaseName` that is exposed via the `CaseBehaviorExpression.Name` extension method. This allows the following:

``` csharp
CaseExecution.Name(@case =>
{
    return @case.Name.Replace('+', '.');
});
```

It sort of felt weird adding the `Name()` to the `CaseExecution`, since it's not really _part_ of the execution. But, I stuck it there for now unless that needs to change.

It'll only override the name if the result of the `GetCaseName` function returns a non-null and non-whitespace value.
