### PR TITLE
Restore support for initializing TargetMember when a class is the target of a TD.NET invocation

### DIFF
--- a/src/Fixie.Samples/Fixie.Samples.csproj
+++ b/src/Fixie.Samples/Fixie.Samples.csproj
@@ -52,6 +52,8 @@
     <Compile Include="MbUnitStyle\Attributes.cs" />
     <Compile Include="MbUnitStyle\CalculatorTests.cs" />
     <Compile Include="MbUnitStyle\CustomConvention.cs" />
+    <Compile Include="Nested\CalculatorTests.cs" />
+    <Compile Include="Nested\CustomConvention.cs" />
     <Compile Include="NUnitStyle\CalculatorTests.cs" />
     <Compile Include="NUnitStyle\CustomConvention.cs" />
     <Compile Include="NUnitStyle\Attributes.cs" />

--- a/src/Fixie.Samples/Fixie.Samples.csproj
+++ b/src/Fixie.Samples/Fixie.Samples.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Shuffle\CustomConvention.cs" />
     <Compile Include="Shuffle\OrderTests.cs" />
     <Compile Include="Skipped\ExplicitAttribute.cs" />
+    <Compile Include="Skipped\ExplicitClassTests.cs" />
     <Compile Include="Skipped\SkipAttribute.cs" />
     <Compile Include="Skipped\SkipClassTests.cs" />
     <Compile Include="Skipped\CustomConvention.cs" />

--- a/src/Fixie.Samples/Nested/CalculatorTests.cs
+++ b/src/Fixie.Samples/Nested/CalculatorTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Text;
+using Should;
+
+namespace Fixie.Samples.Nested
+{
+    public class CalculatorTests
+    {
+        class AddingTests : IDisposable
+        {
+            readonly Calculator calculator;
+            readonly StringBuilder log;
+
+            public AddingTests()
+            {
+                calculator = new Calculator();
+                log = new StringBuilder();
+                log.WhereAmI();
+            }
+
+            public void ShouldAdd()
+            {
+                log.WhereAmI();
+                calculator.Add(2, 3).ShouldEqual(5);
+            }
+
+            public void Dispose()
+            {
+                log.WhereAmI();
+
+                log.ShouldHaveLines(
+                    ".ctor",
+                    "ShouldAdd",
+                    "Dispose");
+            }
+        }
+
+        class SubtractingTests : IDisposable
+        {
+            readonly Calculator calculator;
+            readonly StringBuilder log;
+
+            public SubtractingTests()
+            {
+                calculator = new Calculator();
+                log = new StringBuilder();
+                log.WhereAmI();
+            }
+
+            public void ShouldSubtract()
+            {
+                log.WhereAmI();
+                calculator.Subtract(5, 3).ShouldEqual(2);
+            }
+
+            public void Dispose()
+            {
+                log.WhereAmI();
+
+                log.ShouldHaveLines(
+                    ".ctor",
+                    "ShouldSubtract",
+                    "Dispose");
+            }
+        }
+    }
+}

--- a/src/Fixie.Samples/Nested/CustomConvention.cs
+++ b/src/Fixie.Samples/Nested/CustomConvention.cs
@@ -1,0 +1,15 @@
+﻿namespace Fixie.Samples.Nested
+{
+    public class CustomConvention : Convention
+    {
+        public CustomConvention()
+        {
+            Classes
+                .InTheSameNamespaceAs(typeof(CustomConvention))
+                .NameEndsWith("Tests");
+
+            Methods
+                .Where(method => method.IsVoid());
+        }
+    }
+}

--- a/src/Fixie.Samples/SamplesAssembly.cs
+++ b/src/Fixie.Samples/SamplesAssembly.cs
@@ -9,6 +9,7 @@
             Apply<IoC.CustomConvention>();
             Apply<LowCeremony.CustomConvention>();
             Apply<MbUnitStyle.CustomConvention>();
+            Apply<Nested.CustomConvention>();
             Apply<NUnitStyle.CustomConvention>();
             Apply<Parameterized.CustomConvention>();
             Apply<Shuffle.CustomConvention>();

--- a/src/Fixie.Samples/Skipped/CustomConvention.cs
+++ b/src/Fixie.Samples/Skipped/CustomConvention.cs
@@ -14,7 +14,8 @@ namespace Fixie.Samples.Skipped
                 .Where(method => method.IsVoid());
 
             CaseExecution
-                .Skip(SkipDueToExplicitAttribute, @case => "[Explicit] tests run only when they are individually selected for execution.")
+                .Skip(SkipDueToClassLevelExplicitAttribute, @case => "Tests within [Explicit] classes run only when the class is individually selected for execution.")
+                .Skip(SkipDueToMethodLevelExplicitAttribute, @case => "[Explicit] tests run only when they are individually selected for execution.")
                 .Skip(SkipDueToClassLevelSkipAttribute, @case => "whole class skipped")
                 .Skip(SkipDueToMethodLevelSkipAttribute);
 
@@ -23,7 +24,16 @@ namespace Fixie.Samples.Skipped
                 .SortCases((caseA, caseB) => String.Compare(caseA.Name, caseB.Name, StringComparison.Ordinal));
         }
 
-        bool SkipDueToExplicitAttribute(Case @case)
+        bool SkipDueToClassLevelExplicitAttribute(Case @case)
+        {
+            var method = @case.Method;
+
+            var isMarkedExplicit = method.DeclaringType.Has<ExplicitAttribute>();
+
+            return isMarkedExplicit && TargetMember != method.DeclaringType && TargetMember != method;
+        }
+
+        bool SkipDueToMethodLevelExplicitAttribute(Case @case)
         {
             var method = @case.Method;
 
@@ -34,12 +44,12 @@ namespace Fixie.Samples.Skipped
 
         static bool SkipDueToClassLevelSkipAttribute(Case @case)
         {
-            return @case.Method.DeclaringType.HasOrInherits<SkipAttribute>();
+            return @case.Method.DeclaringType.Has<SkipAttribute>();
         }
 
         static bool SkipDueToMethodLevelSkipAttribute(Case @case)
         {
-            return @case.Method.HasOrInherits<SkipAttribute>();
+            return @case.Method.Has<SkipAttribute>();
         }
     }
 }

--- a/src/Fixie.Samples/Skipped/ExplicitAttribute.cs
+++ b/src/Fixie.Samples/Skipped/ExplicitAttribute.cs
@@ -2,6 +2,6 @@
 
 namespace Fixie.Samples.Skipped
 {
-    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
     public class ExplicitAttribute : Attribute { }
 }

--- a/src/Fixie.Samples/Skipped/ExplicitClassTests.cs
+++ b/src/Fixie.Samples/Skipped/ExplicitClassTests.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Fixie.Samples.Skipped
+{
+    [Explicit]
+    public class ExplicitClassTests
+    {
+        public void TestWithinExplicitClass()
+        {
+            throw new Exception("TestWithinExplicitClass was invoked explicitly.");
+        }
+    }
+}

--- a/src/Fixie.Samples/Skipped/SkipClassTests.cs
+++ b/src/Fixie.Samples/Skipped/SkipClassTests.cs
@@ -10,4 +10,13 @@ namespace Fixie.Samples.Skipped
             throw new Exception("This test should be skipped.");
         }
     }
+
+    [Explicit]
+    public class ExplicitClassTests
+    {
+        public void TestWithinExplicitClass()
+        {
+            throw new Exception("TestWithinExplicitClass was invoked explicitly.");
+        }
+    }
 }

--- a/src/Fixie.Samples/Skipped/SkipClassTests.cs
+++ b/src/Fixie.Samples/Skipped/SkipClassTests.cs
@@ -10,13 +10,4 @@ namespace Fixie.Samples.Skipped
             throw new Exception("This test should be skipped.");
         }
     }
-
-    [Explicit]
-    public class ExplicitClassTests
-    {
-        public void TestWithinExplicitClass()
-        {
-            throw new Exception("TestWithinExplicitClass was invoked explicitly.");
-        }
-    }
 }

--- a/src/Fixie.TestDriven/TdNetRunner.cs
+++ b/src/Fixie.TestDriven/TdNetRunner.cs
@@ -37,21 +37,9 @@ namespace Fixie.TestDriven
 
             var type = member as Type;
             if (type != null)
-            {
-                var types = GetTypeAndNestedTypes(type).ToArray();
-
-                return Run(testListener, runner => runner.RunTypes(assembly, types));
-            }
+                return Run(testListener, runner => runner.RunType(assembly, type));
 
             return TestRunState.Error;
-        }
-
-        static IEnumerable<Type> GetTypeAndNestedTypes(Type type)
-        {
-            yield return type;
-
-            foreach (var nested in type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic).SelectMany(GetTypeAndNestedTypes))
-                yield return nested;
         }
 
         static TestRunState Run(ITestListener testListener, Func<Runner, AssemblyResult> run)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -38,13 +38,7 @@ namespace Fixie.Internal
         {
             RunContext.Set(options, type);
 
-            return RunTypesInternal(assembly, type);
-        }
-
-        public AssemblyResult RunTypes(Assembly assembly, params Type[] types)
-        {
-            RunContext.Set(options);
-
+            var types = GetTypeAndNestedTypes(type).ToArray();
             return RunTypesInternal(assembly, types);
         }
 
@@ -73,6 +67,14 @@ namespace Fixie.Internal
         public AssemblyResult RunMethods(Assembly assembly, MethodGroup[] methodGroups)
         {
             return RunMethods(assembly, GetMethods(assembly, methodGroups));
+        }
+
+        static IEnumerable<Type> GetTypeAndNestedTypes(Type type)
+        {
+            yield return type;
+
+            foreach (var nested in type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic).SelectMany(GetTypeAndNestedTypes))
+                yield return nested;
         }
 
         static MethodInfo[] GetMethods(Assembly assembly, MethodGroup[] methodGroups)


### PR DESCRIPTION
While implementing #87 to run nested test classes when TD.NET is used to invoke a single surrounding test class, I introduced a bug in which Convention.TargetMember would no longer be initialized at the class level.  If you used TD.NET to invoke a specific class, the convention wouldn't know that the class had been specifically selected for execution.  This lack of initialization would prevent a convention author from mimicking NUnit's class-level [Explicit] attributes, for instance.

This pull request fixes the initialization of TargetMember, preserves the behavior of running nested classes under TD.NET, and includes new Fixie.Samples conventions to demonstrate those scenarios.