### PR TITLE
Listener factory constructor arguments

### DIFF
--- a/src/Fixie.Console/ListenerFactory.cs
+++ b/src/Fixie.Console/ListenerFactory.cs
@@ -19,14 +19,12 @@ namespace Fixie.ConsoleRunner
 
     public class ListenerFactory : IListenerFactory
     {
-        readonly IExecutionSink executionSink;
-
-        public ListenerFactory(IExecutionSink executionSink)
+        public ListenerFactory(IExecutionSink executionSink, string message)
         {
-            executionSink.SendMessage("Message sent to execution sink from within the ListenerFactory's own constructor.");
+            executionSink.SendMessage("Message sent to execution sink from within the ListenerFactory's own constructor: " + message);
         }
 
-        public Listener Create(Options options, IExecutionSink executionSink)
+        public Listener Create(Options options)
         {
             if (ShouldUseTeamCityListener(options))
                 return new TeamCityListener();

--- a/src/Fixie.Console/ListenerFactory.cs
+++ b/src/Fixie.Console/ListenerFactory.cs
@@ -4,26 +4,8 @@ using Fixie.Execution;
 
 namespace Fixie.ConsoleRunner
 {
-    public class ExecutionSink : LongLivedMarshalByRefObject, IExecutionSink
-    {
-        public void SendMessage(string message)
-        {
-            Console.WriteLine("SENDMESSAGE: " + message);
-        }
-
-        public void RecordResult(CaseResult caseResult)
-        {
-            Console.WriteLine("RECORDRESULT: " + caseResult.Name);
-        }
-    }
-
     public class ListenerFactory : IListenerFactory
     {
-        public ListenerFactory(IExecutionSink executionSink, string message)
-        {
-            executionSink.SendMessage("Message sent to execution sink from within the ListenerFactory's own constructor: " + message);
-        }
-
         public Listener Create(Options options)
         {
             if (ShouldUseTeamCityListener(options))

--- a/src/Fixie.Console/ListenerFactory.cs
+++ b/src/Fixie.Console/ListenerFactory.cs
@@ -4,8 +4,28 @@ using Fixie.Execution;
 
 namespace Fixie.ConsoleRunner
 {
+    public class ExecutionSink : LongLivedMarshalByRefObject, IExecutionSink
+    {
+        public void SendMessage(string message)
+        {
+            Console.WriteLine("SENDMESSAGE: " + message);
+        }
+
+        public void RecordResult(CaseResult caseResult)
+        {
+            Console.WriteLine("RECORDRESULT: " + caseResult.Name);
+        }
+    }
+
     public class ListenerFactory : IListenerFactory
     {
+        readonly IExecutionSink executionSink;
+
+        public ListenerFactory(IExecutionSink executionSink)
+        {
+            executionSink.SendMessage("Message sent to execution sink from within the ListenerFactory's own constructor.");
+        }
+
         public Listener Create(Options options, IExecutionSink executionSink)
         {
             if (ShouldUseTeamCityListener(options))

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -113,11 +113,8 @@ namespace Fixie.ConsoleRunner
         static AssemblyResult Execute(string assemblyPath, Options options)
         {
             using (var environment = new ExecutionEnvironment(assemblyPath))
-            using (var executionSink = new ExecutionSink())
             {
-                environment.ResolveAssemblyContaining<ExecutionSink>();
-
-                return environment.RunAssembly<ListenerFactory>(options, executionSink, "Hello, world!");
+                return environment.RunAssembly<ListenerFactory>(options);
             }
         }
     }

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -113,8 +113,9 @@ namespace Fixie.ConsoleRunner
         static AssemblyResult Execute(string assemblyPath, Options options)
         {
             using (var environment = new ExecutionEnvironment(assemblyPath))
+            using (var executionSink = new ExecutionSink())
             {
-                return environment.RunAssembly<ListenerFactory>(options, null);
+                return environment.RunAssembly<ListenerFactory>(options, executionSink);
             }
         }
     }

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -115,6 +115,8 @@ namespace Fixie.ConsoleRunner
             using (var environment = new ExecutionEnvironment(assemblyPath))
             using (var executionSink = new ExecutionSink())
             {
+                environment.ResolveAssemblyContaining<ExecutionSink>();
+
                 return environment.RunAssembly<ListenerFactory>(options, executionSink);
             }
         }

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -117,7 +117,7 @@ namespace Fixie.ConsoleRunner
             {
                 environment.ResolveAssemblyContaining<ExecutionSink>();
 
-                return environment.RunAssembly<ListenerFactory>(options, executionSink);
+                return environment.RunAssembly<ListenerFactory>(options, executionSink, "Hello, world!");
             }
         }
     }

--- a/src/Fixie.Tests/Execution/AppDomainCommunicationAssertions.cs
+++ b/src/Fixie.Tests/Execution/AppDomainCommunicationAssertions.cs
@@ -75,8 +75,14 @@ namespace Fixie.Tests.Execution
 
             visitedTypes.Add(type);
 
-            if (type == typeof(object))
-                return false;
+            if (type == typeof(object) || type == typeof(object[]))
+            {
+                //These types may or may not cross the AppDomain boundary successfully,
+                //but like IExecutionSink it is the responsibilty of the caller to pass
+                //safe types.  There is nothing left to check for here, so it is assumed
+                //to be valid.
+                return true;
+            }
 
             if (type == typeof(Type))
                 return false;

--- a/src/Fixie.VisualStudio.TestAdapter/ListenerFactory.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/ListenerFactory.cs
@@ -4,7 +4,14 @@ namespace Fixie.VisualStudio.TestAdapter
 {
     public class ListenerFactory : IListenerFactory
     {
-        public Listener Create(Options options, IExecutionSink executionSink)
+        readonly IExecutionSink executionSink;
+
+        public ListenerFactory(IExecutionSink executionSink)
+        {
+            this.executionSink = executionSink;
+        }
+
+        public Listener Create(Options options)
         {
             return new VisualStudioListener(executionSink);
         }

--- a/src/Fixie.VisualStudio.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.VisualStudio.TestAdapter/VsTestExecutor.cs
@@ -42,6 +42,8 @@ namespace Fixie.VisualStudio.TestAdapter
                         using (var executionSink = new ExecutionSink(frameworkHandle, assemblyPath))
                         using (var environment = new ExecutionEnvironment(assemblyPath))
                         {
+                            environment.ResolveAssemblyContaining<ExecutionSink>();
+
                             environment.RunAssembly<ListenerFactory>(new Options(), executionSink);
                         }
                     }
@@ -89,7 +91,9 @@ namespace Fixie.VisualStudio.TestAdapter
                         using (var executionSink = new ExecutionSink(frameworkHandle, assemblyPath))
                         using (var environment = new ExecutionEnvironment(assemblyPath))
                         {
-                            environment.RunMethods<ListenerFactory>(new Options(), executionSink, methodGroups);
+                            environment.ResolveAssemblyContaining<ExecutionSink>();
+
+                            environment.RunMethods<ListenerFactory>(new Options(), methodGroups, executionSink);
                         }
                     }
                     else

--- a/src/Fixie/Execution/ExecutionEnvironment.cs
+++ b/src/Fixie/Execution/ExecutionEnvironment.cs
@@ -12,6 +12,7 @@ namespace Fixie.Execution
         readonly string assemblyFullPath;
         readonly AppDomain appDomain;
         readonly string previousWorkingDirectory;
+        readonly RemoteAssemblyResolver assemblyResolver;
 
         public ExecutionEnvironment(string assemblyPath)
         {
@@ -21,6 +22,13 @@ namespace Fixie.Execution
             previousWorkingDirectory = Directory.GetCurrentDirectory();
             var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath);
             Directory.SetCurrentDirectory(assemblyDirectory);
+
+            assemblyResolver = Create<RemoteAssemblyResolver>();
+        }
+
+        public void ResolveAssemblyContaining<T>()
+        {
+            assemblyResolver.AddAssemblyLocation(typeof(T).Assembly.Location);
         }
 
         public IReadOnlyList<MethodGroup> DiscoverTestMethodGroups(Options options)
@@ -70,6 +78,7 @@ namespace Fixie.Execution
 
         public void Dispose()
         {
+            assemblyResolver.Dispose();
             AppDomain.Unload(appDomain);
             Directory.SetCurrentDirectory(previousWorkingDirectory);
         }

--- a/src/Fixie/Execution/ExecutionEnvironment.cs
+++ b/src/Fixie/Execution/ExecutionEnvironment.cs
@@ -69,9 +69,9 @@ namespace Fixie.Execution
 
             var type = o.GetType();
             var message = string.Format("Type '{0}' in Assembly '{1}' must either be [Serialiable] or inherit from '{2}'.",
-                type.FullName,
-                type.Assembly,
-                typeof(LongLivedMarshalByRefObject).FullName);
+                                        type.FullName,
+                                        type.Assembly,
+                                        typeof(LongLivedMarshalByRefObject).FullName);
             throw new Exception(message);
         }
 

--- a/src/Fixie/Execution/ExecutionEnvironment.cs
+++ b/src/Fixie/Execution/ExecutionEnvironment.cs
@@ -40,7 +40,7 @@ namespace Fixie.Execution
         public AssemblyResult RunAssembly<TListenerFactory>(Options options, params object[] listenerFactoryArgs) where TListenerFactory : IListenerFactory
         {
             foreach (var arg in listenerFactoryArgs)
-                AssertIsLongLivedMarshalByRefObject(arg);
+                AssertSafeForAppDomainCommunication(arg);
 
             var listenerFactoryAssemblyFullPath = typeof(TListenerFactory).Assembly.Location;
             var listenerFactoryType = typeof(TListenerFactory).FullName;
@@ -52,7 +52,7 @@ namespace Fixie.Execution
         public AssemblyResult RunMethods<TListenerFactory>(Options options, MethodGroup[] methodGroups, params object[] listenerFactoryArgs) where TListenerFactory : IListenerFactory
         {
             foreach (var arg in listenerFactoryArgs)
-                AssertIsLongLivedMarshalByRefObject(arg);
+                AssertSafeForAppDomainCommunication(arg);
 
             var listenerFactoryAssemblyFullPath = typeof(TListenerFactory).Assembly.Location;
             var listenerFactoryType = typeof(TListenerFactory).FullName;
@@ -61,7 +61,7 @@ namespace Fixie.Execution
                 return executionProxy.RunMethods(assemblyFullPath, listenerFactoryAssemblyFullPath, listenerFactoryType, options, methodGroups, listenerFactoryArgs);
         }
 
-        static void AssertIsLongLivedMarshalByRefObject(object o)
+        static void AssertSafeForAppDomainCommunication(object o)
         {
             if (o == null) return;
             if (o is LongLivedMarshalByRefObject) return;

--- a/src/Fixie/Execution/IListenerFactory.cs
+++ b/src/Fixie/Execution/IListenerFactory.cs
@@ -2,6 +2,6 @@
 {
     public interface IListenerFactory
     {
-        Listener Create(Options options, IExecutionSink executionSink);
+        Listener Create(Options options);
     }
 }

--- a/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
+++ b/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
@@ -6,8 +6,8 @@ namespace Fixie.Execution
     /// <summary>
     /// Simplifies the definition of MarshalByRefObject classes whose
     /// instances need to live longer than the default lease lifetime
-    /// allows, such as implementations of Listener provided by test
-    /// runners.
+    /// allows, such as objects passed from a Fixie runner into the
+    /// AppDomain of a running test assembly.
     /// 
     /// Instances of LongLivedMarshalByRefObject have an infinite
     /// lease lifetime so that they won't become defective after

--- a/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
+++ b/src/Fixie/Execution/LongLivedMarshalByRefObject.cs
@@ -38,7 +38,7 @@ namespace Fixie.Execution
             return null;
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             RemotingServices.Disconnect(this);
         }

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Execution\IExecutionSink.cs" />
     <Compile Include="Execution\IListenerFactory.cs" />
     <Compile Include="Execution\LongLivedMarshalByRefObject.cs" />
+    <Compile Include="Internal\RemoteAssemblyResolver.cs" />
     <Compile Include="Internal\Discoverer.cs" />
     <Compile Include="Internal\ParameterDiscoverer.cs" />
     <Compile Include="Internal\SkipRule.cs" />

--- a/src/Fixie/Internal/ExecutionProxy.cs
+++ b/src/Fixie/Internal/ExecutionProxy.cs
@@ -40,7 +40,7 @@ namespace Fixie.Internal
         {
             var type = LoadAssembly(listenerFactoryAssemblyFullPath).GetType(listenerFactoryType);
 
-            var factory = (IListenerFactory)Activator.CreateInstance(type);
+            var factory = (IListenerFactory)Activator.CreateInstance(type, executionSink);
 
             return factory.Create(options, executionSink);
         }

--- a/src/Fixie/Internal/ExecutionProxy.cs
+++ b/src/Fixie/Internal/ExecutionProxy.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Fixie.Execution;
 
@@ -23,17 +22,7 @@ namespace Fixie.Internal
 
             var assembly = LoadAssembly(assemblyFullPath);
 
-            var assemblyResult = runner.RunAssembly(assembly);
-
-            var sink = ((IExecutionSink)listenerFactoryArgs.First());
-            sink.SendMessage("------------");
-            sink.SendMessage("Although passed across as simply an object, the execution sink's runtime type in the child domain is: " + sink.GetType());
-            sink.SendMessage("At the end of this run, the child appdomain contained these assemblies:");
-            foreach (var a in AppDomain.CurrentDomain.GetAssemblies().Select(x => x.ToString()).OrderBy(x => x))
-                sink.SendMessage("\t" + a.ToString());
-            sink.SendMessage("------------");
-
-            return assemblyResult;
+            return runner.RunAssembly(assembly);
         }
 
         public AssemblyResult RunMethods(string assemblyFullPath, string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, MethodGroup[] methodGroups, object[] listenerFactoryArgs)
@@ -44,17 +33,7 @@ namespace Fixie.Internal
 
             var assembly = LoadAssembly(assemblyFullPath);
 
-            var assemblyResult = runner.RunMethods(assembly, methodGroups);
-
-            var sink = ((IExecutionSink)listenerFactoryArgs.First());
-            sink.SendMessage("------------");
-            sink.SendMessage("Although passed across as simply an object, the execution sink's runtime type in the child domain is: " + sink.GetType());
-            sink.SendMessage("At the end of this run, the child appdomain contained these assemblies:");
-            foreach (var a in AppDomain.CurrentDomain.GetAssemblies().Select(x => x.ToString()).OrderBy(x => x))
-                sink.SendMessage("\t" + a.ToString());
-            sink.SendMessage("------------");
-
-            return assemblyResult;
+            return runner.RunMethods(assembly, methodGroups);
         }
 
         static Listener CreateListener(string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, object[] listenerFactoryArgs)

--- a/src/Fixie/Internal/ExecutionProxy.cs
+++ b/src/Fixie/Internal/ExecutionProxy.cs
@@ -14,9 +14,9 @@ namespace Fixie.Internal
             return new Discoverer(options).DiscoverTestMethodGroups(assembly);
         }
 
-        public AssemblyResult RunAssembly(string assemblyFullPath, string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, IExecutionSink executionSink)
+        public AssemblyResult RunAssembly(string assemblyFullPath, string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, object[] listenerFactoryArgs)
         {
-            var listener = CreateListener(listenerFactoryAssemblyFullPath, listenerFactoryType, options, executionSink);
+            var listener = CreateListener(listenerFactoryAssemblyFullPath, listenerFactoryType, options, listenerFactoryArgs);
 
             var runner = new Runner(listener, options);
 
@@ -25,9 +25,9 @@ namespace Fixie.Internal
             return runner.RunAssembly(assembly);
         }
 
-        public AssemblyResult RunMethods(string assemblyFullPath, string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, IExecutionSink executionSink, MethodGroup[] methodGroups)
+        public AssemblyResult RunMethods(string assemblyFullPath, string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, MethodGroup[] methodGroups, object[] listenerFactoryArgs)
         {
-            var listener = CreateListener(listenerFactoryAssemblyFullPath, listenerFactoryType, options, executionSink);
+            var listener = CreateListener(listenerFactoryAssemblyFullPath, listenerFactoryType, options, listenerFactoryArgs);
 
             var runner = new Runner(listener, options);
 
@@ -36,13 +36,13 @@ namespace Fixie.Internal
             return runner.RunMethods(assembly, methodGroups);
         }
 
-        static Listener CreateListener(string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, IExecutionSink executionSink)
+        static Listener CreateListener(string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, object[] listenerFactoryArgs)
         {
             var type = LoadAssembly(listenerFactoryAssemblyFullPath).GetType(listenerFactoryType);
 
-            var factory = (IListenerFactory)Activator.CreateInstance(type, executionSink);
+            var factory = (IListenerFactory)Activator.CreateInstance(type, listenerFactoryArgs);
 
-            return factory.Create(options, executionSink);
+            return factory.Create(options);
         }
 
         static Assembly LoadAssembly(string assemblyFullPath)

--- a/src/Fixie/Internal/ExecutionProxy.cs
+++ b/src/Fixie/Internal/ExecutionProxy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Fixie.Execution;
 
@@ -22,7 +23,17 @@ namespace Fixie.Internal
 
             var assembly = LoadAssembly(assemblyFullPath);
 
-            return runner.RunAssembly(assembly);
+            var assemblyResult = runner.RunAssembly(assembly);
+
+            var sink = ((IExecutionSink)listenerFactoryArgs.First());
+            sink.SendMessage("------------");
+            sink.SendMessage("Although passed across as simply an object, the execution sink's runtime type in the child domain is: " + sink.GetType());
+            sink.SendMessage("At the end of this run, the child appdomain contained these assemblies:");
+            foreach (var a in AppDomain.CurrentDomain.GetAssemblies().Select(x => x.ToString()).OrderBy(x => x))
+                sink.SendMessage("\t" + a.ToString());
+            sink.SendMessage("------------");
+
+            return assemblyResult;
         }
 
         public AssemblyResult RunMethods(string assemblyFullPath, string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, MethodGroup[] methodGroups, object[] listenerFactoryArgs)
@@ -33,7 +44,17 @@ namespace Fixie.Internal
 
             var assembly = LoadAssembly(assemblyFullPath);
 
-            return runner.RunMethods(assembly, methodGroups);
+            var assemblyResult = runner.RunMethods(assembly, methodGroups);
+
+            var sink = ((IExecutionSink)listenerFactoryArgs.First());
+            sink.SendMessage("------------");
+            sink.SendMessage("Although passed across as simply an object, the execution sink's runtime type in the child domain is: " + sink.GetType());
+            sink.SendMessage("At the end of this run, the child appdomain contained these assemblies:");
+            foreach (var a in AppDomain.CurrentDomain.GetAssemblies().Select(x => x.ToString()).OrderBy(x => x))
+                sink.SendMessage("\t" + a.ToString());
+            sink.SendMessage("------------");
+
+            return assemblyResult;
         }
 
         static Listener CreateListener(string listenerFactoryAssemblyFullPath, string listenerFactoryType, Options options, object[] listenerFactoryArgs)

--- a/src/Fixie/Internal/RemoteAssemblyResolver.cs
+++ b/src/Fixie/Internal/RemoteAssemblyResolver.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Fixie.Execution;
+
+namespace Fixie.Internal
+{
+    public class RemoteAssemblyResolver : LongLivedMarshalByRefObject
+    {
+        readonly List<string> allowedAssemblyLocations = new List<string>();
+
+        public void AddAssemblyLocation(string assemblyLocation)
+        {
+            if (!allowedAssemblyLocations.Contains(assemblyLocation))
+                allowedAssemblyLocations.Add(assemblyLocation);
+        }
+
+        public RemoteAssemblyResolver()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += Resolve;
+        }
+
+        public override void Dispose()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve -= Resolve;
+            base.Dispose();
+        }
+
+        Assembly Resolve(object sender, ResolveEventArgs args)
+        {
+            var pathTailWithoutExtension = Path.DirectorySeparatorChar + new AssemblyName(args.Name).Name;
+
+            foreach (var location in allowedAssemblyLocations)
+            {
+                try
+                {
+                    if (location.EndsWith(pathTailWithoutExtension + ".dll") && File.Exists(location))
+                        return LoadAssembly(location);
+
+                    if (location.EndsWith(pathTailWithoutExtension + ".exe") && File.Exists(location))
+                        return LoadAssembly(location);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                }
+            }
+
+            return null;
+        }
+
+        static Assembly LoadAssembly(string assemblyFullPath)
+        {
+            return Assembly.Load(AssemblyName.GetAssemblyName(assemblyFullPath));
+        }
+    }
+}

--- a/src/Fixie/Internal/RemoteAssemblyResolver.cs
+++ b/src/Fixie/Internal/RemoteAssemblyResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using Fixie.Execution;
@@ -43,7 +44,7 @@ namespace Fixie.Internal
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine(ex);
+                    Debug.WriteLine(typeof(RemoteAssemblyResolver).FullName + " failed to load assembly at " + location + ": " + ex);
                 }
             }
 


### PR DESCRIPTION
In #120, the Listener interface was separated from `AppDomain` communication so that they would stop having to be limited in the types they accept/return, and to limit the amount of code that cares about the deprecated concept of `AppDomains`.  This introduced `IExecutionSink` as a low-level interface that *did* continue to work with `AppDomains` so that Listener itself wouldn't have to.  Unfortunately, `IExecutionSink` became a declared argument on the `IListenerFactory`'s `Create` method, although *most* runners had no need for providing a concrete implemetation of `IExecutionSink`.

This pull request allows `IListenerFactory` implementations to have arbitrary constructor arguments, passed from the Fixie runner's `AppDomain` to the child `AppDomain` dedicated to each test assembly, partly to allow `IListenerFactory` to no longer depend on `IExecutionSink` explicitly.  Now, only the Visual Studio runner cares about providing an `IExecutionSink`.

Concrete implementations of `IExecutionSink` are likely to be defined in a runner rather than inside Fixie.dll.  The Visual Studio runner's own `ExecutionSink` is an example of that structure.  Consider the fact that the assembly containing such a concrete implementation is often *not* sitting in the running test assembly's own folder and would not be loaded in the child `AppDomain` at the moment the runner attempts to pass it into that `AppDomain`.  Because that would result in a runtime assembly loading failure, `ExecutionEnvironment` gains the ability to let a runner instruct it to load assemblies containing such a concrete type.  The Visual Studio runner does just that in order to successfully pass its `ExecutionSink` across the boundary.