### PR TITLE
Take Fixture Setup timing in consideration when calculating CaseResult duration

### DIFF
--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Framework.cs" />
     <Compile Include="Internal\Discoverer.cs" />
     <Compile Include="Internal\ParameterDiscoverer.cs" />
+    <Compile Include="Internal\Behaviors\TimeClassExecution.cs" />
     <Compile Include="MethodGroup.cs" />
     <Compile Include="Internal\ExecutionProxy.cs" />
     <Compile Include="Execution\AssemblyInfo.cs" />

--- a/src/Fixie/Internal/Behaviors/TimeClassExecution.cs
+++ b/src/Fixie/Internal/Behaviors/TimeClassExecution.cs
@@ -1,0 +1,30 @@
+namespace Fixie.Internal.Behaviors
+{
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+
+    public class TimeClassExecution : ClassBehavior
+    {
+        public void Execute(Class context, Action next)
+        {
+            var sw = Stopwatch.StartNew();
+            next();
+            sw.Stop();
+            var classExecutionDuration = sw.Elapsed;
+
+            var totalCaseDuration = TimeSpan.FromTicks(context.Cases.Sum(x => x.Duration.Ticks));
+
+            var numberOfCases = context.Cases.Count;
+
+            var buildChainDuration = classExecutionDuration - totalCaseDuration;
+
+            var buildChainDurationPerCase = TimeSpan.FromTicks(buildChainDuration.Ticks/numberOfCases);
+
+            foreach (var @case in context.Cases)
+            {
+                @case.Duration = @case.Duration + buildChainDurationPerCase;
+            }
+        }
+    }
+}

--- a/src/Fixie/Internal/ExecutionPlan.cs
+++ b/src/Fixie/Internal/ExecutionPlan.cs
@@ -3,6 +3,8 @@ using Fixie.Internal.Behaviors;
 
 namespace Fixie.Internal
 {
+    using System.Collections.Generic;
+
     public class ExecutionPlan
     {
         readonly BehaviorChain<Class> classBehaviors;
@@ -29,6 +31,8 @@ namespace Fixie.Internal
                 .ToList();
 
             chain.Add(GetInnermostBehavior(config, fixtureBehaviors));
+
+            chain.Insert(0, new TimeClassExecution());
 
             return new BehaviorChain<Class>(chain);
         }


### PR DESCRIPTION
When capturing the duration of a test case execution, we now take in
consideration the duration to create the instance of the Test Fixture.
That way, if there is expensive work being done in the test class
constructor it is captured in the CaseResult duration.

The impact of the fixture setup duration in the case duration is dependent
on the number of cases that are executed by that Test Fixture instance,
as:

````
TotalCaseDuration = CaseDuration + (FixtureSetupDuration / NumberOfCases)
````