### PR TITLE
TestDriven.NET runner includes tests from nested classes when the user targets a type.

### DIFF
--- a/src/Fixie.TestDriven/TdNetRunner.cs
+++ b/src/Fixie.TestDriven/TdNetRunner.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Fixie.Execution;
 using Fixie.Internal;
@@ -35,9 +37,21 @@ namespace Fixie.TestDriven
 
             var type = member as Type;
             if (type != null)
-                return Run(testListener, runner => runner.RunType(assembly, type));
+            {
+                var types = GetTypeAndNestedTypes(type).ToArray();
+
+                return Run(testListener, runner => runner.RunTypes(assembly, types));
+            }
 
             return TestRunState.Error;
+        }
+
+        IEnumerable<Type> GetTypeAndNestedTypes(Type type)
+        {
+            yield return type;
+
+            foreach (var nested in type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic).SelectMany(GetTypeAndNestedTypes))
+                yield return nested;
         }
 
         public TestRunState Run(ITestListener testListener, Func<Runner, AssemblyResult> run)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -41,6 +41,13 @@ namespace Fixie.Internal
             return RunTypesInternal(assembly, type);
         }
 
+        public AssemblyResult RunTypes(Assembly assembly, params Type[] types)
+        {
+            RunContext.Set(options);
+
+            return RunTypesInternal(assembly, types);
+        }
+
         public AssemblyResult RunTypes(Assembly assembly, Convention convention, params Type[] types)
         {
             RunContext.Set(options);

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -24,21 +24,21 @@ namespace Fixie.Internal
         {
             RunContext.Set(options);
 
-            return RunTypes(assembly, assembly.GetTypes());
+            return RunTypesInternal(assembly, assembly.GetTypes());
         }
 
         public AssemblyResult RunNamespace(Assembly assembly, string ns)
         {
             RunContext.Set(options);
 
-            return RunTypes(assembly, assembly.GetTypes().Where(type => type.IsInNamespace(ns)).ToArray());
+            return RunTypesInternal(assembly, assembly.GetTypes().Where(type => type.IsInNamespace(ns)).ToArray());
         }
 
         public AssemblyResult RunType(Assembly assembly, Type type)
         {
             RunContext.Set(options, type);
 
-            return RunTypes(assembly, type);
+            return RunTypesInternal(assembly, type);
         }
 
         public AssemblyResult RunTypes(Assembly assembly, Convention convention, params Type[] types)
@@ -81,7 +81,7 @@ namespace Fixie.Internal
                 .Where(m => m.Name == methodGroup.Method);
         }
 
-        AssemblyResult RunTypes(Assembly assembly, params Type[] types)
+        AssemblyResult RunTypesInternal(Assembly assembly, params Type[] types)
         {
             return Run(assembly, GetConventions(assembly), types);
         }


### PR DESCRIPTION
When using the TestDriven.NET runner against a target namespace, test classes including nested test classes in the namespace are executed.  This pull request implements similar behavior when running the TestDriven.NET runner against a target class.

@TheCloudlessSky identified the bug using the following sample class:

```cs
class CalculatorTests
{
    class Adding
    {
        public void computes_the_sum()
        {
            var sut = new Calculator();

            var result = sut.Add(1, 2);

            result.ShouldEqual(3);
        }
    }

    class Subtracting
    {
        public void computes_the_difference()
        {
            var sut = new Calculator();

            var result = sut.Subtract(3, 2);

            result.ShouldEqual(1);
        }
    }
}
```

This pull request ensures that when invoking TestDriven.NET on CalculatorTests, the inner types Adding and Subtracting are also considered by the applicable conventions, instead of only considering CalculatorTests.  Doing so brings Fixie's TestDriven.NET in line with the same behavior in the xUnit TestDriven.NET runner. (Naturally, if the conventions don't consider the nested types to be test classes, they'll be rightly skipped over like any other non-test class.)