### PR TITLE
Cross-compilable sln

### DIFF
--- a/src/Fixie.Runner/ExecutionEnvironment.cs
+++ b/src/Fixie.Runner/ExecutionEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.Runner
 {
+#if NET45
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -73,4 +74,37 @@
             return File.Exists(configFullPath) ? configFullPath : null;
         }
     }
+#else
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    public class ExecutionEnvironment : IDisposable
+    {
+        readonly string assemblyFullPath;
+        readonly string previousWorkingDirectory;
+        readonly ExecutionProxy executionProxy;
+
+        public ExecutionEnvironment(string assemblyPath)
+        {
+            assemblyFullPath = Path.GetFullPath(assemblyPath);
+
+            previousWorkingDirectory = Directory.GetCurrentDirectory();
+            var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath);
+            Directory.SetCurrentDirectory(assemblyDirectory);
+
+            executionProxy = new ExecutionProxy();
+        }
+
+        public int Run(IReadOnlyList<string> runnerArguments, IReadOnlyList<string> conventionArguments)
+        {
+            return executionProxy.Run(assemblyFullPath, runnerArguments, conventionArguments);
+        }
+
+        public void Dispose()
+        {
+            Directory.SetCurrentDirectory(previousWorkingDirectory);
+        }
+    }
+#endif
 }

--- a/src/Fixie.Runner/ExecutionProxy.cs
+++ b/src/Fixie.Runner/ExecutionProxy.cs
@@ -4,13 +4,21 @@
     using System.Reflection;
     using Cli;
 
-    public class ExecutionProxy : LongLivedMarshalByRefObject
+    public class ExecutionProxy
+#if NET45
+        : LongLivedMarshalByRefObject
+#endif
     {
         public int Run(string assemblyFullPath, IReadOnlyList<string> runnerArguments, IReadOnlyList<string> conventionArguments)
         {
             var options = CommandLine.Parse<Options>(runnerArguments);
 
-            var assembly = Assembly.Load(AssemblyName.GetAssemblyName(assemblyFullPath));
+            Assembly assembly =
+#if NET45
+                Assembly.Load(AssemblyName.GetAssemblyName(assemblyFullPath));
+#else
+                null;
+#endif
 
             return Runner(options).Run(assemblyFullPath, assembly, options, conventionArguments);
         }

--- a/src/Fixie.Runner/LongLivedMarshalByRefObject.cs
+++ b/src/Fixie.Runner/LongLivedMarshalByRefObject.cs
@@ -1,4 +1,5 @@
-﻿namespace Fixie.Runner
+﻿#if NET45
+namespace Fixie.Runner
 {
     using System;
     using System.Runtime.Remoting;
@@ -44,3 +45,4 @@
         }
     }
 }
+#endif

--- a/src/Fixie.Runner/RemoteAssemblyResolver.cs
+++ b/src/Fixie.Runner/RemoteAssemblyResolver.cs
@@ -1,3 +1,4 @@
+#if NET45
 namespace Fixie.Runner
 {
     using System;
@@ -56,3 +57,4 @@ namespace Fixie.Runner
         }
     }
 }
+#endif

--- a/src/Fixie.Runner/RunnerBase.cs
+++ b/src/Fixie.Runner/RunnerBase.cs
@@ -11,9 +11,11 @@ namespace Fixie.Runner
 
         protected static void DiscoverMethods(Assembly assembly, IReadOnlyList<string> conventionArguments, IReadOnlyList<Listener> listeners)
         {
+#if NET45
             var bus = new Bus(listeners);
 
             Discoverer(bus, conventionArguments).DiscoverMethods(assembly);
+#endif
         }
 
         protected static void RunAssembly(Assembly assembly, IReadOnlyList<string> conventionArguments, IReadOnlyList<Listener> listeners)

--- a/src/Fixie.Runner/RunnerBase.cs
+++ b/src/Fixie.Runner/RunnerBase.cs
@@ -11,11 +11,9 @@ namespace Fixie.Runner
 
         protected static void DiscoverMethods(Assembly assembly, IReadOnlyList<string> conventionArguments, IReadOnlyList<Listener> listeners)
         {
-#if NET45
             var bus = new Bus(listeners);
 
             Discoverer(bus, conventionArguments).DiscoverMethods(assembly);
-#endif
         }
 
         protected static void RunAssembly(Assembly assembly, IReadOnlyList<string> conventionArguments, IReadOnlyList<Listener> listeners)

--- a/src/Fixie.Runner/SourceLocationProvider.cs
+++ b/src/Fixie.Runner/SourceLocationProvider.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.Runner
 {
+#if NET45
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.CompilerServices;
@@ -105,4 +106,20 @@
             return className.Replace("+", "/");
         }
     }
+#else
+    // SourceLocationProvider cannot be implemented for netstandard until
+    // after upgrading the Mono.Cecil dependencies.
+    public class SourceLocationProvider
+    {
+        public SourceLocationProvider(string assemblyPath)
+        {
+        }
+
+        public bool TryGetSourceLocation(MethodGroup methodGroup, out SourceLocation sourceLocation)
+        {
+            sourceLocation = null;
+            return false;
+        }
+    }
+#endif
 }

--- a/src/Fixie.Runner/project.json
+++ b/src/Fixie.Runner/project.json
@@ -15,6 +15,14 @@
       "dependencies": {
         "Mono.Cecil": "0.9.6.4"
       }
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      }
     }
   }
 }

--- a/src/Fixie.Runner/project.json
+++ b/src/Fixie.Runner/project.json
@@ -7,11 +7,14 @@
   "dependencies": {
     "Fixie": { "target": "project" },
     "Fixie.Execution": { "target": "project" },
-    "Mono.Cecil": "0.9.6.4",
     "Newtonsoft.Json": "9.0.1"
   },
 
   "frameworks": {
-    "net45": { }
+    "net45": {
+      "dependencies": {
+        "Mono.Cecil": "0.9.6.4"
+      }
+    }
   }
 }

--- a/src/Fixie.Tests/Execution/CompoundExceptionTests.cs
+++ b/src/Fixie.Tests/Execution/CompoundExceptionTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Fixie.Tests.Execution
 {
     using System;
+    using System.IO;
     using Assertions;
     using Fixie.Execution;
     using static Utility;
@@ -67,8 +68,8 @@
                     "Secondary Exception!",
                     At<CompoundExceptionTests>("GetSecondaryException()"),
                     "",
-                    "------- Inner Exception: System.ApplicationException -------",
-                    "Application Exception!",
+                    "------- Inner Exception: System.IO.IOException -------",
+                    "IO Exception!",
                     At<CompoundExceptionTests>("GetSecondaryException()"),
                     "",
                     "------- Inner Exception: System.NotImplementedException -------",
@@ -112,8 +113,8 @@
                     "Secondary Exception!",
                     "",
                     "",
-                    "------- Inner Exception: System.ApplicationException -------",
-                    "Application Exception!",
+                    "------- Inner Exception: System.IO.IOException -------",
+                    "IO Exception!",
                     "",
                     "",
                     "------- Inner Exception: System.NotImplementedException -------",
@@ -156,7 +157,7 @@
                     }
                     catch (Exception exception)
                     {
-                        throw new ApplicationException("Application Exception!", exception);
+                        throw new IOException("IO Exception!", exception);
                     }
                 }
                 catch (Exception exception)

--- a/src/Fixie.Tests/Execution/ExecutionEnvironmentTests.cs
+++ b/src/Fixie.Tests/Execution/ExecutionEnvironmentTests.cs
@@ -1,3 +1,4 @@
+#if NET45
 namespace Fixie.Tests.Execution
 {
     using System;
@@ -43,3 +44,4 @@ namespace Fixie.Tests.Execution
         }
     }
 }
+#endif

--- a/src/Fixie.Tests/Execution/Listeners/NUnitXmlTests.cs
+++ b/src/Fixie.Tests/Execution/Listeners/NUnitXmlTests.cs
@@ -37,6 +37,7 @@
 
         static void XsdValidate(XDocument doc)
         {
+#if NET45
             var schemaSet = new XmlSchemaSet();
             using (var xmlReader = XmlReader.Create(Path.Combine("Execution", Path.Combine("Listeners", "NUnitXmlReport.xsd"))))
             {
@@ -44,6 +45,7 @@
             }
 
             doc.Validate(schemaSet, null);
+#endif
         }
 
         static string CleanBrittleValues(string actualRawContent)

--- a/src/Fixie.Tests/Execution/Listeners/XUnitXmlTests.cs
+++ b/src/Fixie.Tests/Execution/Listeners/XUnitXmlTests.cs
@@ -77,7 +77,12 @@
             get
             {
                 var assemblyLocation = GetType().Assembly().Location;
-                var configLocation = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+                var configLocation =
+#if NET45
+                    AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+#else
+                    "Unknown Configuration File";
+#endif
                 var fileLocation = TestClassPath();
                 return XDocument.Parse(File.ReadAllText(Path.Combine("Execution", Path.Combine("Listeners", "XUnitXmlReport.xml"))))
                                 .ToString(SaveOptions.DisableFormatting)

--- a/src/Fixie.Tests/Execution/Listeners/XUnitXmlTests.cs
+++ b/src/Fixie.Tests/Execution/Listeners/XUnitXmlTests.cs
@@ -38,6 +38,7 @@
 
         static void XsdValidate(XDocument doc)
         {
+#if NET45
             var schemaSet = new XmlSchemaSet();
             using (var xmlReader = XmlReader.Create(Path.Combine("Execution", Path.Combine("Listeners", "XUnitXmlReport.xsd"))))
             {
@@ -45,6 +46,7 @@
             }
 
             doc.Validate(schemaSet, null);
+#endif
         }
 
         static string CleanBrittleValues(string actualRawContent)

--- a/src/Fixie.Tests/ReflectionShim.cs
+++ b/src/Fixie.Tests/ReflectionShim.cs
@@ -17,6 +17,7 @@
     }
 #else
     using System;
+    using System.Collections.Generic;
     using System.Reflection;
 
     static class ReflectionShim
@@ -29,6 +30,12 @@
 
         public static bool IsNestedPrivate(this Type type)
             => type.GetTypeInfo().IsNestedPrivate;
+
+        public static T GetCustomAttribute<T>(this Type type, bool inherit) where T : Attribute
+            => type.GetTypeInfo().GetCustomAttribute<T>(inherit);
+
+        public static PropertyInfo[] GetProperties(this Type type)
+            => type.GetTypeInfo().GetProperties();
     }
 #endif
 }

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -2,10 +2,10 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Reflection;
     using System.Text.RegularExpressions;
-    using System.Threading;
     using Fixie.Execution;
 
     public static class TestExtensions
@@ -48,7 +48,7 @@
         {
             //Avoid brittle assertion introduced by test duration.
 
-            var decimalSeparator = Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+            var decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
             return Regex.Replace(output, @"took [\d" + Regex.Escape(decimalSeparator) + @"]+ seconds", @"took 1.23 seconds");
         }


### PR DESCRIPTION
This PR does not enable cross-platform support for .NET Core testing.

The Fixie.Samples and Fixie.Tests projects still target only the full .NET Framework. Attempts to target netcoreapp1.0 in those projects *does* compile with this PR, though. At runtime, `dotnet test` fails to actually locate `dotnet-test-fixie`, though, so targeting netcoreapp1.0 in those projects is temporarily omitted. Other runtime gaps exist after that problem gets resolved as well, such as ExecutionProxy's need to load assemblies reliably without an AppDomain. Still, this PR represents the *ability* to compile all of the projects against both net45 and netcoreapp/netstandard.