### PR TITLE
Fix character escaping within test case names

### DIFF
--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -19,6 +19,20 @@ namespace Fixie.Tests
             @case.Name.ShouldEqual("Fixie.Tests.CaseTests.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g\"..., null, Fixie.Tests.CaseTests)");
         }
 
+        public void ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasParameters()
+        {
+            Case("String", "\"").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\\"\")");
+            Case("String", "\\").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\\\\")");
+            Case("String", "\0").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\0\")");
+            Case("String", "\a").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\a\")");
+            Case("String", "\b").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\b\")");
+            Case("String", "\f").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\f\")");
+            Case("String", "\n").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\n\")");
+            Case("String", "\r").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\r\")");
+            Case("String", "\t").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\t\")");
+            Case("String", "\v").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\v\")");
+        }
+
         public void ShouldIncludeResolvedGenericArgumentsInNameWhenTheUnderlyingMethodIsGeneric()
         {
             Case("Generic", 123, true, "a", "b")
@@ -108,6 +122,10 @@ namespace Fixie.Tests
         }
 
         void Parameterized(int i, bool b, char ch, string s1, string s2, object obj, CaseTests complex)
+        {
+        }
+
+        void String(string s)
         {
         }
 

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -16,7 +16,7 @@ namespace Fixie.Tests
         {
             var @case = Case("Parameterized", 123, true, 'a', "with \"quotes\"", "long \"string\" gets truncated", null, this);
 
-            @case.Name.ShouldEqual("Fixie.Tests.CaseTests.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g\"..., null, Fixie.Tests.CaseTests)");
+            @case.Name.ShouldEqual("Fixie.Tests.CaseTests.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseTests)");
         }
 
         public void ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -19,9 +19,59 @@ namespace Fixie.Tests
             @case.Name.ShouldEqual("Fixie.Tests.CaseTests.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g\"..., null, Fixie.Tests.CaseTests)");
         }
 
-        public void ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasParameters()
+        public void ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()
         {
+            Case("Char", '\"').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\"')");
+            Case("Char", '"').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\"')");
+            Case("Char", '\'').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\'')");
+
+            Case("Char", '\\').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\\\')");
+            Case("Char", '\0').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\0')");
+            Case("Char", '\a').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\a')");
+            Case("Char", '\b').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\b')");
+            Case("Char", '\f').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\f')");
+            Case("Char", '\n').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\n')");
+            Case("Char", '\r').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\r')");
+            Case("Char", '\t').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\t')");
+            Case("Char", '\v').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\v')");
+
+            // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
+            // Just like \r and \n, we escape these in order to present a readable string literal.  All other unicode sequences pass through
+            // with no additional special treatment.
+
+            // \uxxxx - Unicode escape sequence for character with hex value xxxx.
+            Case("Char", '\u0000').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\0')");
+            Case("Char", '\u0085').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u0085')");
+            Case("Char", '\u2028').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u2028')");
+            Case("Char", '\u2029').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u2029')");
+            Case("Char", '\u263A').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('☺')");
+
+            // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
+            Case("Char", '\x0000').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\0')");
+            Case("Char", '\x000').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\0')");
+            Case("Char", '\x00').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\0')");
+            Case("Char", '\x0').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\0')");
+            Case("Char", '\x0085').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u0085')");
+            Case("Char", '\x085').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u0085')");
+            Case("Char", '\x85').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u0085')");
+            Case("Char", '\x2028').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u2028')");
+            Case("Char", '\x2029').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u2029')");
+            Case("Char", '\x263A').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('☺')");
+
+            //\Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
+            Case("Char", '\U00000000').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\0')");
+            Case("Char", '\U00000085').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u0085')");
+            Case("Char", '\U00002028').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u2028')");
+            Case("Char", '\U00002029').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('\\u2029')");
+            Case("Char", '\U0000263A').Name.ShouldEqual("Fixie.Tests.CaseTests.Char('☺')");
+        }
+
+        public void ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasStringParameters()
+        {
+            Case("String", "\'").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"'\")");
+            Case("String", "'").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"'\")");
             Case("String", "\"").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\\"\")");
+
             Case("String", "\\").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\\\\")");
             Case("String", "\0").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\0\")");
             Case("String", "\a").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\a\")");
@@ -152,6 +202,10 @@ namespace Fixie.Tests
         }
 
         void Parameterized(int i, bool b, char ch, string s1, string s2, object obj, CaseTests complex)
+        {
+        }
+
+        void Char(char ch)
         {
         }
 

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -31,6 +31,36 @@ namespace Fixie.Tests
             Case("String", "\r").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\r\")");
             Case("String", "\t").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\t\")");
             Case("String", "\v").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\v\")");
+
+            // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
+            // Just like \r and \n, we escape these in order to present a readable string literal.  All other unicode sequences pass through
+            // with no additional special treatment.
+
+            // \uxxxx - Unicode escape sequence for character with hex value xxxx.
+            Case("String", "\u0000").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\0\")");
+            Case("String", "\u0085").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u0085\")");
+            Case("String", "\u2028").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u2028\")");
+            Case("String", "\u2029").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u2029\")");
+            Case("String", "\u263A").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"☺\")");
+
+            // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
+            Case("String", "\x0000").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\0\")");
+            Case("String", "\x000").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\0\")");
+            Case("String", "\x00").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\0\")");
+            Case("String", "\x0").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\0\")");
+            Case("String", "\x0085").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u0085\")");
+            Case("String", "\x085").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u0085\")");
+            Case("String", "\x85").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u0085\")");
+            Case("String", "\x2028").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u2028\")");
+            Case("String", "\x2029").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u2029\")");
+            Case("String", "\x263A").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"☺\")");
+
+            //\Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
+            Case("String", "\U00000000").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\0\")");
+            Case("String", "\U00000085").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u0085\")");
+            Case("String", "\U00002028").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u2028\")");
+            Case("String", "\U00002029").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"\\u2029\")");
+            Case("String", "\U0000263A").Name.ShouldEqual("Fixie.Tests.CaseTests.String(\"☺\")");
         }
 
         public void ShouldIncludeResolvedGenericArgumentsInNameWhenTheUnderlyingMethodIsGeneric()

--- a/src/Fixie/Internal/ObjectExtensions.cs
+++ b/src/Fixie/Internal/ObjectExtensions.cs
@@ -23,7 +23,7 @@ namespace Fixie.Internal
                 const int trimLength = 15;
 
                 if (s.Length > trimLength)
-                    return "\"" + s.Substring(0, trimLength).Escape() + "\"...";
+                    return "\"" + s.Substring(0, trimLength).Escape() + "...\"";
 
                 return "\"" + s.Escape() + "\"";
             }

--- a/src/Fixie/Internal/ObjectExtensions.cs
+++ b/src/Fixie/Internal/ObjectExtensions.cs
@@ -12,7 +12,10 @@ namespace Fixie.Internal
                 return "null";
 
             if (parameter is char)
-                return "'" + parameter + "'";
+            {
+                var ch = (char)parameter;
+                return "'" + ch.Escape(Literal.Character) + "'";
+            }
 
             var s = parameter as string;
             if (s != null)
@@ -33,16 +36,18 @@ namespace Fixie.Internal
             var sb = new StringBuilder();
 
             foreach (var ch in s)
-                sb.Append(Escape(ch));
+                sb.Append(ch.Escape(Literal.String));
 
             return sb.ToString();
         }
 
-        static string Escape(char ch)
+        static string Escape(this char ch, Literal literal)
         {
             switch (ch)
             {
-                case '\"': return "\\\"";
+                case '\"': return literal == Literal.String ? "\\\"" : Char.ToString(ch);
+                case '\'': return literal == Literal.Character ? "\\\'" : Char.ToString(ch);
+
                 case '\\': return "\\\\";
                 case '\0': return "\\0";
                 case '\a': return "\\a";
@@ -62,5 +67,7 @@ namespace Fixie.Internal
                     return Char.ToString(ch);
             }
         }
+
+        enum Literal { Character, String }
     }
 }

--- a/src/Fixie/Internal/ObjectExtensions.cs
+++ b/src/Fixie/Internal/ObjectExtensions.cs
@@ -12,33 +12,33 @@ namespace Fixie.Internal
                 return "null";
 
             if (parameter is char)
-            {
-                var ch = (char)parameter;
-                return "'" + ch.Escape(Literal.Character) + "'";
-            }
+                return CharacterLiteral((char)parameter);
 
             var s = parameter as string;
             if (s != null)
-            {
-                const int trimLength = 15;
-
-                if (s.Length > trimLength)
-                    return "\"" + s.Substring(0, trimLength).Escape() + "...\"";
-
-                return "\"" + s.Escape() + "\"";
-            }
+                return ShortStringLiteral(s);
 
             return Convert.ToString(parameter, CultureInfo.InvariantCulture);
         }
 
-        static string Escape(this string s)
+        static string CharacterLiteral(char ch)
         {
+            return "'" + ch.Escape(Literal.Character) + "'";
+        }
+
+        static string ShortStringLiteral(string s)
+        {
+            const int trimLength = 15;
+
+            if (s.Length > trimLength)
+                s = s.Substring(0, trimLength) + "...";
+
             var sb = new StringBuilder();
 
             foreach (var ch in s)
                 sb.Append(ch.Escape(Literal.String));
 
-            return sb.ToString();
+            return "\"" + sb + "\"";
         }
 
         static string Escape(this char ch, Literal literal)

--- a/src/Fixie/Internal/ObjectExtensions.cs
+++ b/src/Fixie/Internal/ObjectExtensions.cs
@@ -1,29 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text.RegularExpressions;
+using System.Text;
 
 namespace Fixie.Internal
 {
     public static class ObjectExtensions
     {
-        static readonly Dictionary<string, string> EscapeMapping = new Dictionary<string, string>()
-        {
-            { "\"", "\\\"" },
-            { "\\\\", @"\\" },
-            { "\0", @"\0" },
-            { "\a", @"\a" },
-            { "\b", @"\b" },
-            { "\f", @"\f" },
-            { "\n", @"\n" },
-            { "\r", @"\r" },
-            { "\t", @"\t" },
-            { "\v", @"\v" }
-        };
-
-        static readonly Regex SpecialCharacters = new Regex(string.Join("|", EscapeMapping.Keys.ToArray()));
-
         public static string ToDisplayString(this object parameter)
         {
             if (parameter == null)
@@ -48,12 +30,37 @@ namespace Fixie.Internal
 
         static string Escape(this string s)
         {
-            return SpecialCharacters.Replace(s, Replacement);
+            var sb = new StringBuilder();
+
+            foreach (var ch in s)
+                sb.Append(Escape(ch));
+
+            return sb.ToString();
         }
 
-        static string Replacement(Match m)
+        static string Escape(char ch)
         {
-            return EscapeMapping.ContainsKey(m.Value) ? EscapeMapping[m.Value] : EscapeMapping[Regex.Escape(m.Value)];
+            switch (ch)
+            {
+                case '\"': return "\\\"";
+                case '\\': return "\\\\";
+                case '\0': return "\\0";
+                case '\a': return "\\a";
+                case '\b': return "\\b";
+                case '\f': return "\\f";
+                case '\n': return "\\n";
+                case '\r': return "\\r";
+                case '\t': return "\\t";
+                case '\v': return "\\v";
+
+                case '\u0085': //Next Line
+                case '\u2028': //Line Separator
+                case '\u2029': //Paragraph Separator
+                   return string.Format("\\u{0:X4}", (int)ch);
+
+                default:
+                    return Char.ToString(ch);
+            }
         }
     }
 }


### PR DESCRIPTION
* Fixes display of string literals by properly including the "..." *inside* the quotation marks of truncated string literals.
* Fixes display of string literals to properly escape unicode line ending characters  U+0085 (Next Line), U+2028 (Line Separator), and U+2029 (Paragraph Separator) as `\u####` sequences.
* Fixes display of char literals in test case names by displaying special characters with escape sequences, including the unicode fix above.
* Phases out needlessly-complex Regex solution for a simpler loop-and-switch replacement.