### PR TITLE
Samples.MbUnitStyle added parameter data type converter

### DIFF
--- a/src/Fixie.Samples/MbUnitStyle/CalculatorTests.cs
+++ b/src/Fixie.Samples/MbUnitStyle/CalculatorTests.cs
@@ -31,7 +31,7 @@ namespace Fixie.Samples.MbUnitStyle
 
         [Test]
         [Row(2, 3, 5)]
-        [Row(3, 5, 8)]
+        [Row(3, "5", 8)]
         public void ShouldAdd(int a, int b, int expectedSum)
         {
             log.AppendLine($"ShouldAdd({a}, {b}, {expectedSum})");
@@ -40,7 +40,7 @@ namespace Fixie.Samples.MbUnitStyle
 
         [Test]
         public void ShouldSubtract([Column(7, 8, 9)] int a,
-                                   [Column(5, 6)] int b)
+                                   [Column("5", 6)] int b)
         {
             log.AppendLine($"ShouldSubtract({a}, {b})");
             calculator.Subtract(a, b).ShouldEqual(a - b);

--- a/src/Fixie.Samples/MbUnitStyle/CustomConvention.cs
+++ b/src/Fixie.Samples/MbUnitStyle/CustomConvention.cs
@@ -65,11 +65,16 @@ namespace Fixie.Samples.MbUnitStyle
                 ParameterInfo[] parameterInfos = method.GetParameters();
 
                 if (parameterInfos.Length == 0)
-                    yield break;
+                    return null;
 
                 if (parameterInfos[0].GetCustomAttributes<ColumnAttribute>(true).Any() == false)
-                    yield break;
+                    return null;
 
+                return GetColumnParameters(parameterInfos);
+            }
+
+            private static IEnumerable<object[]> GetColumnParameters(ParameterInfo[] parameterInfos)
+            {
                 foreach (var parameterInfo in parameterInfos)
                 {
                     yield return Array.ConvertAll(parameterInfo.GetCustomAttributes<ColumnAttribute>(true).Single().Parameters,

--- a/src/Fixie.Samples/MbUnitStyle/CustomConvention.cs
+++ b/src/Fixie.Samples/MbUnitStyle/CustomConvention.cs
@@ -35,7 +35,21 @@ namespace Fixie.Samples.MbUnitStyle
         {
             public IEnumerable<object[]> GetParameters(MethodInfo method)
             {
-                return method.GetCustomAttributes<RowAttribute>(true).Select(input => input.Parameters);
+                ParameterInfo[] parameterInfos = method.GetParameters();
+
+                var rowAttributes = method.GetCustomAttributes<RowAttribute>(true);
+
+                foreach (var rowAttribute in rowAttributes)
+                {
+                    object[] parameters = rowAttribute.Parameters;
+
+                    for (int i = 0; i < parameterInfos.Length; i++)
+                    {
+                        parameters[i] = ChangeType(parameters[i], parameterInfos[i].ParameterType);
+                    }
+                
+                    yield return parameters;
+                }
             }
         }
 
@@ -48,17 +62,19 @@ namespace Fixie.Samples.MbUnitStyle
 
             static IEnumerable<object[]> Columns(MethodInfo method)
             {
-                ParameterInfo[] parameters = method.GetParameters();
+                ParameterInfo[] parameterInfos = method.GetParameters();
 
-                if (parameters.Length == 0)
-                    return null;
+                if (parameterInfos.Length == 0)
+                    yield break;
 
-                if (parameters[0].GetCustomAttributes<ColumnAttribute>(true).Any() == false)
-                    return null;
+                if (parameterInfos[0].GetCustomAttributes<ColumnAttribute>(true).Any() == false)
+                    yield break;
 
-                return parameters
-                    .Select(parameter =>
-                        parameter.GetCustomAttributes<ColumnAttribute>(true).Single().Parameters);
+                foreach (var parameterInfo in parameterInfos)
+                {
+                    yield return Array.ConvertAll(parameterInfo.GetCustomAttributes<ColumnAttribute>(true).Single().Parameters,
+                                                  x => ChangeType(x, parameterInfo.ParameterType));
+                }
             }
 
             static IEnumerable<object[]> CartesianProduct(IEnumerable<object[]> sequences)
@@ -77,6 +93,20 @@ namespace Fixie.Samples.MbUnitStyle
                         from item in sequence
                         select accseq.Concat(new[] { item }).ToArray());
             }
+        }
+
+        private static object ChangeType(object parameter, Type type)
+        {
+            if (parameter != null && parameter.GetType() != type)
+            {
+                try
+                {
+                    parameter = Convert.ChangeType(parameter, type);
+                }
+                catch { }
+            }
+
+            return parameter;
         }
     }
 


### PR DESCRIPTION
add parameter data type converter as original MbUnit behave. one of most useful example is to change string value ie "11/22/2016" to DataTime value. so developers are able to define parameters in different/easy ways.  