### PR TITLE
Fix tests for non-en locales

### DIFF
--- a/src/Fixie.Tests/AssertionLibraryFilteringTests.cs
+++ b/src/Fixie.Tests/AssertionLibraryFilteringTests.cs
@@ -77,7 +77,7 @@ namespace Fixie.Tests
             var cleaned = Regex.Replace(actualRawContent, @"\(Fixie \d+\.\d+\.\d+\.\d+\)", @"(Fixie 1.2.3.4)");
 
             //Avoid brittle assertion introduced by test duration.
-            cleaned = Regex.Replace(cleaned, @"took [\d\.]+ seconds", @"took 1.23 seconds");
+            cleaned = Regex.Replace(cleaned, @"took [\d\.,/]+ seconds", @"took 1.23 seconds");
 
             //Avoid brittle assertion introduced by stack trace line numbers.
             cleaned = Regex.Replace(cleaned, @":line \d+", ":line #");

--- a/src/Fixie.Tests/ConsoleRunner/ConsoleListenerTests.cs
+++ b/src/Fixie.Tests/ConsoleRunner/ConsoleListenerTests.cs
@@ -91,7 +91,7 @@ namespace Fixie.Tests.ConsoleRunner
             var cleaned = Regex.Replace(actualRawContent, @"\(Fixie \d+\.\d+\.\d+\.\d+\)", @"(Fixie 1.2.3.4)");
 
             //Avoid brittle assertion introduced by test duration.
-            cleaned = Regex.Replace(cleaned, @"took [\d\.]+ seconds", @"took 1.23 seconds");
+            cleaned = Regex.Replace(cleaned, @"took [\d\.,/]+ seconds", @"took 1.23 seconds");
 
             //Avoid brittle assertion introduced by stack trace line numbers.
             cleaned = Regex.Replace(cleaned, @":line \d+", ":line #");


### PR DESCRIPTION
In some locales (ro-RO, in my case) the tests fail because the decimal separator is not the
point. I tried all the locales in `CultureInfo.GetCultures` and found
the other possible values are forward slash and comma.