### PR TITLE
Simplify nuget package

### DIFF
--- a/build/Fixie.build.net452.props
+++ b/build/Fixie.build.net452.props
@@ -9,39 +9,4 @@
   <ItemGroup Condition="'$(Language)'=='C#'">
     <Compile Include="$(MSBuildThisFileDirectory)..\Fixie.Program$(DefaultLanguageSourceExtension)"/>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Fixie.VisualStudio.TestAdapter.dll">
-      <Link>Fixie.VisualStudio.TestAdapter.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Mono.Cecil.dll">
-      <Link>Mono.Cecil.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Mono.Cecil.Rocks.dll">
-      <Link>Mono.Cecil.Rocks.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Mono.Cecil.Pdb.dll">
-      <Link>Mono.Cecil.Pdb.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Fixie.dll">
-      <Link>Fixie.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </None>
-  </ItemGroup>
 </Project>

--- a/build/Fixie.build.netcoreapp1.0.props
+++ b/build/Fixie.build.netcoreapp1.0.props
@@ -10,14 +10,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\Fixie.Program$(DefaultLanguageSourceExtension)"/>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Fixie.VisualStudio.TestAdapter.dll">
+    <None Include="$(MSBuildThisFileDirectory)..\..\lib\netcoreapp1.0\Fixie.VisualStudio.TestAdapter.dll">
       <Link>Fixie.VisualStudio.TestAdapter.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Fixie.dll">
+    <None Include="$(MSBuildThisFileDirectory)..\..\lib\netcoreapp1.0\Fixie.dll">
       <Link>Fixie.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/src/Fixie/Fixie.nuspec
+++ b/src/Fixie/Fixie.nuspec
@@ -44,11 +44,10 @@
 
     <!-- Visual Studio Adapter -->
 
-    <file target="build\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Fixie.dll" />
-    <file target="build\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Fixie.VisualStudio.TestAdapter.dll" />
-    <file target="build\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.dll" />
-    <file target="build\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.Rocks.dll" />
-    <file target="build\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.Pdb.dll" />
+    <file target="lib\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Fixie.VisualStudio.TestAdapter.dll" />
+    <file target="lib\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.dll" />
+    <file target="lib\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.Rocks.dll" />
+    <file target="lib\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.Pdb.dll" />
 
     <file target="lib\netcoreapp1.0" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\netcoreapp1.0\Fixie.VisualStudio.TestAdapter.dll" />
 

--- a/src/Fixie/Fixie.nuspec
+++ b/src/Fixie/Fixie.nuspec
@@ -17,7 +17,7 @@
     </references>
     <dependencies>
       <group targetFramework="net452" />
-      <group targetFramework="netstandard1.6">
+      <group targetFramework="netcoreapp1.0">
         <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.TestPlatform.TestHost" version="15.3.0" />
         <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
@@ -34,7 +34,7 @@
     <!-- Reference Library -->
 
     <file target="lib\net452" src="..\Fixie\bin\Release\net452\Fixie.dll" />
-    <file target="lib\netstandard1.6" src="..\Fixie\bin\Release\netstandard1.6\Fixie.dll" />
+    <file target="lib\netcoreapp1.0" src="..\Fixie\bin\Release\netstandard1.6\Fixie.dll" />
 
     <!-- TestDriven.NET Adapter -->
 
@@ -49,11 +49,10 @@
     <file target="build\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.dll" />
     <file target="build\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.Rocks.dll" />
     <file target="build\net452" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\net452\Mono.Cecil.Pdb.dll" />
-    <file target="build\netcoreapp1.0" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\netcoreapp1.0\Fixie.VisualStudio.TestAdapter.dll" />
+
+    <file target="lib\netcoreapp1.0" src="..\Fixie.VisualStudio.TestAdapter\bin\Release\netcoreapp1.0\Fixie.VisualStudio.TestAdapter.dll" />
 
     <!-- Run Time Support -->
-
-    <file target="build\netcoreapp1.0" src="..\Fixie\bin\Release\netstandard1.6\Fixie.dll" />
 
     <file target="build\net452\Fixie.props" src="..\..\build\Fixie.build.net452.props" />
     <file target="build\netcoreapp1.0\Fixie.props" src="..\..\build\Fixie.build.netcoreapp1.0.props" />


### PR DESCRIPTION
The Fixie.nuspec is consistent in its naming of target frameworks for consumers targeting .NET Core.

The Fixie.nuspec avoids excessive file copies into the consumer's build output folder for consumers targeting the full .NET Framework. For the full .NET Framework, it is sufficient to place the *TestAdapter.dll and its dependencies within the lib/net452 package folder, as these will be picked up and used by Test Explorer successfully.

It appears that for .NET Core test assemblies, the *TestAdapter.dll still has to be located in the consumer's build output folder, so we continue to accomplish that via a *.props file located in the package.