### PR TITLE
Simplify case result type hierarchy.

### DIFF
--- a/src/Fixie.Tests/Execution/AppDomainCommunicationAssertions.cs
+++ b/src/Fixie.Tests/Execution/AppDomainCommunicationAssertions.cs
@@ -75,12 +75,6 @@ namespace Fixie.Tests.Execution
 
             visitedTypes.Add(type);
 
-            if (type == typeof(CaseResult))
-            {
-                return KnownCaseResultImplementations()
-                    .All(implementationType => IsSafeForAppDomainCommunication(implementationType, visitedTypes));
-            }
-
             if (type == typeof(object))
                 return false;
 
@@ -117,14 +111,6 @@ namespace Fixie.Tests.Execution
             }
 
             return true;
-        }
-
-        static IEnumerable<Type> KnownCaseResultImplementations()
-        {
-            return typeof(CaseResult)
-                .Assembly
-                .GetTypes()
-                .Where(type => typeof(CaseResult).IsAssignableFrom(type) && type.IsClass);
         }
     }
 }

--- a/src/Fixie.Tests/Execution/CaseResultTests.cs
+++ b/src/Fixie.Tests/Execution/CaseResultTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Fixie.Execution;
+using Fixie.Internal;
+using Should;
+
+namespace Fixie.Tests.Execution
+{
+    public class CaseResultTests
+    {
+        public void ShouldDescribeCaseResults()
+        {
+            var listener = new StubListener();
+            var convention = SelfTestConvention.Build();
+            convention.CaseExecution.Skip(x => x.Method.Name == "Skip", x => "Skipped by naming convention.");
+
+            using (new RedirectedConsole())
+            {
+                var assemblyResult = new Runner(listener).RunTypes(GetType().Assembly, convention, typeof(SampleTestClass));
+                var classResult = assemblyResult.ConventionResults.Single().ClassResults.Single();
+
+                var skip = classResult.CaseResults[0];
+                var fail = classResult.CaseResults[1];
+                var pass = classResult.CaseResults[2];
+
+                pass.Name.ShouldEqual("Fixie.Tests.Execution.CaseResultTests+SampleTestClass.Pass");
+                pass.MethodGroup.FullName.ShouldEqual("Fixie.Tests.Execution.CaseResultTests+SampleTestClass.Pass");
+                pass.Output.ShouldEqual("Pass" + Environment.NewLine);
+                pass.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+                pass.Status.ShouldEqual(CaseStatus.Passed);
+                pass.Exceptions.ShouldBeNull();
+                pass.SkipReason.ShouldBeNull();
+
+                fail.Name.ShouldEqual("Fixie.Tests.Execution.CaseResultTests+SampleTestClass.Fail");
+                fail.MethodGroup.FullName.ShouldEqual("Fixie.Tests.Execution.CaseResultTests+SampleTestClass.Fail");
+                fail.Output.ShouldEqual("Fail" + Environment.NewLine);
+                fail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+                fail.Status.ShouldEqual(CaseStatus.Failed);
+                fail.Exceptions.PrimaryException.Message.ShouldEqual("'Fail' failed!");
+                fail.SkipReason.ShouldBeNull();
+
+                skip.Name.ShouldEqual("Fixie.Tests.Execution.CaseResultTests+SampleTestClass.Skip");
+                skip.MethodGroup.FullName.ShouldEqual("Fixie.Tests.Execution.CaseResultTests+SampleTestClass.Skip");
+                skip.Output.ShouldBeNull();
+                skip.Duration.ShouldEqual(TimeSpan.Zero);
+                skip.Status.ShouldEqual(CaseStatus.Skipped);
+                skip.Exceptions.ShouldBeNull();
+                skip.SkipReason.ShouldEqual("Skipped by naming convention.");
+            }
+        }
+
+        static void WhereAmI([CallerMemberName] string member = null)
+        {
+            Console.WriteLine(member);
+        }
+
+        class SampleTestClass
+        {
+            public void Fail()
+            {
+                WhereAmI();
+                throw new FailureException();
+            }
+
+            public void Pass()
+            {
+                WhereAmI();
+            }
+
+            public void Skip()
+            {
+                WhereAmI();
+            }
+        }
+    }
+}

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="AssertionLibraryFilteringTests.cs" />
     <Compile Include="Assertions.cs" />
     <Compile Include="Execution\ExecutionEnvironmentTests.cs" />
+    <Compile Include="Execution\CaseResultTests.cs" />
     <Compile Include="MethodGroupTests.cs" />
     <Compile Include="Internal\ParameterDiscovererTests.cs" />
     <Compile Include="Execution\AppDomainCommunicationAssertions.cs" />

--- a/src/Fixie/Execution/CaseResult.cs
+++ b/src/Fixie/Execution/CaseResult.cs
@@ -2,14 +2,48 @@ using System;
 
 namespace Fixie.Execution
 {
-    public interface CaseResult
+    [Serializable]
+    public class CaseResult
     {
-        CaseStatus Status { get; }
-        string Name  { get; }
-        MethodGroup MethodGroup  { get; }
-        string Output  { get; }
-        TimeSpan Duration  { get; }
-        CompoundException Exceptions { get; }
-        string SkipReason { get; }
+        public CaseResult(PassResult result)
+        {
+            Status = CaseStatus.Passed;
+            Name = result.Name;
+            MethodGroup = result.MethodGroup;
+            Output = result.Output;
+            Duration = result.Duration;
+            Exceptions = null;
+            SkipReason= null;
+        }
+
+        public CaseResult(FailResult result)
+        {
+            Status = CaseStatus.Failed;
+            Name = result.Name;
+            MethodGroup = result.MethodGroup;
+            Output = result.Output;
+            Duration = result.Duration;
+            Exceptions = result.Exceptions;
+            SkipReason = null;
+        }
+
+        public CaseResult(SkipResult result)
+        {
+            Status = CaseStatus.Skipped;
+            Name = result.Name;
+            MethodGroup = result.MethodGroup;
+            Output = null;
+            Duration = TimeSpan.Zero;
+            Exceptions = null;
+            SkipReason = result.SkipReason;
+        }
+
+        public CaseStatus Status { get; private set; }
+        public string Name { get; private set; }
+        public MethodGroup MethodGroup { get; private set; }
+        public string Output { get; private set; }
+        public TimeSpan Duration { get; private set; }
+        public CompoundException Exceptions { get; private set; }
+        public string SkipReason { get; private set; }
     }
 }

--- a/src/Fixie/Execution/FailResult.cs
+++ b/src/Fixie/Execution/FailResult.cs
@@ -4,7 +4,7 @@ using Fixie.Internal;
 namespace Fixie.Execution
 {
     [Serializable]
-    public class FailResult : CaseResult
+    public class FailResult
     {
         public FailResult(Case @case, AssertionLibraryFilter filter)
         {
@@ -21,8 +21,5 @@ namespace Fixie.Execution
         public string Output { get; private set; }
         public TimeSpan Duration { get; private set; }
         public CompoundException Exceptions { get; private set; }
-
-        CaseStatus CaseResult.Status { get { return CaseStatus.Failed; } }
-        string CaseResult.SkipReason { get { return null; } }
     }
 }

--- a/src/Fixie/Execution/PassResult.cs
+++ b/src/Fixie/Execution/PassResult.cs
@@ -3,7 +3,7 @@
 namespace Fixie.Execution
 {
     [Serializable]
-    public class PassResult : CaseResult
+    public class PassResult
     {
         public PassResult(Case @case)
         {
@@ -17,9 +17,5 @@ namespace Fixie.Execution
         public MethodGroup MethodGroup { get; private set; }
         public string Output { get; private set; }
         public TimeSpan Duration { get; private set; }
-
-        CaseStatus CaseResult.Status { get { return CaseStatus.Passed; } }
-        CompoundException CaseResult.Exceptions { get { return null; } }
-        string CaseResult.SkipReason { get { return null; } }
     }
 }

--- a/src/Fixie/Execution/SkipResult.cs
+++ b/src/Fixie/Execution/SkipResult.cs
@@ -3,7 +3,7 @@
 namespace Fixie.Execution
 {
     [Serializable]
-    public class SkipResult : CaseResult
+    public class SkipResult
     {
         public SkipResult(Case @case, string skipReason)
         {
@@ -15,10 +15,5 @@ namespace Fixie.Execution
         public string Name { get; private set; }
         public MethodGroup MethodGroup { get; private set; }
         public string SkipReason { get; private set; }
-
-        CaseStatus CaseResult.Status { get { return CaseStatus.Skipped; } }
-        string CaseResult.Output { get { return null; } }
-        TimeSpan CaseResult.Duration { get { return TimeSpan.Zero; } }
-        CompoundException CaseResult.Exceptions { get { return null; } }
     }
 }

--- a/src/Fixie/Internal/ClassRunner.cs
+++ b/src/Fixie/Internal/ClassRunner.cs
@@ -152,21 +152,21 @@ namespace Fixie.Internal
         {
             var result = new SkipResult(@case, reason);
             listener.CaseSkipped(result);
-            return result;
+            return new CaseResult(result);
         }
 
         CaseResult Pass(Case @case)
         {
             var result = new PassResult(@case);
             listener.CasePassed(result);
-            return result;
+            return new CaseResult(result);
         }
 
         CaseResult Fail(Case @case)
         {
             var result = new FailResult(@case, assertionLibraryFilter);
             listener.CaseFailed(result);
-            return result;
+            return new CaseResult(result);
         }
     }
 }


### PR DESCRIPTION
To enable upcoming changes to the runner API and its use of AppDomains, this separates CaseResult from the more specific types PassResult, FailResult, and SkipResult.  The 3 specific result types allow for the Listener interface to be easy to work with, but need not inherit from CaseResult, which complicated their implementation.