### PR TITLE
Allow the TD.NET runner to execute nested classes given a type

### DIFF
--- a/src/Fixie.TestDriven/TdNetRunner.cs
+++ b/src/Fixie.TestDriven/TdNetRunner.cs
@@ -2,7 +2,9 @@
 using System.Reflection;
 using Fixie.Execution;
 using Fixie.Internal;
+using System.Linq;
 using TestDriven.Framework;
+using System.Collections.Generic;
 
 namespace Fixie.TestDriven
 {
@@ -26,9 +28,22 @@ namespace Fixie.TestDriven
 
             var type = member as Type;
             if (type != null)
-                return Run(testListener, runner => runner.RunType(assembly, type));
+            {
+                var types = GetTypeAndNestedTypes(type).ToArray();
+                return Run(testListener, runner => runner.RunTypes(assembly, types));
+            }
 
             return TestRunState.Error;
+        }
+
+        private static IEnumerable<Type> GetTypeAndNestedTypes(Type type)
+        {
+            yield return type;
+
+            foreach (var nestedType in type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic).SelectMany(t => GetTypeAndNestedTypes(t)))
+            {
+                yield return nestedType;
+            }
         }
 
         public TestRunState Run(ITestListener testListener, Func<Runner, AssemblyResult> run)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -41,6 +41,11 @@ namespace Fixie.Internal
             return RunTypes(assembly, type);
         }
 
+        public AssemblyResult RunTypes(Assembly assembly, params Type[] types)
+        {
+            return Run(assembly, GetConventions(assembly), types);
+        }
+
         public AssemblyResult RunTypes(Assembly assembly, Convention convention, params Type[] types)
         {
             RunContext.Set(options);
@@ -80,12 +85,7 @@ namespace Fixie.Internal
                 .GetMethods(BindingFlags.Public | BindingFlags.Instance)
                 .Where(m => m.Name == methodGroup.Method);
         }
-
-        AssemblyResult RunTypes(Assembly assembly, params Type[] types)
-        {
-            return Run(assembly, GetConventions(assembly), types);
-        }
-
+        
         static Convention[] GetConventions(Assembly assembly)
         {
             return new ConventionDiscoverer(assembly).GetConventions();


### PR DESCRIPTION
We use xUnit.net and TestDriven.NET for tests. Currently, we use nested classes for adding more context to our test classes/test names. For example:

```csharp
class CalculatorTests
{
    class Adding
    {
        public void computes_the_sum()
        {
            var sut = new Calculator();

            var result = sut.Add(1, 2);

            result.ShouldEqual(3);
        }
    }

    class Subtracting
    {
        public void computes_the_difference()
        {
            var sut = new Calculator();

            var result = sut.Subtract(3, 2);

            result.ShouldEqual(1);
        }
    }
}
```

If we put our cursor on the `CalculatorTests`, it runs all of the tests (including nested classes). Right now, fixie only runs the given type, `CalculatorTests` and does not run the nested tests. However, if we run the whole assembly, the tests are run (inconsistent). This PR makes fixie's TD.NET runner run the given type and all nested types.

It uses recursion to find all nested classes for a given type. It also makes the `Fixie.Internal.Runner.RunType` unused (should it be marked as `Obsolete`?).