### PR TITLE
Support non english locales for fixie's tests

### DIFF
--- a/src/Fixie.Tests/AssertionLibraryFilteringTests.cs
+++ b/src/Fixie.Tests/AssertionLibraryFilteringTests.cs
@@ -71,13 +71,13 @@ namespace Fixie.Tests
             }
         }
 
-        static string CleanBrittleValues(string actualRawContent)
+        internal static string CleanBrittleValues(string actualRawContent)
         {
             //Avoid brittle assertion introduced by fixie version.
             var cleaned = Regex.Replace(actualRawContent, @"\(Fixie \d+\.\d+\.\d+\.\d+\)", @"(Fixie 1.2.3.4)");
 
             //Avoid brittle assertion introduced by test duration.
-            cleaned = Regex.Replace(cleaned, @"took [\d\.]+ seconds", @"took 1.23 seconds");
+            cleaned = cleaned.ReplaceTime(@"took {0} seconds", @"took 1.23 seconds");
 
             //Avoid brittle assertion introduced by stack trace line numbers.
             cleaned = Regex.Replace(cleaned, @":line \d+", ":line #");

--- a/src/Fixie.Tests/ConsoleRunner/ConsoleListenerTests.cs
+++ b/src/Fixie.Tests/ConsoleRunner/ConsoleListenerTests.cs
@@ -85,18 +85,23 @@ namespace Fixie.Tests.ConsoleRunner
             }
         }
 
-        static string CleanBrittleValues(string actualRawContent)
+        internal static string CleanBrittleValues(string actualRawContent)
         {
             //Avoid brittle assertion introduced by fixie version.
             var cleaned = Regex.Replace(actualRawContent, @"\(Fixie \d+\.\d+\.\d+\.\d+\)", @"(Fixie 1.2.3.4)");
 
             //Avoid brittle assertion introduced by test duration.
-            cleaned = Regex.Replace(cleaned, @"took [\d\.]+ seconds", @"took 1.23 seconds");
+            cleaned = cleaned.ReplaceTime(@"took {0} seconds", @"took 1.23 seconds");
 
             //Avoid brittle assertion introduced by stack trace line numbers.
             cleaned = Regex.Replace(cleaned, @":line \d+", ":line #");
 
             return cleaned;
+        }
+
+        static string ReplaceTime(string cleaned, string patternFormat, string timePattern, string replacement)
+        {
+            return Regex.Replace(cleaned, string.Format(patternFormat, timePattern), replacement);
         }
 
         static string PathToThisFile([CallerFilePath] string path = null)

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="AssertionLibraryFilteringTests.cs" />
     <Compile Include="Assertions.cs" />
+    <Compile Include="MetaTests\AssertionLibraryFilteringTestsTests.cs" />
     <Compile Include="MetaTests\ConsoleListenerTestsTests.cs" />
     <Compile Include="MethodGroupTests.cs" />
     <Compile Include="Internal\ParameterDiscovererTests.cs" />

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="AssertionLibraryFilteringTests.cs" />
     <Compile Include="Assertions.cs" />
+    <Compile Include="MetaTests\ConsoleListenerTestsTests.cs" />
     <Compile Include="MethodGroupTests.cs" />
     <Compile Include="Internal\ParameterDiscovererTests.cs" />
     <Compile Include="Execution\AppDomainCommunicationAssertions.cs" />

--- a/src/Fixie.Tests/MetaTests/AssertionLibraryFilteringTestsTests.cs
+++ b/src/Fixie.Tests/MetaTests/AssertionLibraryFilteringTestsTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using Should;
+
+namespace Fixie.Tests.MetaTests
+{
+    public class AssertionLibraryFilteringTestsTests : IDisposable
+    {
+        readonly CultureInfo originalCulture;
+        readonly Thread currentThread;
+
+        public AssertionLibraryFilteringTestsTests()
+        {
+            currentThread = Thread.CurrentThread;
+            originalCulture = currentThread.CurrentCulture;
+        }
+
+        public void CleanBrittleValuesShouldCleanTimeOnEnglishLocale()
+        {
+            currentThread.CurrentCulture = new CultureInfo("en-US");
+
+            var cleaned = AssertionLibraryFilteringTests.CleanBrittleValues("took 12.96 seconds");
+
+            cleaned.ShouldEqual("took 1.23 seconds");
+        }
+
+        public void CleanBrittleValuesShouldCleanTimeOnGermanLocale()
+        {
+            currentThread.CurrentCulture = new CultureInfo("de-AT");
+
+            var cleaned = AssertionLibraryFilteringTests.CleanBrittleValues("took 12,96 seconds");
+
+            cleaned.ShouldEqual("took 1.23 seconds");
+        }
+
+        public void Dispose()
+        {
+            currentThread.CurrentCulture = originalCulture;
+        }
+    }
+}

--- a/src/Fixie.Tests/MetaTests/ConsoleListenerTestsTests.cs
+++ b/src/Fixie.Tests/MetaTests/ConsoleListenerTestsTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using Fixie.Tests.ConsoleRunner;
+using Should;
+
+namespace Fixie.Tests.MetaTests
+{
+    public class ConsoleListenerTestsTests : IDisposable
+    {
+        readonly CultureInfo originalCulture;
+        readonly Thread currentThread;
+
+        public ConsoleListenerTestsTests()
+        {
+            currentThread = Thread.CurrentThread;
+            originalCulture = currentThread.CurrentCulture;
+        }
+
+        public void CleanBrittleValuesShouldCleanTimeOnEnglishLocale()
+        {
+            currentThread.CurrentCulture = new CultureInfo("en-US");
+
+            var cleaned = ConsoleListenerTests.CleanBrittleValues("took 12.96 seconds");
+
+            cleaned.ShouldEqual("took 1.23 seconds");
+        }
+
+        public void CleanBrittleValuesShouldCleanTimeOnGermanLocale()
+        {
+            currentThread.CurrentCulture = new CultureInfo("de-AT");
+
+            var cleaned = ConsoleListenerTests.CleanBrittleValues("took 12,96 seconds");
+
+            cleaned.ShouldEqual("took 1.23 seconds");
+        }
+
+        public void Dispose()
+        {
+            currentThread.CurrentCulture = originalCulture;
+        }
+    }
+}

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
 using Fixie.Execution;
 using Fixie.Internal;
 
@@ -28,6 +30,24 @@ namespace Fixie.Tests
         public static void Run(this Type sampleTestClass, Listener listener, Convention convention)
         {
             new Runner(listener).RunTypes(sampleTestClass.Assembly, convention, sampleTestClass);
+        }
+
+        public static string ReplaceTime(this string original, string patternFormat, string replacement)
+        {
+            var decSepLocal = GetLocalDecimalSeparator();
+            return original.ReplaceTime(patternFormat, replacement, decSepLocal);
+        }
+
+        static string GetLocalDecimalSeparator()
+        {
+            return Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+        }
+
+        static string ReplaceTime(this string original, string patternFormat, string replacement, string decSep)
+        {
+            var timeRegex = string.Format(@"[\d{0}]+", Regex.Escape(decSep));
+            var pattern = string.Format(patternFormat, timeRegex);
+            return Regex.Replace(original, pattern, replacement);
         }
     }
 }


### PR DESCRIPTION
Fixes the problems with some of Fixie's own tests on non-english localized machines according to issue #90.
I am not sure about the similar cases that are not failing on my machine:

* NUnitXmlReportTests
* XUnitXmlReportTests
