### PR TITLE
Fix generic case failure scenarios

### DIFF
--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -12,7 +12,7 @@ namespace Fixie.Tests
             @case.Name.ShouldEqual("Fixie.Tests.CaseTests.Returns");
         }
 
-        public void ShouldIncludeParmeterValuesInNameWhenTheUnderlyingMethodHasParameters()
+        public void ShouldIncludeParameterValuesInNameWhenTheUnderlyingMethodHasParameters()
         {
             var @case = Case("Parameterized", 123, true, 'a', "with \"quotes\"", "long \"string\" gets truncated", null, this);
 
@@ -123,6 +123,18 @@ namespace Fixie.Tests
 
             Case("Generic", 123, 1.23m, "a", null)
                 .Name.ShouldEqual("Fixie.Tests.CaseTests.Generic<System.Decimal, System.String>(123, 1.23, \"a\", null)");
+
+            Case("ConstrainedGeneric", 1)
+                .Name.ShouldEqual("Fixie.Tests.CaseTests.ConstrainedGeneric<System.Int32>(1)");
+
+            Case("ConstrainedGeneric", true)
+                .Name.ShouldEqual("Fixie.Tests.CaseTests.ConstrainedGeneric<System.Boolean>(True)");
+        }
+
+        public void ShouldUseGenericTypeParametersInNameWhenGenericTypeParamtersCannotBeResolved()
+        {
+            Case("ConstrainedGeneric", "Incompatable")
+                .Name.ShouldEqual("Fixie.Tests.CaseTests.ConstrainedGeneric<T>(\"Incompatable\")");
         }
 
         public void ShouldHaveMethodGroupComposedOfClassNameAndMethodNameWithNoSignature()
@@ -132,6 +144,9 @@ namespace Fixie.Tests
             Case("Generic", 123, true, "a", "b").MethodGroup.FullName.ShouldEqual("Fixie.Tests.CaseTests.Generic");
             Case("Generic", 123, true, 1, null).MethodGroup.FullName.ShouldEqual("Fixie.Tests.CaseTests.Generic");
             Case("Generic", 123, 1.23m, "a", null).MethodGroup.FullName.ShouldEqual("Fixie.Tests.CaseTests.Generic");
+            Case("ConstrainedGeneric", 1).MethodGroup.FullName.ShouldEqual("Fixie.Tests.CaseTests.ConstrainedGeneric");
+            Case("ConstrainedGeneric", true).MethodGroup.FullName.ShouldEqual("Fixie.Tests.CaseTests.ConstrainedGeneric");
+            Case("ConstrainedGeneric", "Incompatable").MethodGroup.FullName.ShouldEqual("Fixie.Tests.CaseTests.ConstrainedGeneric");
         }
 
         public void ShouldInferAppropriateClassGivenCaseMethod()
@@ -214,6 +229,10 @@ namespace Fixie.Tests
         }
 
         void Generic<T1, T2>(int i, T1 t1, T2 t2a, T2 t2b)
+        {
+        }
+
+        void ConstrainedGeneric<T>(T t) where T : struct
         {
         }
     }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -111,7 +111,7 @@ namespace Fixie.Tests.Cases
                 "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
                 "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.UnconstrainedGeneric<System.Int32>(0) passed",
                 "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.UnconstrainedGeneric<System.Int32>(1) passed",
-                "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.ConstrainedGeneric<> failed: Exception thrown while attempting to yield input parameters for method: ConstrainedGeneric",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.ConstrainedGeneric<T> failed: Exception thrown while attempting to yield input parameters for method: ConstrainedGeneric",
                 "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.UnconstrainedGeneric<System.Object> failed: Exception thrown while attempting to yield input parameters for method: UnconstrainedGeneric");
         }
 
@@ -122,10 +122,10 @@ namespace Fixie.Tests.Cases
             Run<GenericTestClass>();
 
             Listener.Entries.ShouldEqual(
-                "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.ConstrainedGeneric<>(\"Oops\") failed: Could not resolve type parameters for generic test case.",
                 "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.ConstrainedGeneric<T>(\"Oops\") failed: Could not resolve type parameters for generic test case.",
 
-                "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.ConstrainedGenericMethodWithNoInputsProvided<> failed: Could not resolve type parameters for generic test case.",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.ConstrainedGenericMethodWithNoInputsProvided<T> failed: Could not resolve type parameters for generic test case.",
 
                 "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.GenericMethodWithIncorrectParameterCountProvided<System.Object>(123, 123) failed: Parameter count mismatch.",
                 "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.GenericMethodWithNoInputsProvided<System.Object> failed: Parameter count mismatch.",

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -100,6 +100,21 @@ namespace Fixie.Tests.Cases
                 "Fixie.Tests.Cases.ParameterizedCaseTests+ParameterizedTestClass.ZeroArgs failed: Exception thrown while attempting to yield input parameters for method: ZeroArgs");
         }
 
+        public void ShouldFailWithClearExplanationWhenParameterGenerationExceptionPreventsGenericTypeParametersFromBeingResolvable()
+        {
+            Convention.Parameters.Add<BuggyParameterSource>();
+
+            Run<ConstrainedGenericTestClass>();
+
+            Listener.Entries.ShouldEqual(
+                "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(0) passed",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.UnconstrainedGeneric<System.Int32>(0) passed",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.UnconstrainedGeneric<System.Int32>(1) passed",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.ConstrainedGeneric<> failed: Exception thrown while attempting to yield input parameters for method: ConstrainedGeneric",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+ConstrainedGenericTestClass.UnconstrainedGeneric<System.Object> failed: Exception thrown while attempting to yield input parameters for method: UnconstrainedGeneric");
+        }
+
         public void ShouldResolveGenericTypeParameters()
         {
             Convention.Parameters.Add<InputAttributeParameterSource>();
@@ -107,6 +122,11 @@ namespace Fixie.Tests.Cases
             Run<GenericTestClass>();
 
             Listener.Entries.ShouldEqual(
+                "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.ConstrainedGeneric<>(\"Oops\") failed: Could not resolve type parameters for generic test case.",
+                "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
+
+                "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.ConstrainedGenericMethodWithNoInputsProvided<> failed: Could not resolve type parameters for generic test case.",
+
                 "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.GenericMethodWithIncorrectParameterCountProvided<System.Object>(123, 123) failed: Parameter count mismatch.",
                 "Fixie.Tests.Cases.ParameterizedCaseTests+GenericTestClass.GenericMethodWithNoInputsProvided<System.Object> failed: Parameter count mismatch.",
 
@@ -260,9 +280,33 @@ namespace Fixie.Tests.Cases
                 throw new ShouldBeUnreachableException();
             }
 
+            [Input(1)]
+            [Input("Oops")]
+            public void ConstrainedGeneric<T>(T input) where T : struct
+            {
+                typeof(T).IsValueType.ShouldBeTrue();
+            }
+
+            public void ConstrainedGenericMethodWithNoInputsProvided<T>(T input) where T : struct
+            {
+                throw new ShouldBeUnreachableException();
+            }
+
             static string Format(object obj)
             {
                 return obj?.ToString() ?? "[null]";
+            }
+        }
+
+        class ConstrainedGenericTestClass
+        {
+            public void UnconstrainedGeneric<T>(T input)
+            {
+            }
+
+            public void ConstrainedGeneric<T>(T input) where T : struct
+            {
+                typeof(T).IsValueType.ShouldBeTrue();
             }
         }
 

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -19,7 +19,7 @@ namespace Fixie
             Class = caseMethod.ReflectedType;
 
             Method = caseMethod.IsGenericMethodDefinition
-                         ? caseMethod.MakeGenericMethod(GenericArgumentResolver.ResolveTypeArguments(caseMethod, parameters))
+                         ? TryMakeGenericMethod(caseMethod, parameters)
                          : caseMethod;
 
             MethodGroup = new MethodGroup(caseMethod);
@@ -27,6 +27,18 @@ namespace Fixie
             Name = GetName();
 
             exceptions = new List<Exception>();
+        }
+
+        private static MethodInfo TryMakeGenericMethod(MethodInfo caseMethod, object[] parameters)
+        {
+            try
+            {
+                return caseMethod.MakeGenericMethod(GenericArgumentResolver.ResolveTypeArguments(caseMethod, parameters));
+            }
+            catch (Exception e)
+            {
+                return caseMethod;
+            }
         }
 
         string GetName()

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -18,9 +18,7 @@ namespace Fixie
             Parameters = parameters != null && parameters.Length == 0 ? null : parameters;
             Class = caseMethod.ReflectedType;
 
-            Method = caseMethod.IsGenericMethodDefinition
-                         ? TryMakeGenericMethod(caseMethod, parameters)
-                         : caseMethod;
+            Method = TryResolveTypeArguments(caseMethod, parameters);
 
             MethodGroup = new MethodGroup(caseMethod);
 
@@ -29,16 +27,23 @@ namespace Fixie
             exceptions = new List<Exception>();
         }
 
-        private static MethodInfo TryMakeGenericMethod(MethodInfo caseMethod, object[] parameters)
+        private static MethodInfo TryResolveTypeArguments(MethodInfo caseMethod, object[] parameters)
         {
-            try
+            if (caseMethod.IsGenericMethodDefinition)
             {
-                return caseMethod.MakeGenericMethod(GenericArgumentResolver.ResolveTypeArguments(caseMethod, parameters));
+                var typeArguments = GenericArgumentResolver.ResolveTypeArguments(caseMethod, parameters);
+
+                try
+                {
+                    return caseMethod.MakeGenericMethod(typeArguments);
+                }
+                catch (Exception)
+                {
+                    return caseMethod;
+                }
             }
-            catch (Exception e)
-            {
-                return caseMethod;
-            }
+
+            return caseMethod;
         }
 
         string GetName()

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -46,7 +46,7 @@ namespace Fixie
             var name = MethodGroup.FullName;
 
             if (Method.IsGenericMethod)
-                name = $"{name}<{string.Join(", ", Method.GetGenericArguments().Select(x => x.FullName))}>";
+                name = $"{name}<{string.Join(", ", Method.GetGenericArguments().Select(x => x.IsGenericParameter ? x.Name : x.FullName))}>";
 
             if (Parameters != null && Parameters.Length > 0)
                 name = $"{name}({string.Join(", ", Parameters.Select(x => x.ToDisplayString()))})";

--- a/src/Fixie/Internal/Behaviors/InvokeMethod.cs
+++ b/src/Fixie/Internal/Behaviors/InvokeMethod.cs
@@ -21,6 +21,9 @@ namespace Fixie.Internal.Behaviors
                 object returnValue;
                 try
                 {
+                    if (method.IsGenericMethodDefinition)
+                        throw new Exception("Could not resolve type parameters for generic test case.");
+
                     returnValue = method.Invoke(@case.Fixture.Instance, @case.Parameters);
                 }
                 catch (TargetInvocationException exception)

--- a/src/Fixie/Internal/Behaviors/InvokeMethod.cs
+++ b/src/Fixie/Internal/Behaviors/InvokeMethod.cs
@@ -21,7 +21,7 @@ namespace Fixie.Internal.Behaviors
                 object returnValue;
                 try
                 {
-                    if (method.IsGenericMethodDefinition)
+                    if (method.ContainsGenericParameters)
                         throw new Exception("Could not resolve type parameters for generic test case.");
 
                     returnValue = method.Invoke(@case.Fixture.Instance, @case.Parameters);


### PR DESCRIPTION
This pull request fixes exception handling and user-facing messaging in scenarios in which parameterized generic test methods fail to execute.

Previously, when Fixie attempted to resolve the declared generic type parameters against the incoming actual test case parameter values, the attempt could fail due to violation of generic type constraints (`where T: struct`, `where T: new()`, etc). The failure produced an uncaught exception which would kill the process, and had a confusing exception message provided by Method.Invoke(...). With this PR, the exception is handled and the test case simply fails with a clear explanation.