### PR TITLE
Simplify the pattern to properly manage MarshalByRefObjectLifetimes (primarily for implementations of Listener).

### DIFF
--- a/src/Fixie.Console/ConsoleListener.cs
+++ b/src/Fixie.Console/ConsoleListener.cs
@@ -4,7 +4,7 @@ using Fixie.Execution;
 
 namespace Fixie.ConsoleRunner
 {
-    public class ConsoleListener : MarshalByRefObject, Listener
+    public class ConsoleListener : LongLivedMarshalByRefObject, Listener
     {
         public void AssemblyStarted(AssemblyInfo assembly)
         {
@@ -34,11 +34,6 @@ namespace Fixie.ConsoleRunner
         {
             Console.WriteLine(result.Summary);
             Console.WriteLine();
-        }
-
-        public override object InitializeLifetimeService()
-        {
-            return null; //Allowing the instance to live indefinitely.
         }
     }
 }

--- a/src/Fixie.Console/TeamCityListener.cs
+++ b/src/Fixie.Console/TeamCityListener.cs
@@ -6,7 +6,7 @@ using Fixie.Execution;
 
 namespace Fixie.ConsoleRunner
 {
-    public class TeamCityListener : MarshalByRefObject, Listener
+    public class TeamCityListener : LongLivedMarshalByRefObject, Listener
     {
         public void AssemblyStarted(AssemblyInfo assembly)
         {
@@ -85,11 +85,6 @@ namespace Fixie.ConsoleRunner
         static string SuiteName(AssemblyInfo assembly)
         {
             return Path.GetFileName(assembly.Location);
-        }
-
-        public override object InitializeLifetimeService()
-        {
-            return null; //Allowing the instance to live indefinitely.
         }
     }
 }

--- a/src/Fixie.Tests/AssertionLibraryFilteringTests.cs
+++ b/src/Fixie.Tests/AssertionLibraryFilteringTests.cs
@@ -12,9 +12,8 @@ namespace Fixie.Tests
         public void ShouldNotAffectOutputByDefault()
         {
             using (var console = new RedirectedConsole())
+            using (var listener = new ConsoleListener())
             {
-                var listener = new ConsoleListener();
-
                 typeof(SampleTestClass).Run(listener, SelfTestConvention.Build());
 
                 console
@@ -41,9 +40,8 @@ namespace Fixie.Tests
         public void ShouldFilterAssertionLibraryImplementationDetailsWhenLibraryTypesAreSpecified()
         {
             using (var console = new RedirectedConsole())
+            using (var listener = new ConsoleListener())
             {
-                var listener = new ConsoleListener();
-
                 var convention = SelfTestConvention.Build();
 
                 convention

--- a/src/Fixie.Tests/ConsoleRunner/ConsoleListenerTests.cs
+++ b/src/Fixie.Tests/ConsoleRunner/ConsoleListenerTests.cs
@@ -12,9 +12,8 @@ namespace Fixie.Tests.ConsoleRunner
         public void ShouldReportResultsToTheConsole()
         {
             using (var console = new RedirectedConsole())
+            using (var listener = new ConsoleListener())
             {
-                var listener = new ConsoleListener();
-
                 typeof(PassFailTestClass).Run(listener, SelfTestConvention.Build());
 
                 var testClass = typeof(PassFailTestClass).FullName;
@@ -49,9 +48,8 @@ namespace Fixie.Tests.ConsoleRunner
         public void ShouldNotReportSkipCountsWhenZeroTestsHaveBeenSkipped()
         {
             using (var console = new RedirectedConsole())
+            using (var listener = new ConsoleListener())
             {
-                var listener = new ConsoleListener();
-
                 var convention = SelfTestConvention.Build();
 
                 convention

--- a/src/Fixie.Tests/ConsoleRunner/TeamCityListenerTests.cs
+++ b/src/Fixie.Tests/ConsoleRunner/TeamCityListenerTests.cs
@@ -12,9 +12,8 @@ namespace Fixie.Tests.ConsoleRunner
         public void ShouldReportResultsToTheConsoleInTeamCityFormat()
         {
             using (var console = new RedirectedConsole())
+            using (var listener = new TeamCityListener())
             {
-                var listener = new TeamCityListener();
-
                 typeof(PassFailTestClass).Run(listener, SelfTestConvention.Build());
 
                 var testClass = typeof(PassFailTestClass).FullName;

--- a/src/Fixie.VisualStudio.TestAdapter/VisualStudioListener.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/VisualStudioListener.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace Fixie.VisualStudio.TestAdapter
 {
-    public class VisualStudioListener : MarshalByRefObject, Listener
+    public class VisualStudioListener : LongLivedMarshalByRefObject, Listener
     {
         //The Visual Studio test runner has poor support for parameterized test methods,
         //when the arguments are not known ahead of time. It assumes that the TestCase
@@ -104,11 +104,6 @@ namespace Fixie.VisualStudio.TestAdapter
         {
             if (!String.IsNullOrEmpty(output))
                 testResult.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, output));
-        }
-
-        public override object InitializeLifetimeService()
-        {
-            return null; //Allowing the instance to live indefinitely.
         }
     }
 }

--- a/src/Fixie.VisualStudio.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/VsTestExecutor.cs
@@ -31,8 +31,7 @@ namespace Fixie.VisualStudio.TestAdapter
                     {
                         log.Info("Processing " + assemblyPath);
 
-                        var listener = new VisualStudioListener(frameworkHandle, assemblyPath);
-
+                        using (var listener = new VisualStudioListener(frameworkHandle, assemblyPath))
                         using (var environment = new ExecutionEnvironment(assemblyPath))
                         {
                             environment.RunAssembly(new Options(), listener);
@@ -72,8 +71,7 @@ namespace Fixie.VisualStudio.TestAdapter
 
                         var methodGroups = assemblyGroup.Select(x => new MethodGroup(x.FullyQualifiedName)).ToArray();
 
-                        var listener = new VisualStudioListener(frameworkHandle, assemblyPath);
-
+                        using (var listener = new VisualStudioListener(frameworkHandle, assemblyPath))
                         using (var environment = new ExecutionEnvironment(assemblyPath))
                         {
                             environment.RunMethods(new Options(), listener, methodGroups);

--- a/src/Fixie/Execution/ExecutionEnvironment.cs
+++ b/src/Fixie/Execution/ExecutionEnvironment.cs
@@ -31,7 +31,7 @@ namespace Fixie.Execution
 
         public AssemblyResult RunAssembly(Options options, Listener listener)
         {
-            AssertIsMarshalByRefObject(listener);
+            AssertIsLongLivedMarshalByRefObject(listener);
 
             using (var executionProxy = Create<ExecutionProxy>())
                 return executionProxy.RunAssembly(assemblyFullPath, options, listener);
@@ -39,19 +39,20 @@ namespace Fixie.Execution
 
         public AssemblyResult RunMethods(Options options, Listener listener, MethodGroup[] methodGroups)
         {
-            AssertIsMarshalByRefObject(listener);
+            AssertIsLongLivedMarshalByRefObject(listener);
+
             using (var executionProxy = Create<ExecutionProxy>())
                 return executionProxy.RunMethods(assemblyFullPath, options, listener, methodGroups);
         }
 
-        static void AssertIsMarshalByRefObject(Listener listener)
+        static void AssertIsLongLivedMarshalByRefObject(Listener listener)
         {
-            if (listener is MarshalByRefObject) return;
+            if (listener is LongLivedMarshalByRefObject) return;
             var listenerType = listener.GetType();
             var message = string.Format("Type '{0}' in Assembly '{1}' must inherit from '{2}'.",
                                         listenerType.FullName,
                                         listenerType.Assembly,
-                                        typeof(MarshalByRefObject).FullName);
+                                        typeof(LongLivedMarshalByRefObject).FullName);
             throw new Exception(message);
         }
 

--- a/src/Fixie/Execution/ExecutionEnvironment.cs
+++ b/src/Fixie/Execution/ExecutionEnvironment.cs
@@ -25,19 +25,23 @@ namespace Fixie.Execution
 
         public IReadOnlyList<MethodGroup> DiscoverTestMethodGroups(Options options)
         {
-            return Create<ExecutionProxy>().DiscoverTestMethodGroups(assemblyFullPath, options);
+            using (var executionProxy = Create<ExecutionProxy>())
+                return executionProxy.DiscoverTestMethodGroups(assemblyFullPath, options);
         }
 
         public AssemblyResult RunAssembly(Options options, Listener listener)
         {
             AssertIsMarshalByRefObject(listener);
-            return Create<ExecutionProxy>().RunAssembly(assemblyFullPath, options, listener);
+
+            using (var executionProxy = Create<ExecutionProxy>())
+                return executionProxy.RunAssembly(assemblyFullPath, options, listener);
         }
 
         public AssemblyResult RunMethods(Options options, Listener listener, MethodGroup[] methodGroups)
         {
             AssertIsMarshalByRefObject(listener);
-            return Create<ExecutionProxy>().RunMethods(assemblyFullPath, options, listener, methodGroups);
+            using (var executionProxy = Create<ExecutionProxy>())
+                return executionProxy.RunMethods(assemblyFullPath, options, listener, methodGroups);
         }
 
         static void AssertIsMarshalByRefObject(Listener listener)

--- a/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
+++ b/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
@@ -18,7 +18,7 @@ namespace Fixie.Execution
     /// </summary>
     public class LongLivedMarshalByRefObject : MarshalByRefObject, IDisposable
     {
-        public override object InitializeLifetimeService()
+        public override sealed object InitializeLifetimeService()
         {
             //Returning null here causes the instance to live indefinitely.
 

--- a/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
+++ b/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
@@ -14,7 +14,7 @@ namespace Fixie.Execution
     /// several minutes.  As a consequence, instances must be disposed
     /// to free up all resources.
     /// </summary>
-    public class LongLivedMarshalByRefObject : MarshalByRefObject, IDisposable
+    public abstract class LongLivedMarshalByRefObject : MarshalByRefObject, IDisposable
     {
         public override sealed object InitializeLifetimeService()
         {

--- a/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
+++ b/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Runtime.Remoting;
+
+namespace Fixie.Execution
+{
+    /// <summary>
+    /// Normally, inheriting from MarshalByRefObject introduces an unexpected defect
+    /// in which your instances cease to exist after they get a few minutes old.
+    /// 
+    /// For instance, when a runner provides a MarshalByRefObject to act as the test
+    /// Listener, that Listener may disappear after a long-running test finally finishes,
+    /// causing a runtime exception that interrupts the run. The Listener would no longer
+    /// be available to receive the test's results.
+    /// 
+    /// Inheriting from this alternative to MarshalByRefObject allows the instance
+    /// to be kept alive indefinitely, but you must Dispose() of it yourself when
+    /// its natural lifetime has been reached.
+    /// </summary>
+    public class LongLivedMarshalByRefObject : MarshalByRefObject, IDisposable
+    {
+        public override object InitializeLifetimeService()
+        {
+            //Returning null here causes the instance to live indefinitely.
+
+            //A consequence of keeping a MarshalByRefObject alive like this is that
+            //it must be explicitly cleaned up with a call to RemotingServices.Disconnect(this).
+            //See Dispose().
+
+            return null;
+        }
+
+        public void Dispose()
+        {
+            RemotingServices.Disconnect(this);
+        }
+    }
+}

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Conventions\ParameterSourceExpression.cs" />
+    <Compile Include="Execution\LongLivedMarshalByRefObject.cs" />
     <Compile Include="Internal\Discoverer.cs" />
     <Compile Include="Internal\ParameterDiscoverer.cs" />
     <Compile Include="MethodGroup.cs" />

--- a/src/Fixie/Internal/ExecutionProxy.cs
+++ b/src/Fixie/Internal/ExecutionProxy.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Fixie.Execution;
 
 namespace Fixie.Internal
 {
-    public class ExecutionProxy : MarshalByRefObject
+    public class ExecutionProxy : LongLivedMarshalByRefObject
     {
         public IReadOnlyList<MethodGroup> DiscoverTestMethodGroups(string assemblyFullPath, Options options)
         {
@@ -36,11 +35,6 @@ namespace Fixie.Internal
         static Runner Runner(Options options, Listener listener)
         {
             return new Runner(listener, options);
-        }
-
-        public override object InitializeLifetimeService()
-        {
-            return null; //Allowing the instance to live indefinitely.
         }
     }
 }


### PR DESCRIPTION
Release 1.0.0.3 (https://github.com/fixie/fixie/releases/tag/1.0.0.3) fixed a bug in which long-running tests could cause runners to fail, due to the atypical default lifetimes of MarshalByRefObjects.  The fix worked by giving such objects unlimited lifetimes (as does the NUnit Visual Studio runner, for the same reason).

However, the fix required every subclass of MarshalByRefObject to override InitializeLifetimeService() in the same way, and third-party runner authors would be left to reintroduce/diagnose/fix the same basic bug in their own code.

This pull request solves both of those problems.  Runner authors who provide their own Listener are reminded at runtime to inherit LongLivedMarshalByRefObject instead of simply inheriting MarshalByRefObject.  All built-in Listeners also inherit this helper class so that they need not all remember to override InitializeLifetimeService() redundantly.