### PR TITLE
Report skipped tests in Test Explorer

### DIFF
--- a/src/Fixie.Samples/Explicit/CalculatorTests.cs
+++ b/src/Fixie.Samples/Explicit/CalculatorTests.cs
@@ -27,7 +27,7 @@ namespace Fixie.Samples.Explicit
             test.ShouldBeNull();
             test = "ExplicitTest";
 
-            throw new Exception(test + " was invoked explicitly.");
+            Console.WriteLine(test + " was invoked explicitly.");
         }
     }
 }

--- a/src/Fixie.Samples/Explicit/CustomConvention.cs
+++ b/src/Fixie.Samples/Explicit/CustomConvention.cs
@@ -9,16 +9,23 @@
                 .NameEndsWith("Tests");
 
             Methods
-                .Where(method => method.IsVoid())
-                .Where(method =>
-                {
-                    var isMarkedExplicit = method.Has<ExplicitAttribute>();
-
-                    return !isMarkedExplicit || TargetMember == method;
-                });
+                .Where(method => method.IsVoid());
 
             ClassExecution
                 .CreateInstancePerClass();
+
+            CaseExecution
+                .Skip(SkipDueToExplicitAttribute,
+                      @case => "[Explicit] tests run only when they are individually selected for execution.");
+        }
+
+        bool SkipDueToExplicitAttribute(Case @case)
+        {
+            var method = @case.Method;
+
+            var isMarkedExplicit = method.Has<ExplicitAttribute>();
+
+            return isMarkedExplicit && TargetMember != method;
         }
     }
 }

--- a/src/Fixie.VisualStudio.TestAdapter/VisualStudioListener.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/VisualStudioListener.cs
@@ -39,7 +39,8 @@ namespace Fixie.VisualStudio.TestAdapter
             {
                 DisplayName = result.Name,
                 Outcome = Map(CaseStatus.Skipped),
-                ComputerName = Environment.MachineName
+                ComputerName = Environment.MachineName,
+                ErrorMessage = result.SkipReason
             });
         }
 

--- a/src/Fixie.VisualStudio.TestAdapter/VisualStudioListener.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/VisualStudioListener.cs
@@ -95,7 +95,7 @@ namespace Fixie.VisualStudio.TestAdapter
                 case CaseStatus.Failed:
                     return TestOutcome.Failed;
                 case CaseStatus.Skipped:
-                    return TestOutcome.Skipped;
+                    return TestOutcome.None;
                 default:
                     return TestOutcome.None;
             }

--- a/src/Fixie.VisualStudio.TestAdapter/VisualStudioListener.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/VisualStudioListener.cs
@@ -38,7 +38,7 @@ namespace Fixie.VisualStudio.TestAdapter
             log.RecordResult(new TestResult(TestCase(result.MethodGroup))
             {
                 DisplayName = result.Name,
-                Outcome = Map(CaseStatus.Passed),
+                Outcome = Map(CaseStatus.Skipped),
                 ComputerName = Environment.MachineName
             });
         }

--- a/src/Fixie.VisualStudio.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/VsTestExecutor.cs
@@ -15,6 +15,14 @@ namespace Fixie.VisualStudio.TestAdapter
         public const string Id = "executor://Fixie.VisualStudio";
         public static Uri Uri = new Uri(Id);
 
+        /// <summary>
+        /// Called by Visual Studio, when running all tests.
+        /// Called by TFS Build, when running all tests.
+        /// Called by TFS Build, with a filter within the run context, when running selected tests.
+        /// </summary>
+        /// <param name="sources"></param>
+        /// <param name="runContext"></param>
+        /// <param name="frameworkHandle"></param>
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
             IMessageLogger log = frameworkHandle;
@@ -49,6 +57,13 @@ namespace Fixie.VisualStudio.TestAdapter
             }
         }
 
+        /// <summary>
+        /// Called by Visual Studio, when running selected tests.
+        /// Never called from TFS Build.
+        /// </summary>
+        /// <param name="tests"></param>
+        /// <param name="runContext"></param>
+        /// <param name="frameworkHandle"></param>
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
             IMessageLogger log = frameworkHandle;


### PR DESCRIPTION
Due to a copy/paste error, tests skipped by Fixie would be reported as Passing in Visual Studio's Test Explorer window.  This PR fixes the issue by simply mapping the true status of the test case to Visual Studio.

Note, though, that we deliberately map Fixie's Skipped status to Visual Studio's NotRun status, instead of using Visual Studio's Skipped status.  Fixie uses "skipped" to mean "the test case itself was skipped, so it never ran", while Test Explorer treats "skipped" to mean "the test case may have run but its *result* is to be skipped from failing the build".  If we reported them as Visual Studio's Skipped status, then the UI would present them with a warning icon and would call the whole build Yellow instead of Green.  Visual Studio's NotRun status corresponds with Fixie's Skipped status, displaying the test as existing but grayed out, allowing a passing build to remain Green.