### PR TITLE
Self-testing projects consume the solution's own NuGet packages

### DIFF
--- a/build-helpers.ps1
+++ b/build-helpers.ps1
@@ -1,0 +1,70 @@
+function delete-folder($path) {
+    if (test-path $path) { write-host "Removing $path" }
+    rd $path -recurse -force -ErrorAction SilentlyContinue | out-null
+}
+
+function regenerate-file($path, $newContent) {
+    $oldContent = [IO.File]::ReadAllText($path)
+
+    if ($newContent -ne $oldContent) {
+        $relativePath = Resolve-Path -Relative $path
+        write-host "Generating $relativePath"
+        [System.IO.File]::WriteAllText($path, $newContent, [System.Text.Encoding]::UTF8)
+    }
+}
+
+function get-copyright($birthYear, $maintainers) {
+    $date = Get-Date
+    $year = $date.Year
+    $copyrightSpan = if ($year -eq $birthYear) { $year } else { "$birthYear-$year" }
+    return "Copyright © $copyrightSpan $maintainers"
+}
+
+function license {
+    $copyright = get-copyright $birthYear $maintainers
+
+    regenerate-file "LICENSE.txt" @"
+The MIT License (MIT)
+$copyright
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"@
+}
+
+function exec($cmd) {
+    $global:lastexitcode = 0
+    & $cmd
+    if ($lastexitcode -ne 0) {
+        throw "Error executing command:$cmd"
+    }
+}
+
+function step($block) {
+    $command = $block.ToString().Trim()
+    heading $command
+    &$block
+}
+
+function heading($title) {
+    write-host
+    write-host "$title" -fore CYAN
+}
+
+function run-build($mainBlock) {
+    try {
+        &$mainBlock
+        write-host
+        write-host "Build Succeeded!" -fore GREEN
+        exit 0
+    } catch [Exception] {
+        write-host
+        write-host $_.Exception.Message -fore DARKRED
+        write-host
+        write-host "Build Failed!" -fore DARKRED
+        exit 1
+    }
+}

--- a/build.ps1
+++ b/build.ps1
@@ -51,6 +51,7 @@ run-build {
     step { clean }
     step { license }
 
+
     step { dotnet-restore Fixie }
     step { dotnet-restore Fixie.Execution }
     step { dotnet-restore Fixie.Runner }
@@ -59,15 +60,18 @@ run-build {
     step { dotnet-pack Fixie.Execution }
     step { dotnet-pack Fixie.Runner }
 
+
     step { dotnet-restore Fixie.TestDriven }
     step { dotnet-restore Fixie.Assertions }
 
-    $artifacts = resolve-path .\artifacts
-    step { dotnet-restore Fixie.Tests }
-    step { dotnet-restore Fixie.Samples $artifacts }
-
     step { dotnet-build Fixie.TestDriven }
     step { dotnet-build Fixie.Assertions }
+
+
+    $artifacts = resolve-path .\artifacts
+    step { dotnet-restore Fixie.Tests $artifacts }
+    step { dotnet-restore Fixie.Samples $artifacts }
+
     step { dotnet-test Fixie.Tests }
     step { dotnet-test Fixie.Samples }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-param([string]$target, [int]$buildNumber=0)
+param([int]$buildNumber=0)
 
 $birthYear = 2013
 $maintainers = "Patrick Lioi"
@@ -12,10 +12,7 @@ function main {
     step { License }
     step { Build }
     step { Test }
-
-    if ($target -eq "package") {
-        step { Package }
-    }
+    step { Package }
 }
 
 function Clean {

--- a/build.ps1
+++ b/build.ps1
@@ -1,118 +1,48 @@
 param([int]$buildNumber=0)
 
+. .\build-helpers
+
 $birthYear = 2013
 $maintainers = "Patrick Lioi"
 $configuration = 'Release'
 
 $revision = "{0:D4}" -f [convert]::ToInt32($buildNumber, 10)
 
-function main {
-    clean
-    license
-
-    dotnet-restore
-
-    dotnet-pack Fixie
-    dotnet-pack Fixie.Execution
-    dotnet-pack Fixie.Runner
-
-    dotnet-build Fixie.TestDriven
-    dotnet-build Fixie.Assertions
-
-    dotnet-test Fixie.Tests
-    dotnet-test Fixie.Samples
-}
-
 function clean {
-    heading "clean"
-    rd .\artifacts -recurse -force -ErrorAction SilentlyContinue | out-null
-
-    foreach ($folder in @(gci .\src -rec -filter bin)) {
-       write-host "Removing $($folder.FullName)"
-       rd $folder.FullName -recurse -force -ErrorAction SilentlyContinue | out-null
-    }
-
-    foreach ($folder in @(gci .\src -rec -filter obj)) {
-       write-host "Removing $($folder.FullName)"
-       rd $folder.FullName -recurse -force -ErrorAction SilentlyContinue | out-null
-    }
+    delete-folder .\artifacts
+    @(gci .\src -rec -filter bin) | % { delete-folder $_.FullName }
+    @(gci .\src -rec -filter obj) | % { delete-folder $_.FullName }
 }
 
 function dotnet-restore {
-    heading "dotnet restore"
     exec { & dotnet restore --verbosity Warning }
 }
 
-function dotnet-test($project) {
-    heading "dotnet test $project"
-    exec { & dotnet test .\src\$project --configuration $configuration }
-}
-
-function dotnet-build($project) {
-    heading "dotnet build $project"
-    exec { & dotnet build .\src\$project --configuration $configuration --version-suffix $revision }
-}
-
 function dotnet-pack($project) {
-    heading "dotnet pack $project"
     exec { & dotnet pack .\src\$project --output .\artifacts --configuration $configuration --version-suffix $revision }
 }
 
-function license {
-    heading "license"
-    $copyright = get-copyright
-
-    regenerate-file "LICENSE.txt" @"
-The MIT License (MIT)
-$copyright
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-"@
+function dotnet-build($project) {
+    exec { & dotnet build .\src\$project --configuration $configuration --version-suffix $revision }
 }
 
-function get-copyright {
-    $date = Get-Date
-    $year = $date.Year
-    $copyrightSpan = if ($year -eq $birthYear) { $year } else { "$birthYear-$year" }
-    return "Copyright © $copyrightSpan $maintainers"
+function dotnet-test($project) {
+    exec { & dotnet test .\src\$project --configuration $configuration }
 }
 
-function regenerate-file($path, $newContent) {
-    $oldContent = [IO.File]::ReadAllText($path)
+run-build {
+    step { clean }
+    step { license }
 
-    if ($newContent -ne $oldContent) {
-        $relativePath = Resolve-Path -Relative $path
-        write-host "Generating $relativePath"
-        [System.IO.File]::WriteAllText($path, $newContent, [System.Text.Encoding]::UTF8)
-    }
-}
+    step { dotnet-restore }
 
-function exec($cmd) {
-    $global:lastexitcode = 0
-    & $cmd
-    if ($lastexitcode -ne 0) {
-        throw "Error executing command:$cmd"
-    }
-}
+    step { dotnet-pack Fixie }
+    step { dotnet-pack Fixie.Execution }
+    step { dotnet-pack Fixie.Runner }
 
-function heading($text) {
-    write-host $text -fore CYAN
-    write-host
-}
+    step { dotnet-build Fixie.TestDriven }
+    step { dotnet-build Fixie.Assertions }
 
-try {
-    main
-    write-host
-    write-host "Build Succeeded!" -fore GREEN
-    exit 0
-} catch [Exception] {
-    write-host
-    write-host $_.Exception.Message -fore DARKRED
-    write-host
-    write-host "Build Failed!" -fore DARKRED
-    exit 1
+    step { dotnet-test Fixie.Tests }
+    step { dotnet-test Fixie.Samples }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,6 @@ $revision = "{0:D4}" -f [convert]::ToInt32($buildNumber, 10)
 
 function main {
     step { Clean }
-    step { Restore }
     step { License }
     step { Build }
 }
@@ -27,11 +26,9 @@ function Clean {
     }
 }
 
-function Restore {
-    exec { & dotnet restore --verbosity Warning }
-}
-
 function Build {
+    dotnet-restore
+
     dotnet-pack Fixie
     dotnet-pack Fixie.Execution
     dotnet-pack Fixie.Runner
@@ -41,6 +38,10 @@ function Build {
 
     dotnet-test Fixie.Tests
     dotnet-test Fixie.Samples
+}
+
+function dotnet-restore {
+    exec { & dotnet restore --verbosity Warning }
 }
 
 function dotnet-test($project) {

--- a/build.ps1
+++ b/build.ps1
@@ -23,8 +23,13 @@ function clean {
     @(gci .\src -rec -filter obj) | % { delete-folder $_.FullName }
 }
 
-function dotnet-restore($project) {
-    exec { & dotnet restore .\src\$project --verbosity Verbose }
+function dotnet-restore($project, $localSource) {
+    $remoteSource = "https://api.nuget.org/v3/index.json"
+    if ($localSource) {
+        exec { & dotnet restore .\src\$project --verbosity Verbose --source $localSource --source $remoteSource }
+    } else {
+        exec { & dotnet restore .\src\$project --verbosity Verbose --source $remoteSource }
+    }
 }
 
 function dotnet-pack($project) {
@@ -61,8 +66,10 @@ run-build {
 
     step { dotnet-restore Fixie.TestDriven }
     step { dotnet-restore Fixie.Assertions }
+
+    $artifacts = resolve-path .\artifacts
     step { dotnet-restore Fixie.Tests }
-    step { dotnet-restore Fixie.Samples }
+    step { dotnet-restore Fixie.Samples $artifacts }
 
     step { dotnet-build Fixie.TestDriven }
     step { dotnet-build Fixie.Assertions }

--- a/build.ps1
+++ b/build.ps1
@@ -12,7 +12,6 @@ function main {
     step { License }
     step { Build }
     step { Test }
-    step { Package }
 }
 
 function Clean {
@@ -33,19 +32,24 @@ function Restore {
     exec { & dotnet restore --verbosity Warning }
 }
 
-function Package {
-    exec { & dotnet pack .\src\Fixie --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
-    exec { & dotnet pack .\src\Fixie.Execution --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
-    exec { & dotnet pack .\src\Fixie.Runner --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
-}
-
 function Test {
     exec { & dotnet test .\src\Fixie.Tests --configuration $configuration }
     exec { & dotnet test .\src\Fixie.Samples --configuration $configuration }
 }
 
 function Build {
-    exec { & dotnet build **\project.json --configuration $configuration --version-suffix $revision }
+    exec { & dotnet build src\Fixie\project.json --configuration $configuration --version-suffix $revision }
+    exec { & dotnet build src\Fixie.Execution\project.json --configuration $configuration --version-suffix $revision }
+    exec { & dotnet build src\Fixie.Runner\project.json --configuration $configuration --version-suffix $revision }
+
+    exec { & dotnet pack .\src\Fixie --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
+    exec { & dotnet pack .\src\Fixie.Execution --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
+    exec { & dotnet pack .\src\Fixie.Runner --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
+
+    exec { & dotnet build src\Fixie.TestDriven\project.json --configuration $configuration --version-suffix $revision }
+    exec { & dotnet build src\Fixie.Assertions\project.json --configuration $configuration --version-suffix $revision }
+    exec { & dotnet build src\Fixie.Samples\project.json --configuration $configuration --version-suffix $revision }
+    exec { & dotnet build src\Fixie.Tests\project.json --configuration $configuration --version-suffix $revision }
 }
 
 function License {

--- a/build.ps1
+++ b/build.ps1
@@ -23,8 +23,8 @@ function clean {
     @(gci .\src -rec -filter obj) | % { delete-folder $_.FullName }
 }
 
-function dotnet-restore {
-    exec { & dotnet restore --verbosity Warning }
+function dotnet-restore($project) {
+    exec { & dotnet restore .\src\$project --verbosity Verbose }
 }
 
 function dotnet-pack($project) {
@@ -51,15 +51,21 @@ run-build {
     step { clean }
     step { license }
 
-    step { dotnet-restore }
+    step { dotnet-restore Fixie }
+    step { dotnet-restore Fixie.Execution }
+    step { dotnet-restore Fixie.Runner }
 
     step { dotnet-pack Fixie }
     step { dotnet-pack Fixie.Execution }
     step { dotnet-pack Fixie.Runner }
 
+    step { dotnet-restore Fixie.TestDriven }
+    step { dotnet-restore Fixie.Assertions }
+    step { dotnet-restore Fixie.Tests }
+    step { dotnet-restore Fixie.Samples }
+
     step { dotnet-build Fixie.TestDriven }
     step { dotnet-build Fixie.Assertions }
-
     step { dotnet-test Fixie.Tests }
     step { dotnet-test Fixie.Samples }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -33,23 +33,35 @@ function Restore {
 }
 
 function Test {
-    exec { & dotnet test .\src\Fixie.Tests --configuration $configuration }
-    exec { & dotnet test .\src\Fixie.Samples --configuration $configuration }
+    dotnet-test Fixie.Tests
+    dotnet-test Fixie.Samples
 }
 
 function Build {
-    exec { & dotnet build src\Fixie\project.json --configuration $configuration --version-suffix $revision }
-    exec { & dotnet build src\Fixie.Execution\project.json --configuration $configuration --version-suffix $revision }
-    exec { & dotnet build src\Fixie.Runner\project.json --configuration $configuration --version-suffix $revision }
+    dotnet-build Fixie
+    dotnet-build Fixie.Execution
+    dotnet-build Fixie.Runner
 
-    exec { & dotnet pack .\src\Fixie --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
-    exec { & dotnet pack .\src\Fixie.Execution --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
-    exec { & dotnet pack .\src\Fixie.Runner --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
+    dotnet-pack Fixie
+    dotnet-pack Fixie.Execution
+    dotnet-pack Fixie.Runner
 
-    exec { & dotnet build src\Fixie.TestDriven\project.json --configuration $configuration --version-suffix $revision }
-    exec { & dotnet build src\Fixie.Assertions\project.json --configuration $configuration --version-suffix $revision }
-    exec { & dotnet build src\Fixie.Samples\project.json --configuration $configuration --version-suffix $revision }
-    exec { & dotnet build src\Fixie.Tests\project.json --configuration $configuration --version-suffix $revision }
+    dotnet-build Fixie.TestDriven
+    dotnet-build Fixie.Assertions
+    dotnet-build Fixie.Samples
+    dotnet-build Fixie.Tests
+}
+
+function dotnet-test($project) {
+    exec { & dotnet test .\src\$project --configuration $configuration }
+}
+
+function dotnet-build($project) {
+    exec { & dotnet build .\src\$project --configuration $configuration --version-suffix $revision }
+}
+
+function dotnet-pack($project) {
+    exec { & dotnet pack .\src\$project --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
 }
 
 function License {

--- a/build.ps1
+++ b/build.ps1
@@ -23,13 +23,8 @@ function clean {
     @(gci .\src -rec -filter obj) | % { delete-folder $_.FullName }
 }
 
-function dotnet-restore($project, $localSource) {
-    $remoteSource = "https://api.nuget.org/v3/index.json"
-    if ($localSource) {
-        exec { & dotnet restore .\src\$project --verbosity Verbose --source $localSource --source $remoteSource }
-    } else {
-        exec { & dotnet restore .\src\$project --verbosity Verbose --source $remoteSource }
-    }
+function dotnet-restore($project, $source="https://api.nuget.org/v3/index.json") {
+    exec { & dotnet restore .\src\$project --verbosity Verbose --source $source }
 }
 
 function dotnet-pack($project) {

--- a/build.ps1
+++ b/build.ps1
@@ -38,10 +38,6 @@ function Test {
 }
 
 function Build {
-    dotnet-build Fixie
-    dotnet-build Fixie.Execution
-    dotnet-build Fixie.Runner
-
     dotnet-pack Fixie
     dotnet-pack Fixie.Execution
     dotnet-pack Fixie.Runner
@@ -61,7 +57,7 @@ function dotnet-build($project) {
 }
 
 function dotnet-pack($project) {
-    exec { & dotnet pack .\src\$project --output .\artifacts --no-build --configuration $configuration --version-suffix $revision }
+    exec { & dotnet pack .\src\$project --output .\artifacts --configuration $configuration --version-suffix $revision }
 }
 
 function License {

--- a/build.ps1
+++ b/build.ps1
@@ -24,7 +24,7 @@ function clean {
 }
 
 function dotnet-restore($project, $source="https://api.nuget.org/v3/index.json") {
-    exec { & dotnet restore .\src\$project --verbosity Verbose --source $source }
+    exec { & dotnet restore .\src\$project --verbosity Information --source $source }
 }
 
 function dotnet-pack($project) {

--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,6 @@ function main {
     step { Restore }
     step { License }
     step { Build }
-    step { Test }
 }
 
 function Clean {
@@ -32,11 +31,6 @@ function Restore {
     exec { & dotnet restore --verbosity Warning }
 }
 
-function Test {
-    dotnet-test Fixie.Tests
-    dotnet-test Fixie.Samples
-}
-
 function Build {
     dotnet-pack Fixie
     dotnet-pack Fixie.Execution
@@ -44,8 +38,9 @@ function Build {
 
     dotnet-build Fixie.TestDriven
     dotnet-build Fixie.Assertions
-    dotnet-build Fixie.Samples
-    dotnet-build Fixie.Tests
+
+    dotnet-test Fixie.Tests
+    dotnet-test Fixie.Samples
 }
 
 function dotnet-test($project) {

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="local" value="artifacts" />
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="local" value="artifacts" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Fixie.Execution/project.json
+++ b/src/Fixie.Execution/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.0.0-alpha-*",
+  "version": "2.0.0-*",
 
   "copyright": "2013-2016 Patrick Lioi",
 

--- a/src/Fixie.Runner/project.json
+++ b/src/Fixie.Runner/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.0.0-alpha-*",
+  "version": "2.0.0-*",
 
   "copyright": "2013-2016 Patrick Lioi",
 

--- a/src/Fixie.Samples/project.json
+++ b/src/Fixie.Samples/project.json
@@ -2,8 +2,14 @@
   "testRunner": "fixie",
 
   "dependencies": {
-    "Fixie": { "target": "project" },
-    "Fixie.Runner": { "target": "project" },
+    "Fixie": {
+      "target": "package",
+      "version": "2.0.0-*"
+    },
+    "Fixie.Runner": {
+      "target": "package",
+      "version": "2.0.0-*"
+    },
     "Fixie.Assertions": { "target": "project" }
   },
 

--- a/src/Fixie.Tests/project.json
+++ b/src/Fixie.Tests/project.json
@@ -13,10 +13,19 @@
   },
 
   "dependencies": {
-    "Fixie": { "target": "project" },
-    "Fixie.Execution": { "target": "project" },
+    "Fixie": {
+      "target": "package",
+      "version": "2.0.0-*"
+    },
+    "Fixie.Execution": {
+      "target": "package",
+      "version": "2.0.0-*"
+    },
+    "Fixie.Runner": {
+      "target": "package",
+      "version": "2.0.0-*"
+    },
     "Fixie.TestDriven": { "target": "project" },
-    "Fixie.Runner": { "target": "project" },
     "Fixie.Assertions": { "target": "project" },
     "TestDriven.Framework": "2.0.0-alpha2"
   },

--- a/src/Fixie/project.json
+++ b/src/Fixie/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.0.0-alpha-*",
+  "version": "2.0.0-*",
 
   "copyright": "2013-2016 Patrick Lioi",
 


### PR DESCRIPTION
Because NuGet package references and runtime assembly loading strategies behave very differently when targeting the full .NET Framework vs targeting netcoreapp/netstandard, Fixie's own self-testing test projects must reference the code under test *as NuGet packages* rather than as normal intra-solution project references.

To date, when targeting the regular framework exclusively, regular project references were enough because that would place things like `dotnet-test-fixie.exe` in the build output folder, and `dotnet test` would know to look for `dotnet-test-fixie.exe` in that same folder.

However, when a test project targets (or *also* targets) not-full-frameworks like netcoreapp/netstandard, build output folders no longer have redundant copies of NuGet package contents nor their transitive NuGet packages' contents, and along with that `dotnet test` uses a different strategy for finding `dotnet-test-fixie-dll`.

Following a strategy similar to the xunit runner, the build script now optimistially creates NuGet packages under a local .\artifacts folder, and Fixie's self-testing projects reference *those*.  For regular full framework test runs, the assemblies all wind up in the build output folder like normal and are found successfully by `dotnet test`; for non-full-framework test runs, the assemblies correctly avoid winding up in the build output folder and are still found successfully by `dotnet test`.

Note that we no longer rely on NuGet.config to specify things like the local .\artifacts folder as a package source, instead using the --source option on `dotnet restore` commands. The config file was blatantly ignored, so that the attempts to reference local packages failed and nuget.org published packages would incorrectly "win". Note also that only one --source is specified per `dotnet restore` command because attempting to include both .\artifacts and nuget.org similarly failed to prioritize them correctly.

(This PR does not include making the self-testing projects actually target netcoreapp, though that was tested locally, because unrelated downstream issues remain to be fixed in future pull requests.)