### PR TITLE
Fix ReportListener compatibility with xUnit v2 format

### DIFF
--- a/src/Fixie.Tests/Internal/Listeners/XUnitXmlReport.xml
+++ b/src/Fixie.Tests/Internal/Listeners/XUnitXmlReport.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <assemblies>
 <assembly name="[assemblyLocation]" run-date="YYYY-MM-DD" run-time="HH:MM:SS" time="1.234" total="5" passed="1" failed="2" skipped="2" environment="00-bit .NET 1.2.3.4" test-framework="Fixie 1.2.3.4">
-  <class time="1.234" name="[testClass]" total="5" passed="1" failed="2" skipped="2">
+  <collection time="1.234" name="[testClass]" total="5" passed="1" failed="2" skipped="2">
     <test name="[testClass].Fail" type="[testClass]" method="Fail" result="Fail" time="1.234">
       <failure exception-type="Fixie.Tests.FailureException">
         <message><![CDATA['Fail' failed!]]></message>
@@ -22,6 +22,6 @@ Actual:   1]]></message>
       </reason>
     </test>
     <test name="[testClass].SkipWithoutReason" type="[testClass]" method="SkipWithoutReason" result="Skip" time="1.234"/>
-  </class>
+  </collection>
 </assembly>
 </assemblies>

--- a/src/Fixie/Internal/Listeners/ReportListener.cs
+++ b/src/Fixie/Internal/Listeners/ReportListener.cs
@@ -66,7 +66,7 @@
         public void Handle(ClassCompleted message)
         {
             classes.Add(
-                new XElement("class",
+                new XElement("collection",
                     new XAttribute("time", Seconds(message.Duration)),
                     new XAttribute("name", message.Class.FullName),
                     new XAttribute("total", message.Total),


### PR DESCRIPTION
Change `assembly > class` to `assembly > collection` to match [xUnit v2 format](https://xunit.github.io/docs/format-xml-v2.html#assembly). 

Closes https://github.com/fixie/fixie/issues/188.