### PR TITLE
Cross Platform Fixie.Execution Assembly

### DIFF
--- a/src/Fixie.Assertions/ReflectionShim.cs
+++ b/src/Fixie.Assertions/ReflectionShim.cs
@@ -11,7 +11,7 @@
         public static bool IsValueType(this Type type)
             => type.IsValueType;
     }
-#elif NETSTANDARD1_3
+#elif NETSTANDARD1_5
     using System;
     using System.Reflection;
 

--- a/src/Fixie.Assertions/project.json
+++ b/src/Fixie.Assertions/project.json
@@ -4,7 +4,7 @@
 
   "frameworks": {
     "net45": {},
-    "netstandard1.3": {
+    "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
         "System.Reflection.TypeExtensions": "4.1.0"

--- a/src/Fixie.Execution/Behaviors/InvokeMethod.cs
+++ b/src/Fixie.Execution/Behaviors/InvokeMethod.cs
@@ -43,7 +43,7 @@
                         throw new PreservedException(exception.InnerExceptions.First());
                     }
 
-                    if (method.ReturnType.IsGenericType)
+                    if (method.ReturnType.IsGenericType())
                     {
                         var property = task.GetType().GetProperty("Result", BindingFlags.Instance | BindingFlags.Public);
 

--- a/src/Fixie.Execution/ClassDiscoverer.cs
+++ b/src/Fixie.Execution/ClassDiscoverer.cs
@@ -41,7 +41,7 @@ namespace Fixie.Execution
             => testClassConditions.All(condition => condition(candidate));
 
         static bool ConcreteClasses(Type type)
-            => type.IsClass && !type.IsAbstract;
+            => type.IsClass() && !type.IsAbstract();
 
         static bool NonDiscoveryClasses(Type type)
             => !type.IsSubclassOf(typeof(Convention));

--- a/src/Fixie.Execution/ConventionDiscoverer.cs
+++ b/src/Fixie.Execution/ConventionDiscoverer.cs
@@ -31,7 +31,7 @@
         {
             return assembly
                 .GetTypes()
-                .Where(t => t.IsSubclassOf(typeof(Convention)) && !t.IsAbstract)
+                .Where(t => t.IsSubclassOf(typeof(Convention)) && !t.IsAbstract())
                 .ToArray();
         }
 

--- a/src/Fixie.Execution/Env.cs
+++ b/src/Fixie.Execution/Env.cs
@@ -26,7 +26,7 @@
         public static string ConfigurationFile
             => AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
     }
-#elif NETSTANDARD1_3
+#elif NETSTANDARD1_5
     using System.Runtime.InteropServices;
 
     static class Env

--- a/src/Fixie.Execution/Env.cs
+++ b/src/Fixie.Execution/Env.cs
@@ -1,0 +1,64 @@
+﻿namespace Fixie.Execution
+{
+#if NET45
+    using System;
+
+    static class Env
+    {
+        public static string Version
+            => Environment.Version.ToString();
+
+        public static string OSVersion
+            => Environment.OSVersion.ToString();
+
+        public static string OSVersionPlatform
+            => Environment.OSVersion.Platform.ToString();
+
+        public static string MachineName
+            => Environment.MachineName;
+
+        public static string UserName
+            => Environment.UserName;
+
+        public static string UserDomainName
+            => Environment.UserDomainName;
+    }
+#elif NETSTANDARD1_3
+    using System.Runtime.InteropServices;
+
+    static class Env
+    {
+        public static string Version
+            => RuntimeInformation.FrameworkDescription;
+
+        public static string OSVersion
+            => RuntimeInformation.OSDescription;
+
+        public static string OSVersionPlatform
+        {
+            get
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    return OSPlatform.Windows.ToString();
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    return OSPlatform.Linux.ToString();
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    return OSPlatform.OSX.ToString();
+
+                return "Unknown Platform";
+            }
+        }
+
+        public static string MachineName
+            => "Unknown MachineName";
+
+        public static string UserName
+            => "Unknown UserName";
+
+        public static string UserDomainName
+            => "UserDomainName";
+    }
+#endif
+}

--- a/src/Fixie.Execution/Env.cs
+++ b/src/Fixie.Execution/Env.cs
@@ -22,6 +22,9 @@
 
         public static string UserDomainName
             => Environment.UserDomainName;
+
+        public static string ConfigurationFile
+            => AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
     }
 #elif NETSTANDARD1_3
     using System.Runtime.InteropServices;
@@ -58,7 +61,10 @@
             => "Unknown UserName";
 
         public static string UserDomainName
-            => "UserDomainName";
+            => "Unknown UserDomainName";
+
+        public static string ConfigurationFile
+            => "Unknown Configuration File";
     }
 #endif
 }

--- a/src/Fixie.Execution/Listeners/AppVeyorListener.cs
+++ b/src/Fixie.Execution/Listeners/AppVeyorListener.cs
@@ -5,8 +5,8 @@
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text;
-    using System.Web.Script.Serialization;
     using Execution;
+    using Newtonsoft.Json;
 
     public class AppVeyorListener :
         Handler<AssemblyStarted>,
@@ -78,7 +78,7 @@
 
         void Post(TestResult result)
         {
-            var content = new JavaScriptSerializer().Serialize(result);
+            var content = JsonConvert.SerializeObject(result);
             client.PostAsync(url, new StringContent(content, Encoding.UTF8, "application/json"))
                   .ContinueWith(x => x.Result.EnsureSuccessStatusCode())
                   .Wait();

--- a/src/Fixie.Execution/Listeners/NUnitXml.cs
+++ b/src/Fixie.Execution/Listeners/NUnitXml.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Globalization;
+    using System.IO;
     using System.Linq;
     using System.Xml.Linq;
     using Execution;
@@ -49,7 +50,7 @@
                 new XAttribute("clr-version", System.Environment.Version.ToString()),
                 new XAttribute("os-version", System.Environment.OSVersion.ToString()),
                 new XAttribute("platform", System.Environment.OSVersion.Platform.ToString()),
-                new XAttribute("cwd", System.Environment.CurrentDirectory),
+                new XAttribute("cwd", Directory.GetCurrentDirectory()),
                 new XAttribute("machine-name", System.Environment.MachineName),
                 new XAttribute("user", System.Environment.UserName),
                 new XAttribute("user-domain", System.Environment.UserDomainName));

--- a/src/Fixie.Execution/Listeners/NUnitXml.cs
+++ b/src/Fixie.Execution/Listeners/NUnitXml.cs
@@ -47,13 +47,13 @@
         {
             return new XElement("environment",
                 new XAttribute("nunit-version", "2.6.4"), //The NUnit version whose XSD we are complying with.
-                new XAttribute("clr-version", System.Environment.Version.ToString()),
-                new XAttribute("os-version", System.Environment.OSVersion.ToString()),
-                new XAttribute("platform", System.Environment.OSVersion.Platform.ToString()),
+                new XAttribute("clr-version", Env.Version),
+                new XAttribute("os-version", Env.OSVersion),
+                new XAttribute("platform", Env.OSVersionPlatform),
                 new XAttribute("cwd", Directory.GetCurrentDirectory()),
-                new XAttribute("machine-name", System.Environment.MachineName),
-                new XAttribute("user", System.Environment.UserName),
-                new XAttribute("user-domain", System.Environment.UserDomainName));
+                new XAttribute("machine-name", Env.MachineName),
+                new XAttribute("user", Env.UserName),
+                new XAttribute("user-domain", Env.UserDomainName));
         }
 
         static XElement Assembly(AssemblyReport assemblyReport)

--- a/src/Fixie.Execution/Listeners/ReportListener.cs
+++ b/src/Fixie.Execution/Listeners/ReportListener.cs
@@ -62,7 +62,10 @@
             var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(assemblyReport.Assembly.Location);
             var formatName = format.Name;
             var filePath = Path.Combine(folder, $"{fileNameWithoutExtension}.{formatName}.xml");
-            xDocument.Save(filePath, SaveOptions.None);
+
+            using (var stream = new FileStream(filePath, FileMode.Create))
+            using (var writer = new StreamWriter(stream))
+                xDocument.Save(writer, SaveOptions.None);
         }
     }
 }

--- a/src/Fixie.Execution/Listeners/XUnitXml.cs
+++ b/src/Fixie.Execution/Listeners/XUnitXml.cs
@@ -20,7 +20,7 @@
                         new XAttribute("name", assemblyReport.Assembly.Location),
                         new XAttribute("run-date", now.ToString("yyyy-MM-dd")),
                         new XAttribute("run-time", now.ToString("HH:mm:ss")),
-                        new XAttribute("configFile", AppDomain.CurrentDomain.SetupInformation.ConfigurationFile),
+                        new XAttribute("configFile", Env.ConfigurationFile),
                         new XAttribute("time", Seconds(assemblyReport.Duration)),
                         new XAttribute("total", assemblyReport.Total),
                         new XAttribute("passed", assemblyReport.Passed),

--- a/src/Fixie.Execution/Listeners/XUnitXml.cs
+++ b/src/Fixie.Execution/Listeners/XUnitXml.cs
@@ -26,7 +26,7 @@
                         new XAttribute("passed", assemblyReport.Passed),
                         new XAttribute("failed", assemblyReport.Failed),
                         new XAttribute("skipped", assemblyReport.Skipped),
-                        new XAttribute("environment", $"{IntPtr.Size*8}-bit .NET {Environment.Version}"),
+                        new XAttribute("environment", $"{IntPtr.Size*8}-bit .NET {Env.Version}"),
                         new XAttribute("test-framework", Framework.Version),
                         assemblyReport.Classes.Select(Class))));
         }

--- a/src/Fixie.Execution/ReflectionShim.cs
+++ b/src/Fixie.Execution/ReflectionShim.cs
@@ -1,0 +1,36 @@
+﻿namespace Fixie.Execution
+{
+#if NET45
+    using System;
+
+    static class ReflectionShim
+    {
+        public static bool IsClass(this Type type)
+            => type.IsClass;
+
+        public static bool IsAbstract(this Type type)
+            => type.IsAbstract;
+
+        public static bool IsGenericType(this Type type)
+            => type.IsGenericType;
+    }
+#elif NETSTANDARD1_3
+    using System;
+    using System.Reflection;
+
+    static class ReflectionShim
+    {
+        public static bool IsClass(this Type type)
+            => type.GetTypeInfo().IsClass;
+
+        public static bool IsAbstract(this Type type)
+            => type.GetTypeInfo().IsAbstract;
+
+        public static bool IsGenericType(this Type type)
+            => type.GetTypeInfo().IsGenericType;
+
+        public static bool IsSubclassOf(this Type type, Type c)
+            => type.GetTypeInfo().IsSubclassOf(c);
+    }
+#endif
+}

--- a/src/Fixie.Execution/ReflectionShim.cs
+++ b/src/Fixie.Execution/ReflectionShim.cs
@@ -14,7 +14,7 @@
         public static bool IsGenericType(this Type type)
             => type.IsGenericType;
     }
-#elif NETSTANDARD1_3
+#elif NETSTANDARD1_5
     using System;
     using System.Reflection;
 

--- a/src/Fixie.Execution/project.json
+++ b/src/Fixie.Execution/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "Fixie": { "target": "project" }
+    "Fixie": { "target": "project" },
+    "Newtonsoft.Json": "9.0.1"
   },
 
   "frameworks": {
@@ -8,8 +9,7 @@
       "frameworkAssemblies": {
         "System.Xml": "4.0.0.0",
         "System.Xml.Linq": "4.0.0.0",
-        "System.Net.Http": "4.0.0.0",
-        "System.Web.Extensions": "4.0.0.0"
+        "System.Net.Http": "4.0.0.0"
       }
     }
   }

--- a/src/Fixie.Execution/project.json
+++ b/src/Fixie.Execution/project.json
@@ -11,6 +11,11 @@
         "System.Xml.Linq": "4.0.0.0",
         "System.Net.Http": "4.0.0.0"
       }
+    },
+    "netstandard1.5": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0"
+      }
     }
   }
 }

--- a/src/Fixie.Samples/Skipped/CustomConvention.cs
+++ b/src/Fixie.Samples/Skipped/CustomConvention.cs
@@ -30,7 +30,7 @@
 
             var isMarkedExplicit = method.DeclaringType.Has<ExplicitAttribute>();
 
-            return isMarkedExplicit && TargetMember != method.DeclaringType && TargetMember != method;
+            return isMarkedExplicit && !IsTarget(method.DeclaringType) && !IsTarget(method);
         }
 
         bool SkipDueToMethodLevelExplicitAttribute(Case @case)
@@ -39,7 +39,7 @@
 
             var isMarkedExplicit = method.Has<ExplicitAttribute>();
 
-            return isMarkedExplicit && TargetMember != method;
+            return isMarkedExplicit && !IsTarget(method);
         }
 
         static bool SkipDueToClassLevelSkipAttribute(Case @case)

--- a/src/Fixie.Tests/Execution/Listeners/AppVeyorListenerTests.cs
+++ b/src/Fixie.Tests/Execution/Listeners/AppVeyorListenerTests.cs
@@ -7,7 +7,7 @@
     using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Web.Script.Serialization;
+    using Newtonsoft.Json;
     using Assertions;
     using Fixie.Execution;
     using Fixie.Execution.Listeners;
@@ -104,8 +104,8 @@
                 request.Headers.Accept.ShouldContain(new MediaTypeWithQualityHeaderValue("application/json"));
                 request.Content.Headers.ContentType.ToString().ShouldEqual("application/json; charset=utf-8");
 
-                var requestContent1 = request.Content.ReadAsStringAsync().Result;
-                results.Add(new JavaScriptSerializer().Deserialize<AppVeyorListener.TestResult>(requestContent1));
+                var requestContent = request.Content.ReadAsStringAsync().Result;
+                results.Add(JsonConvert.DeserializeObject<AppVeyorListener.TestResult>(requestContent));
 
                 return new HttpResponseMessage { StatusCode = HttpStatusCode.Accepted };
             }));

--- a/src/Fixie/Convention.cs
+++ b/src/Fixie/Convention.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie
 {
+    using System;
     using System.Reflection;
     using Cli;
     using Conventions;
@@ -37,10 +38,18 @@
             => CommandLine.Parse<TModel>(RunContext.ConventionArguments);
 
         /// <summary>
-        /// Gets the target Type or MethodInfo identified by the test runner as the sole item
-        /// to be executed. Null under normal test execution.
+        /// Determines whether the given Type was selected as the sole
+        /// item to be executed. False under normal test execution.
         /// </summary>
-        public MemberInfo TargetMember => RunContext.TargetMember;
+        public static bool IsTarget(Type type)
+            => RunContext.TargetType == type;
+
+        /// <summary>
+        /// Determines whether the given MethodInfo was selected as the sole
+        /// item to be executed. False under normal test execution.
+        /// </summary>
+        public static bool IsTarget(MethodInfo method)
+            => RunContext.TargetMethod == method;
 
         /// <summary>
         /// Defines the set of conditions that describe which classes are test classes.

--- a/src/Fixie/Internal/RunContext.cs
+++ b/src/Fixie/Internal/RunContext.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.Internal
 {
+    using System;
     using System.Reflection;
 
     /// <summary>
@@ -9,13 +10,23 @@
     {
         public static void Set(string[] conventionArguments)
         {
-            Set(conventionArguments, null);
+            ConventionArguments = conventionArguments;
+            TargetType = null;
+            TargetMethod = null;
         }
 
-        public static void Set(string[] conventionArguments, MemberInfo targetMember)
+        public static void Set(string[] conventionArguments, Type targetType)
         {
             ConventionArguments = conventionArguments;
-            TargetMember = targetMember;
+            TargetType = targetType;
+            TargetMethod = null;
+        }
+
+        public static void Set(string[] conventionArguments, MethodInfo targetMethod)
+        {
+            ConventionArguments = conventionArguments;
+            TargetType = null;
+            TargetMethod = targetMethod;
         }
 
         /// <summary>
@@ -24,10 +35,15 @@
         public static string[] ConventionArguments { get; private set; }
 
         /// <summary>
-        /// Gets the target Type or MethodInfo identified by
-        /// the test runner as the sole item to be executed.
-        /// Null under normal test execution.
+        /// Gets the target Type identified by the test runner as the
+        /// sole item to be executed. Null under normal test execution.
         /// </summary>
-        public static MemberInfo TargetMember { get; private set; }
+        public static Type TargetType { get; private set; }
+
+        /// <summary>
+        /// Gets the target MethodInfo identified by the test runner as the
+        /// sole item to be executed. Null under normal test execution.
+        /// </summary>
+        public static MethodInfo TargetMethod { get; private set; }
     }
 }


### PR DESCRIPTION
This PR makes the Fixie.Execution project target both the regular .NET Framework and netstandard1.5. Because this assembly is only used internally by Fixie at runtime, and does not need to be directly referenced by end users, we're able to target a higher netstandard than Fixie.dll itself does. Doing so saves us from having to reinvent Assembly.Location.