### PR TITLE
Report Test Method Line Numbers to Visual Studio Test Adapter

### DIFF
--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -32,6 +32,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Cecil, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.9.5.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
     <Reference Include="Should">
       <HintPath>..\packages\Should.1.1.12.0\lib\Should.dll</HintPath>
     </Reference>
@@ -81,11 +95,17 @@
     <Compile Include="Cases\ParameterizedCaseTests.cs" />
     <Compile Include="ConsoleRunner\TeamCityListenerTests.cs" />
     <Compile Include="Cases\SkippedCaseTests.cs" />
+    <Compile Include="VisualStudio\TestAdapter\SourceLocationProviderTests.cs" />
+    <Compile Include="VisualStudio\TestAdapter\SourceLocationSamples.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fixie.Console\Fixie.Console.csproj">
       <Project>{3805c0e0-3817-45ad-964f-cf7dc5715b39}</Project>
       <Name>Fixie.Console</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Fixie.VisualStudio.TestAdapter\Fixie.VisualStudio.TestAdapter.csproj">
+      <Project>{E2335E25-000C-4BCC-BB49-A2D2C3ED4A59}</Project>
+      <Name>Fixie.VisualStudio.TestAdapter</Name>
     </ProjectReference>
     <ProjectReference Include="..\Fixie\Fixie.csproj">
       <Project>{474ff43b-4580-4032-999b-a717eb7a0cd3}</Project>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -36,9 +36,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
     <Reference Include="Mono.Cecil.Pdb">
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>

--- a/src/Fixie.Tests/VisualStudio/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/VisualStudio/TestAdapter/SourceLocationProviderTests.cs
@@ -7,8 +7,9 @@ namespace Fixie.Tests.VisualStudio.TestAdapter
     public class SourceLocationProviderTests
     {
         // Line numbers vary slightly between Debug and Release modes.
-        // In Debug mode: opening curly brace.
-        //In Release mode: first non-comment code line or closing curly brace if the method is empty.
+        //
+        //      Debug: opening curly brace.
+        //      Release: first non-comment code line or closing curly brace if the method is empty.
 
         private static readonly string TestAssemblyPath = Path.GetFullPath("Fixie.Tests.dll");
 
@@ -51,6 +52,12 @@ namespace Fixie.Tests.VisualStudio.TestAdapter
         public void ShouldSafelyFailForOverloadedMethodsBecauseTheRequestIsAmbiguous()
         {
             AssertNoLineNumber(typeof(SourceLocationSamples).FullName, "Overloaded");
+        }
+
+        public void ShouldSafelyFailForInheritedMethodsBecauseTheRequestIsAmbiguous()
+        {
+            AssertLineNumber(typeof(SourceLocationSamples.BaseClass).FullName, "Inherited", 72, 72);
+            AssertNoLineNumber(typeof(SourceLocationSamples.ChildClass).FullName, "Inherited");
         }
 
         static void AssertNoLineNumber(string className, string methodName)

--- a/src/Fixie.Tests/VisualStudio/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/VisualStudio/TestAdapter/SourceLocationProviderTests.cs
@@ -1,0 +1,83 @@
+﻿using System.IO;
+using Fixie.VisualStudio.TestAdapter;
+using Should;
+
+namespace Fixie.Tests.VisualStudio.TestAdapter
+{
+    public class SourceLocationProviderTests
+    {
+        // Line numbers vary slightly between Debug and Release modes.
+        // In Debug mode: opening curly brace.
+        //In Release mode: first non-comment code line or closing curly brace if the method is empty.
+
+        private static readonly string TestAssemblyPath = Path.GetFullPath("Fixie.Tests.dll");
+
+        public void ShouldSafelyFailForUnknownMethods()
+        {
+            AssertNoLineNumber("NonExistentClass", "NonExistentMethod");
+            AssertNoLineNumber(typeof(SourceLocationSamples).FullName, "NonExistentMethod");
+        }
+
+        public void ShouldDetectLineNumbersOfEmptyMethods()
+        {
+            AssertLineNumber(typeof(SourceLocationSamples).FullName, "Empty_OneLine", 8, 8);
+            AssertLineNumber(typeof(SourceLocationSamples).FullName, "Empty_TwoLines", 11, 12);
+            AssertLineNumber(typeof(SourceLocationSamples).FullName, "Empty_ThreeLines", 15, 17);
+        }
+
+        public void ShouldDetectLineNumbersOfSynchronousMethods()
+        {
+            AssertLineNumber(typeof(SourceLocationSamples).FullName, "Simple", 20, 21);
+            AssertLineNumber(typeof(SourceLocationSamples).FullName, "Generic", 26, 27);
+        }
+
+        public void ShouldDetectLineNumbersOfAsyncMethods()
+        {
+            AssertLineNumber(typeof(SourceLocationSamples).FullName, "AsyncMethod_Void", 31, 32);
+            AssertLineNumber(typeof(SourceLocationSamples).FullName, "AsyncMethod_Task", 38, 39);
+            AssertLineNumber(typeof(SourceLocationSamples).FullName, "AsyncMethod_TaskOfT", 45, 46);
+        }
+
+        public void ShouldDetectLineNumbersOfMethodsWithinNestedClasses()
+        {
+            AssertLineNumber(typeof(SourceLocationSamples.NestedClass).FullName, "NestedMethod", 54, 55);
+        }
+
+        public void ShouldSafelyFailForUnknownLineNumbers()
+        {
+            AssertNoLineNumber(typeof(SourceLocationSamples).FullName, "Hidden");
+        }
+
+        public void ShouldSafelyFailForOverloadedMethodsBecauseTheRequestIsAmbiguous()
+        {
+            AssertNoLineNumber(typeof(SourceLocationSamples).FullName, "Overloaded");
+        }
+
+        static void AssertNoLineNumber(string className, string methodName)
+        {
+            var sourceLocationProvider = new SourceLocationProvider(TestAssemblyPath);
+
+            SourceLocation location;
+            var success = sourceLocationProvider.TryGetSourceLocation(new MethodGroup(className + "." + methodName), out location);
+
+            success.ShouldBeFalse();
+            location.ShouldBeNull();
+        }
+
+        static void AssertLineNumber(string className, string methodName, int debugLine, int releaseLine)
+        {
+            var sourceLocationProvider = new SourceLocationProvider(TestAssemblyPath);
+
+            SourceLocation location;
+            var success = sourceLocationProvider.TryGetSourceLocation(new MethodGroup(className + "." + methodName), out location);
+
+            location.CodeFilePath.EndsWith("SourceLocationSamples.cs").ShouldBeTrue();
+
+#if DEBUG
+            location.LineNumber.ShouldEqual(debugLine);
+#else
+            location.LineNumber.ShouldEqual(releaseLine);
+#endif
+        }
+    }
+}

--- a/src/Fixie.Tests/VisualStudio/TestAdapter/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/VisualStudio/TestAdapter/SourceLocationSamples.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Fixie.Tests.VisualStudio.TestAdapter
+{
+    public class SourceLocationSamples
+    {
+        public void Empty_OneLine() { } // Debug = Release = 8
+
+        public void Empty_TwoLines()
+        { // Debug = 11
+        } // Release = 12
+
+        public void Empty_ThreeLines()
+        { // Debug = 15
+
+        } // Release = 17
+
+        public void Simple()
+        { // Debug = 20
+            int answer = 42; // Release = 21
+            Console.Write(answer);
+        }
+
+        public void Generic<T>(T x)
+        { // Debug = 26
+            Console.WriteLine(); // Release = 27
+        }
+
+        public async void AsyncMethod_Void()
+        { // Debug = 31
+            int answer = 42; // Release = 32
+            await Task.Delay(0);
+            Console.Write(answer);
+        }
+
+        public async Task AsyncMethod_Task()
+        { // Debug = 38
+            int answer = 42; // Release = 39
+            await Task.Delay(0);
+            Console.Write(answer);
+        }
+
+        public async Task<int> AsyncMethod_TaskOfT()
+        { // Debug = 45
+            int answer = 42; // Release = 46
+            await Task.Delay(0);
+            return answer;
+        }
+
+        public class NestedClass
+        {
+            public void NestedMethod()
+            { // Debug = 54
+                int answer = 42; // Release = 55
+                Console.Write(answer);
+            }
+        }
+
+#line hidden
+        public void Hidden()
+        {
+        }
+#line default
+
+        public void Overloaded() { } // Debug = Release = 66
+
+        public void Overloaded(int y) { } // Debug = Release = 68
+    }
+}

--- a/src/Fixie.Tests/VisualStudio/TestAdapter/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/VisualStudio/TestAdapter/SourceLocationSamples.cs
@@ -66,5 +66,14 @@ namespace Fixie.Tests.VisualStudio.TestAdapter
         public void Overloaded() { } // Debug = Release = 66
 
         public void Overloaded(int y) { } // Debug = Release = 68
+
+        public class BaseClass
+        {
+            public void Inherited() { } // Debug = Release = 72
+        }
+
+        public class ChildClass : BaseClass
+        {
+        }
     }
 }

--- a/src/Fixie.VisualStudio.TestAdapter/Fixie.VisualStudio.TestAdapter.csproj
+++ b/src/Fixie.VisualStudio.TestAdapter/Fixie.VisualStudio.TestAdapter.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>Fixie.VisualStudio.TestAdapter</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,10 +35,24 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <HintPath>..\..\lib\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SourceLocation.cs" />
+    <Compile Include="SourceLocationProvider.cs" />
     <Compile Include="VsTestDiscoverer.cs" />
     <Compile Include="VsTestExecutor.cs" />
     <Compile Include="LoggingExtensions.cs" />
@@ -50,7 +66,11 @@
       <Name>Fixie</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Fixie.VisualStudio.TestAdapter/Fixie.VisualStudio.TestAdapter.csproj
+++ b/src/Fixie.VisualStudio.TestAdapter/Fixie.VisualStudio.TestAdapter.csproj
@@ -38,9 +38,6 @@
     <Reference Include="Mono.Cecil">
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
     <Reference Include="Mono.Cecil.Pdb">
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>

--- a/src/Fixie.VisualStudio.TestAdapter/SourceLocation.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/SourceLocation.cs
@@ -1,0 +1,14 @@
+﻿namespace Fixie.VisualStudio.TestAdapter
+{
+    public class SourceLocation
+    {
+        public SourceLocation(string codeFilePath, int lineNumber)
+        {
+            CodeFilePath = codeFilePath;
+            LineNumber = lineNumber;
+        }
+
+        public string CodeFilePath { get; private set; }
+        public int LineNumber { get; private set; }
+    }
+}

--- a/src/Fixie.VisualStudio.TestAdapter/SourceLocationProvider.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/SourceLocationProvider.cs
@@ -11,10 +11,10 @@ namespace Fixie.VisualStudio.TestAdapter
     {
         readonly IDictionary<string, TypeDefinition> types;
 
-        public SourceLocationProvider(string assemblyFileName)
+        public SourceLocationProvider(string assemblyPath)
         {
             var readerParameters = new ReaderParameters { ReadSymbols = true };
-            var module = ModuleDefinition.ReadModule(assemblyFileName, readerParameters);
+            var module = ModuleDefinition.ReadModule(assemblyPath, readerParameters);
             
             types = new Dictionary<string, TypeDefinition>();
 

--- a/src/Fixie.VisualStudio.TestAdapter/SourceLocationProvider.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/SourceLocationProvider.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
+
+namespace Fixie.VisualStudio.TestAdapter
+{
+    public class SourceLocationProvider
+    {
+        readonly IDictionary<string, TypeDefinition> types;
+
+        public SourceLocationProvider(string assemblyFileName)
+        {
+            var readerParameters = new ReaderParameters { ReadSymbols = true };
+            var module = ModuleDefinition.ReadModule(assemblyFileName, readerParameters);
+            
+            types = new Dictionary<string, TypeDefinition>();
+
+            foreach (var type in module.GetTypes())
+                types[type.FullName] = type;
+        }
+
+        public bool TryGetSourceLocation(MethodGroup methodGroup, out SourceLocation sourceLocation)
+        {
+            sourceLocation = null;
+
+            var className = methodGroup.Class;
+            var methodName = methodGroup.Method;
+
+            SequencePoint sequencePoint;
+
+            if (TryGetSequencePoint(className, methodName, out sequencePoint))
+                sourceLocation = new SourceLocation(sequencePoint.Document.Url, sequencePoint.StartLine);
+
+            return sourceLocation != null;
+        }
+
+        bool TryGetSequencePoint(string className, string methodName, out SequencePoint sequencePoint)
+        {
+            sequencePoint = null;
+
+            MethodDefinition testMethod;
+            if (TryGetMethod(className, methodName, out testMethod))
+            {
+                CustomAttribute asyncStateMachineAttribute;
+
+                if (TryGetAsyncStateMachineAttribute(testMethod, out asyncStateMachineAttribute))
+                    testMethod = GetStateMachineMoveNextMethod(asyncStateMachineAttribute);
+
+                sequencePoint = FirstUnhiddenSequencePoint(testMethod.Body);
+            }
+            
+            return sequencePoint != null;
+        }
+
+        bool TryGetMethod(string className, string methodName, out MethodDefinition method)
+        {
+            method = null;
+            TypeDefinition type;
+
+            if (TryGetType(className, out type))
+            {
+                var matches = type.GetMethods().Where(m => m.Name == methodName).ToArray();
+
+                if (matches.Length == 1)
+                    method = matches[0];
+            }
+
+            return method != null;
+        }
+
+        bool TryGetType(string className, out TypeDefinition type)
+        {
+            return types.TryGetValue(StandardizeTypeName(className), out type);
+        }
+
+        static bool TryGetAsyncStateMachineAttribute(MethodDefinition method, out CustomAttribute attribute)
+        {
+            attribute = method.CustomAttributes.FirstOrDefault(c => c.AttributeType.Name == "AsyncStateMachineAttribute");
+            return attribute != null;
+        }
+
+        static MethodDefinition GetStateMachineMoveNextMethod(CustomAttribute asyncStateMachineAttribute)
+        {
+            var stateMachineType = (TypeDefinition)asyncStateMachineAttribute.ConstructorArguments[0].Value;
+            var stateMachineMoveNextMethod = stateMachineType.GetMethods().First(m => m.Name == "MoveNext");
+            return stateMachineMoveNextMethod;
+        }
+
+        static SequencePoint FirstUnhiddenSequencePoint(MethodBody body)
+        {
+            const int lineNumberIndicatingHiddenLine = 16707566; //0xfeefee
+
+            foreach (var instruction in body.Instructions)
+                if (instruction.SequencePoint != null && instruction.SequencePoint.StartLine != lineNumberIndicatingHiddenLine)
+                    return instruction.SequencePoint;
+
+            return null;
+        }
+
+        static string StandardizeTypeName(string className)
+        {
+            //Mono.Cecil respects ECMA-335 for the FullName of a type, which can differ from Type.FullName.
+            //In order to make reliable comparisons between the class part of a MethodGroup, the class part
+            //must be standardized to the ECMA-335 format.
+            //
+            //ECMA-335 specifies "/" instead of "+" to indicate a nested type.
+
+            return className.Replace("+", "/");
+        }
+    }
+}

--- a/src/Fixie.VisualStudio.TestAdapter/SourceLocationProvider.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/SourceLocationProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
@@ -77,7 +78,7 @@ namespace Fixie.VisualStudio.TestAdapter
 
         static bool TryGetAsyncStateMachineAttribute(MethodDefinition method, out CustomAttribute attribute)
         {
-            attribute = method.CustomAttributes.FirstOrDefault(c => c.AttributeType.Name == "AsyncStateMachineAttribute");
+            attribute = method.CustomAttributes.FirstOrDefault(c => c.AttributeType.Name == typeof(AsyncStateMachineAttribute).Name);
             return attribute != null;
         }
 

--- a/src/Fixie.VisualStudio.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/VsTestDiscoverer.cs
@@ -27,12 +27,32 @@ namespace Fixie.VisualStudio.TestAdapter
                     {
                         log.Info("Processing " + assemblyPath);
 
+                        var sourceLocationProvider = new SourceLocationProvider(assemblyPath);
+
                         using (var environment = new ExecutionEnvironment(assemblyPath))
                         {
                             var methodGroups = environment.DiscoverTestMethodGroups(new Options());
 
                             foreach (var methodGroup in methodGroups)
-                                discoverySink.SendTestCase(new TestCase(methodGroup.FullName, VsTestExecutor.Uri, assemblyPath));
+                            {
+                                var testCase = new TestCase(methodGroup.FullName, VsTestExecutor.Uri, assemblyPath);
+
+                                try
+                                {
+                                    SourceLocation sourceLocation;
+                                    if (sourceLocationProvider.TryGetSourceLocation(methodGroup, out sourceLocation))
+                                    {
+                                        testCase.CodeFilePath = sourceLocation.CodeFilePath;
+                                        testCase.LineNumber = sourceLocation.LineNumber;
+                                    }
+                                }
+                                catch (Exception exception)
+                                {
+                                    log.Error(exception);
+                                }
+
+                                discoverySink.SendTestCase(testCase);
+                            }
                         }
                     }
                     else

--- a/src/Fixie.VisualStudio.TestAdapter/packages.config
+++ b/src/Fixie.VisualStudio.TestAdapter/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
-  <package id="Should" version="1.1.12.0" targetFramework="net45" />
 </packages>

--- a/src/Fixie/Fixie.nuspec
+++ b/src/Fixie/Fixie.nuspec
@@ -22,5 +22,8 @@
     <file src="..\..\build\Fixie.TestDriven.dll" target="lib/net45"></file>
     <file src="..\..\build\TestDriven.Framework.dll" target="lib/net45"></file>
     <file src="..\..\build\Fixie.VisualStudio.TestAdapter.dll" target="lib/net45"></file>
+    <file src="..\..\build\Mono.Cecil.dll" target="lib/net45"></file>
+    <file src="..\..\build\Mono.Cecil.Rocks.dll" target="lib/net45"></file>
+    <file src="..\..\build\Mono.Cecil.Pdb.dll" target="lib/net45"></file>
   </files>
 </package>


### PR DESCRIPTION
Before this pull request, Fixie's Visual Studio test adapter did not make any attempt to report test method line numbers to Visual Studio. Without that data, the Visual Studio Test Explorer cannot navigate from a test name to the corresponding declaration, and context menus within the code editor could not determine what "Run Tests" meant.

This pull request provides line number information to Visual Studio *whenever doing so is unambiguous*.  It does so by leveraging the Mono.Cecil library for its ability to inspect assemblies without loading them into the calling AppDomain.  The NUnit and xUnit test adapters instead rely on DiaSession, defined within Microsoft.VisualStudio.TestPlatform.ObjectModel.dll, but those frameworks have had to jump through additional hoops due to DiaSession not playing nicely with AppDomains.  Since Mono.Cecil makes an end run around the normal reflection types, we get direct and cheap access to the small amount of information we care about (line numbers of the first instruction of the test method) with none of the complications introduced by DiaSession.