### PR TITLE
Add EmptyTestClass to MessagingTests

### DIFF
--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -38,7 +38,7 @@
         protected string TestClass { get; }
 
         protected void Run(Listener listener) 
-            => Utility.Run(listener, convention, typeof(SampleTestClass), typeof(EmptyTestClass));
+            => RunTypes(listener, convention, typeof(SampleTestClass), typeof(EmptyTestClass));
 
         protected class Base
         {

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -17,7 +17,7 @@
 
             convention
                 .Classes
-                .Where(testClass => testClass == typeof(SampleTestClass));
+                .Where(testClass => testClass == typeof(SampleTestClass) || testClass == typeof(EmptyTestClass));
 
             convention
                 .ClassExecution
@@ -38,7 +38,7 @@
         protected string TestClass { get; }
 
         protected void Run(Listener listener)
-            => Run<SampleTestClass>(listener, convention);
+            => RunMany<SampleTestClass, EmptyTestClass>(listener, convention);
 
         protected class Base
         {
@@ -79,6 +79,10 @@
             {
                 throw new ShouldBeUnreachableException();
             }
+        }
+
+        protected class EmptyTestClass
+        {
         }
 
         protected static string At(string method)

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -37,9 +37,6 @@
 
         protected string TestClass { get; }
 
-        protected void Discover(Listener listener)
-            => Discover<SampleTestClass>(listener, convention);
-
         protected void Run(Listener listener)
             => Run<SampleTestClass>(listener, convention);
 

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -37,8 +37,8 @@
 
         protected string TestClass { get; }
 
-        protected void Run(Listener listener)
-            => RunMany<SampleTestClass, EmptyTestClass>(listener, convention);
+        protected void Run(Listener listener) 
+            => Utility.Run(listener, convention, typeof(SampleTestClass), typeof(EmptyTestClass));
 
         protected class Base
         {

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -14,14 +14,6 @@
         public static string PathToThisFile([CallerFilePath] string path = null)
             => path;
 
-        public static void Discover<TSampleTestClass>(Listener listener, Convention convention)
-        {
-            var sampleTestClass = typeof(TSampleTestClass);
-
-            var bus = new Bus(listener);
-            new Discoverer(bus).DiscoverMethods(sampleTestClass.Assembly(), convention);
-        }
-
         public static void Run<TSampleTestClass>(Listener listener, Convention convention)
         {
             var sampleTestClass = typeof(TSampleTestClass);

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -22,7 +22,7 @@
         {
             if (types.Length == 0)
             {
-                throw new InvalidOperationException("RunMany requires at least one type to be specified");
+                throw new InvalidOperationException("Run requires at least one type to be specified");
             }
 
             var bus = new Bus(listener);

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -16,13 +16,13 @@
             => path;
 
         public static void Run<TSampleTestClass>(Listener listener, Convention convention)
-            => Run(listener, convention, typeof(TSampleTestClass));
+            => RunTypes(listener, convention, typeof(TSampleTestClass));
 
-        public static void Run(Listener listener, Convention convention, params Type[] types)
+        public static void RunTypes(Listener listener, Convention convention, params Type[] types)
         {
             if (types.Length == 0)
             {
-                throw new InvalidOperationException("Run requires at least one type to be specified");
+                throw new InvalidOperationException("RunTypes requires at least one type to be specified");
             }
 
             var bus = new Bus(listener);

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -21,5 +21,16 @@
             var bus = new Bus(listener);
             new Runner(bus).RunTypes(sampleTestClass.Assembly(), convention, sampleTestClass);
         }
+
+        public static void RunMany<TSampleTestClass1, TSampleTestClass2>(Listener listener, Convention convention)
+        {
+            var sampleTestClass1 = typeof(TSampleTestClass1);
+            var sampleTestClass2 = typeof(TSampleTestClass2);
+
+            var types = new[] {sampleTestClass1, sampleTestClass2};
+
+            var bus = new Bus(listener);
+            new Runner(bus).RunTypes(sampleTestClass1.Assembly(), convention, types);
+        }
     }
 }

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.Tests
 {
+    using System;
     using System.Runtime.CompilerServices;
     using Fixie.Execution;
 
@@ -15,22 +16,17 @@
             => path;
 
         public static void Run<TSampleTestClass>(Listener listener, Convention convention)
+            => Run(listener, convention, typeof(TSampleTestClass));
+
+        public static void Run(Listener listener, Convention convention, params Type[] types)
         {
-            var sampleTestClass = typeof(TSampleTestClass);
+            if (types.Length == 0)
+            {
+                throw new InvalidOperationException("RunMany requires at least one type to be specified");
+            }
 
             var bus = new Bus(listener);
-            new Runner(bus).RunTypes(sampleTestClass.Assembly(), convention, sampleTestClass);
-        }
-
-        public static void RunMany<TSampleTestClass1, TSampleTestClass2>(Listener listener, Convention convention)
-        {
-            var sampleTestClass1 = typeof(TSampleTestClass1);
-            var sampleTestClass2 = typeof(TSampleTestClass2);
-
-            var types = new[] {sampleTestClass1, sampleTestClass2};
-
-            var bus = new Bus(listener);
-            new Runner(bus).RunTypes(sampleTestClass1.Assembly(), convention, types);
+            new Runner(bus).RunTypes(types[0].Assembly(), convention, types);
         }
     }
 }


### PR DESCRIPTION
This will help to assert that there is no additional output generated to the listeners when running empty classes that are included by a test convention.