### PR TITLE
Provide guidance to the user when the console runner is invoked for a test assembly that does not appear to reference Fixie.dll.

### DIFF
--- a/src/Fixie.Console/CommandLineParser.cs
+++ b/src/Fixie.Console/CommandLineParser.cs
@@ -42,8 +42,12 @@ namespace Fixie.ConsoleRunner
                 errors.Add("Missing required test assembly path(s).");
 
             foreach (var assemblyPath in assemblyPaths)
+            {
                 if (!File.Exists(assemblyPath))
                     errors.Add("Specified test assembly does not exist: " + assemblyPath);
+                else if (!AssemblyDirectoryContainsFixie(assemblyPath))
+                    errors.Add($"Specified assembly {assemblyPath} does not appear to be a test assembly. Ensure that it references Fixie.dll and try again.");
+            }
 
             AssemblyPaths = assemblyPaths.ToArray();
             Options = options;
@@ -90,5 +94,8 @@ namespace Fixie.ConsoleRunner
                 .AppendLine("        test assembly must be specified.")
                 .ToString();
         }
+
+        static bool AssemblyDirectoryContainsFixie(string assemblyPath)
+            => File.Exists(Path.Combine(Path.GetDirectoryName(assemblyPath), "Fixie.dll"));
     }
 }

--- a/src/Fixie.Tests/ConsoleRunner/CommandLineParserTests.cs
+++ b/src/Fixie.Tests/ConsoleRunner/CommandLineParserTests.cs
@@ -42,6 +42,16 @@ namespace Fixie.Tests.ConsoleRunner
             parser.Errors.ShouldEqual("Specified test assembly does not exist: foo.dll", "Specified test assembly does not exist: bar.dll");
         }
 
+        public void DemandsAssemblyDirectoryContainsFixie()
+        {
+            var mscorlib = typeof(string).Assembly.Location;
+            var parser = new CommandLineParser(mscorlib);
+            parser.AssemblyPaths.ShouldEqual(mscorlib);
+            parser.Options.Count.ShouldEqual(0);
+            parser.HasErrors.ShouldBeTrue();
+            parser.Errors.ShouldEqual($"Specified assembly {mscorlib} does not appear to be a test assembly. Ensure that it references Fixie.dll and try again.");
+        }
+
         public void ParsesNUnitXmlOutputFile()
         {
             var parser = new CommandLineParser(assemblyPathA, "--NUnitXml", "TestResult.xml");


### PR DESCRIPTION
When the console runner is invoked for an assembly whose directory does not also contain Fixie.dll, test execution halts with a message explaining that Fixie.dll must be referenced in order for the assembly to be considered a test assembly. Otherwise, the user would be presented with an unhelpful stack trace the first time Fixie.dll was expected to be found there by the child AppDomain.