### PR TITLE
Test case source

### DIFF
--- a/src/Fixie.Samples/Fixie.Samples.csproj
+++ b/src/Fixie.Samples/Fixie.Samples.csproj
@@ -57,9 +57,11 @@
     <Compile Include="NUnitStyle\CalculatorTests.cs" />
     <Compile Include="NUnitStyle\CustomConvention.cs" />
     <Compile Include="NUnitStyle\Attributes.cs" />
+    <Compile Include="Parameterized\TestCaseSourceAttributeCalculatorTests.cs" />
     <Compile Include="Parameterized\CalculatorTests.cs" />
     <Compile Include="Parameterized\CustomConvention.cs" />
     <Compile Include="Parameterized\InputAttribute.cs" />
+    <Compile Include="Parameterized\TestCaseSourceAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SamplesAssembly.cs" />
     <Compile Include="Shuffle\CustomConvention.cs" />

--- a/src/Fixie.Samples/Parameterized/CustomConvention.cs
+++ b/src/Fixie.Samples/Parameterized/CustomConvention.cs
@@ -21,7 +21,8 @@ namespace Fixie.Samples.Parameterized
                 .SortCases((caseA, caseB) => String.Compare(caseA.Name, caseB.Name, StringComparison.Ordinal));
 
             Parameters
-                .Add<InputAttributeParameterSource>();
+                .Add<InputAttributeParameterSource>()
+                .Add<TestCaseSourceAttributeParameterSource>();
         }
 
         class InputAttributeParameterSource : ParameterSource
@@ -29,6 +30,76 @@ namespace Fixie.Samples.Parameterized
             public IEnumerable<object[]> GetParameters(MethodInfo method)
             {
                 return method.GetCustomAttributes<InputAttribute>(true).Select(input => input.Parameters);
+            }
+        }
+
+        class TestCaseSourceAttributeParameterSource : ParameterSource
+        {
+            public IEnumerable<object[]> GetParameters(MethodInfo method)
+            {
+                var testInvocations = new List<object[]>();
+
+                var testCaseSourceAttributes = method.GetCustomAttributes<TestCaseSourceAttribute>(true).ToList();
+
+                foreach (var attribute in testCaseSourceAttributes)
+                {
+                    var sourceType = attribute.SourceType ?? method.ReflectedType;
+
+                    if (sourceType == null)
+                        throw new Exception("Could not find source type for method " + method.Name);
+
+                    var members = sourceType.GetMember(attribute.SourceName,
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+                    if (members.Length != 1)
+                        throw new Exception($"Found {members.Length} members of name {attribute.SourceName} in {sourceType}");
+
+                    var member = members[0];
+
+                    var field = member as FieldInfo;
+                    if (field != null)
+                    {
+                        if (field.IsStatic)
+                        {
+                            var val = field.GetValue(null) as IEnumerable<object[]>;
+                            testInvocations.AddRange(val);
+                        }
+                        else
+                        {
+                            throw new Exception($"Field {field.Name} must be static to be used as TestCaseSource input");
+                        }
+                    }
+                
+                    var property = member as PropertyInfo;
+                    if (property != null)
+                    {
+                        if (property.GetGetMethod(true).IsStatic)
+                        {
+                            var val = property.GetValue(null, null) as IEnumerable<object[]>;
+                            testInvocations.AddRange(val);
+                        }
+                        else
+                        {
+                            throw new Exception($"Property {property.Name} must have a static get() method to be used as TestCaseSource input");
+                        }
+                    }
+
+                    var m = member as MethodInfo;
+                    if (m != null)
+                    {
+                        if (m.IsStatic)
+                        {
+                            var val = m.Invoke(null, null) as IEnumerable<object[]>;
+                            testInvocations.AddRange(val);
+                        }
+                        else
+                        {
+                            throw new Exception($"Method {m.Name} must be static to be used as TestCaseSource input");
+                        }
+                    }
+                }
+
+                return testInvocations;
             }
         }
     }

--- a/src/Fixie.Samples/Parameterized/TestCaseSourceAttribute.cs
+++ b/src/Fixie.Samples/Parameterized/TestCaseSourceAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Fixie.Samples.Parameterized
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class TestCaseSourceAttribute : Attribute
+    {
+        public TestCaseSourceAttribute(string sourceName, Type sourceType)
+        {
+            SourceName = sourceName;
+            SourceType = sourceType;
+        }
+
+        public TestCaseSourceAttribute(string sourceName)
+        {
+            SourceName = sourceName;
+            SourceType = null;
+        }
+
+        public Type SourceType { get; set; }
+        public string SourceName { get; private set; }
+    }
+}

--- a/src/Fixie.Samples/Parameterized/TestCaseSourceAttributeCalculatorTests.cs
+++ b/src/Fixie.Samples/Parameterized/TestCaseSourceAttributeCalculatorTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Text;
+using Should;
+
+namespace Fixie.Samples.Parameterized
+{
+    using System.Collections.Generic;
+
+    public class TestCaseSourceAttributeCalculatorTests : IDisposable
+    {
+        readonly Calculator calculator;
+        readonly StringBuilder log;
+
+        public TestCaseSourceAttributeCalculatorTests()
+        {
+            calculator = new Calculator();
+            log = new StringBuilder();
+            log.WhereAmI();
+        }
+
+        public static IEnumerable<object[]> CustomFieldSource = new List<object[]>
+        {
+            new object[] { 10, 30, 40 },
+            new object[] { 2, 14, 16 }
+        };
+
+        public static IEnumerable<object[]> CustomMethodSource()
+        {
+            return new List<object[]>
+            {
+                new object[]{1, 3, 4},
+                new object[]{12, 15, 27}
+            };
+        }
+
+        public static IEnumerable<object[]> CustomPropertySource => new List<object[]>
+        {
+            new object[] { 8, 5, 3 },
+            new object[] { 5, 3, 2 },
+            new object[] { 10, 5, 5 }
+        };
+
+        [TestCaseSource("CustomFieldSource")]
+        public void ShouldAddFromFieldSource(int a, int b, int expectedSum)
+        {
+            log.AppendFormat("ShouldAdd({0}, {1}, {2})", a, b, expectedSum);
+            log.AppendLine();
+            calculator.Add(a, b).ShouldEqual(expectedSum);
+        }
+
+        [TestCaseSource("CustomFieldSource", typeof(ExternalSourceOfTestCaseData))]
+        public void ShouldAddFromExternalFieldSource(int a, int b, int expectedSum)
+        {
+            log.AppendFormat("ShouldAdd({0}, {1}, {2})", a, b, expectedSum);
+            log.AppendLine();
+            calculator.Add(a, b).ShouldEqual(expectedSum);
+        }
+
+        [TestCaseSource("CustomMethodSource")]
+        public void ShouldAddFromMethodSource(int a, int b, int expectedSum)
+        {
+            log.AppendFormat("ShouldAdd({0}, {1}, {2})", a, b, expectedSum);
+            log.AppendLine();
+            calculator.Add(a, b).ShouldEqual(expectedSum);
+        }
+
+        [TestCaseSource("CustomMethodSource", typeof(ExternalSourceOfTestCaseData))]
+        public void ShouldAddFromExternalMethodSource(int a, int b, int expectedSum)
+        {
+            log.AppendFormat("ShouldAdd({0}, {1}, {2})", a, b, expectedSum);
+            log.AppendLine();
+            calculator.Add(a, b).ShouldEqual(expectedSum);
+        }
+
+        [TestCaseSource("CustomPropertySource")]
+        public void ShouldSubtractFromPropertySource(int a, int b, int expectedDifference)
+        {
+            log.AppendFormat("ShouldSubtract({0}, {1}, {2})", a, b, expectedDifference);
+            log.AppendLine();
+            calculator.Subtract(a, b).ShouldEqual(expectedDifference);
+        }
+
+        [TestCaseSource("CustomPropertySource", typeof(ExternalSourceOfTestCaseData))]
+        public void ShouldSubtractFromExternalPropertySource(int a, int b, int expectedDifference)
+        {
+            log.AppendFormat("ShouldSubtract({0}, {1}, {2})", a, b, expectedDifference);
+            log.AppendLine();
+            calculator.Subtract(a, b).ShouldEqual(expectedDifference);
+        }
+
+        public void Dispose()
+        {
+            log.WhereAmI();
+            log.ShouldHaveLines(
+                ".ctor",
+                "ShouldAdd(100, 300, 400)",
+                "ShouldAdd(22, 34, 56)",
+                "ShouldAdd(11, 33, 44)",
+                "ShouldAdd(110, 115, 225)",
+                "ShouldAdd(10, 30, 40)",
+                "ShouldAdd(2, 14, 16)",
+                "ShouldAdd(1, 3, 4)",
+                "ShouldAdd(12, 15, 27)",
+                "ShouldSubtract(100, 35, 65)",
+                "ShouldSubtract(18, 5, 13)",
+                "ShouldSubtract(25, 23, 2)",
+                "ShouldSubtract(10, 5, 5)",
+                "ShouldSubtract(5, 3, 2)",
+                "ShouldSubtract(8, 5, 3)",
+                "Dispose");
+        }
+    }
+
+    public class ExternalSourceOfTestCaseData
+    {
+        public static IEnumerable<object[]> CustomFieldSource = new List<object[]>
+        {
+            new object[] { 100, 300, 400 },
+            new object[] { 22, 34, 56 }
+        };
+
+        public static IEnumerable<object[]> CustomMethodSource()
+        {
+            return new List<object[]>
+            {
+                new object[]{11, 33, 44},
+                new object[]{110, 115, 225}
+            };
+        }
+        public static IEnumerable<object[]> CustomPropertySource => new List<object[]>
+        {
+            new object[] { 18, 5, 13 },
+            new object[] { 25, 23, 2 },
+            new object[] { 100, 35, 65 }
+        };
+    }
+}


### PR DESCRIPTION
Adding to Fixie samples - this sample adds a Fixie convention to recognize user-defined data sources for parameterized tests. *A simple implementation of [NUnit's TestCaseSource attribute][1] in Fixie.*

In this sample, I added a custom convention that recognizes my "TestCaseSource" attribute, allowing you to name the public static method, field or property that will supply the input parameters. Allows you to specify an additional parameter if the method/field/property is in another class.

*Use cases:*
* When the same test needs to be run for every value of an Enumeration
* When the same test needs to be run for all values in a set, but some inputs should result in a true condition and others in a false condition
* When the same test needs to be run for all possible combination of 2 or more Enumerations (cartesian product)

[1]: http://www.nunit.org/index.php?p=testCaseSource&r=2.5