### PR TITLE
Escape non-ASCII characters in TeamCity output

### DIFF
--- a/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
@@ -68,7 +68,7 @@
             skipWithReason.Method.Name.ShouldEqual("SkipWithReason");
             skipWithReason.Output.ShouldBeEmpty();
             skipWithReason.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-            skipWithReason.Reason.ShouldEqual("Skipped with reason.");
+            skipWithReason.Reason.ShouldEqual("⚠ Skipped with reason.");
 
             skipWithoutReason.Name.ShouldEqual(TestClass + ".SkipWithoutReason");
             skipWithoutReason.Class.FullName.ShouldEqual(TestClass);

--- a/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
@@ -58,7 +58,7 @@
             skipWithReason.TestName.ShouldEqual(TestClass + ".SkipWithReason");
             skipWithReason.Outcome.ShouldEqual("Skipped");
             int.Parse(skipWithReason.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            skipWithReason.ErrorMessage.ShouldEqual("Skipped with reason.");
+            skipWithReason.ErrorMessage.ShouldEqual("⚠ Skipped with reason.");
             skipWithReason.ErrorStackTrace.ShouldBeNull();
             skipWithReason.StdOut.ShouldBeEmpty();
 

--- a/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
@@ -45,7 +45,7 @@
                            "Console.Error: Pass",
 
                            "Test '" + TestClass + ".SkipWithReason' skipped:",
-                           "Skipped with reason.",
+                           "⚠ Skipped with reason.",
                            "",
                            "Test '" + TestClass + ".SkipWithoutReason' skipped",
                            "",

--- a/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
@@ -44,7 +44,7 @@
                         "##teamcity[testFinished name='" + TestClass + ".Pass' duration='#']",
 
                         "##teamcity[testStarted name='" + TestClass + ".SkipWithReason']",
-                        "##teamcity[testIgnored name='" + TestClass + ".SkipWithReason' message='Skipped with reason.']",
+                        "##teamcity[testIgnored name='" + TestClass + ".SkipWithReason' message='⚠ Skipped with reason.']",
                         "##teamcity[testFinished name='" + TestClass + ".SkipWithReason' duration='#']",
 
                         "##teamcity[testStarted name='" + TestClass + ".SkipWithoutReason']",

--- a/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
@@ -44,8 +44,9 @@
                         "##teamcity[testFinished name='" + TestClass + ".Pass' duration='#']",
 
                         "##teamcity[testStarted name='" + TestClass + ".SkipWithReason']",
-                        "##teamcity[testIgnored name='" + TestClass + ".SkipWithReason' message='⚠ Skipped with reason.']",
+                        "##teamcity[testIgnored name='" + TestClass + ".SkipWithReason' message='|0x26a0 Skipped with reason.']",
                         "##teamcity[testFinished name='" + TestClass + ".SkipWithReason' duration='#']",
+
 
                         "##teamcity[testStarted name='" + TestClass + ".SkipWithoutReason']",
                         "##teamcity[testIgnored name='" + TestClass + ".SkipWithoutReason' message='']",

--- a/src/Fixie.Tests/Internal/Listeners/XUnitXmlReport.xml
+++ b/src/Fixie.Tests/Internal/Listeners/XUnitXmlReport.xml
@@ -17,7 +17,7 @@ Actual:   1]]></message>
     </test>
     <test name="[testClass].Pass" type="[testClass]" method="Pass" result="Pass" time="1.234" />
     <test name="[testClass].SkipWithReason" type="[testClass]" method="SkipWithReason" result="Skip" time="1.234">
-      <reason><![CDATA[Skipped with reason.]]></reason>
+      <reason><![CDATA[⚠ Skipped with reason.]]></reason>
     </test>
     <test name="[testClass].SkipWithoutReason" type="[testClass]" method="SkipWithoutReason" result="Skip" time="1.234"/>
   </collection>

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -81,7 +81,8 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            [Skip("Skipped with reason.")]
+            const string alert = "\x26A0";
+            [Skip(alert + " Skipped with reason.")]
             public void SkipWithReason()
             {
                 throw new ShouldBeUnreachableException();

--- a/src/Fixie.Tests/TestDriven/TestDrivenListenerTests.cs
+++ b/src/Fixie.Tests/TestDriven/TestDrivenListenerTests.cs
@@ -49,7 +49,7 @@ namespace Fixie.Tests.TestDriven
 
             skipWithReason.Name.ShouldEqual(TestClass + ".SkipWithReason");
             skipWithReason.State.ShouldEqual(TestState.Ignored);
-            skipWithReason.Message.ShouldEqual("Skipped with reason.");
+            skipWithReason.Message.ShouldEqual("⚠ Skipped with reason.");
             skipWithReason.StackTrace.ShouldBeNull();
 
             skipWithoutReason.Name.ShouldEqual(TestClass + ".SkipWithoutReason");

--- a/src/Fixie/Internal/Listeners/TeamCityListener.cs
+++ b/src/Fixie/Internal/Listeners/TeamCityListener.cs
@@ -88,21 +88,30 @@
                     case '\'': builder.Append("|'"); break;
                     case '[': builder.Append("|["); break;
                     case ']': builder.Append("|]"); break;
-                    case '\n': builder.Append("|n"); break; // Line Feed
-                    case '\r': builder.Append("|r"); break; // Carriage Return
-                    case '\u0085': builder.Append("|x"); break; // Next Line
-                    case '\u2028': builder.Append("|l"); break; // Line Separator
-                    case '\u2029': builder.Append("|p"); break; // Paragraph Separator
-                    default: builder.Append(ch); break;
+                    case '\n': builder.Append("|n"); break;
+                    case '\r': builder.Append("|r"); break;
+                    default:
+                        if (RequiresHexEscape(ch))
+                        {
+                            builder.Append("|0x");
+                            builder.Append(((int) ch).ToString("x4"));
+                        }
+                        else
+                        {
+                            builder.Append(ch);
+                        }
+
+                        break;
                 }
             }
 
             return builder.ToString();
         }
 
+        static bool RequiresHexEscape(char ch)
+            => ch > '\x007f';
+
         static string DurationInMilliseconds(TimeSpan duration)
-        {
-            return ((int)Math.Ceiling(duration.TotalMilliseconds)).ToString();
-        }
+            => ((int)Math.Ceiling(duration.TotalMilliseconds)).ToString();
     }
 }


### PR DESCRIPTION
Because console encoding can affect the output of TeamCityListener, it has been possible for non-ASCII characters to be misinterpreted by TeamCity. The ’ character (RIGHT SINGLE QUOTATION MARK), for example, can be read by TeamCity as a an ASCII single quote ', which is meaningful in the TeamCity service message format. It and all non-ASCII characters should instead be escaped using TeamCity's own escape sequence formatting.

See https://confluence.jetbrains.com/display/TCD18/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-Escapedvalues for documentation on producing valid escape sequences.

Note: We remove 3 old unicode-related cases here because they merely produce shorthand that TeamCity happens to support. The new hex escape sequences cover those characters, so they need not be handled specially on Fixie's end. Those special cases aren't even documented in the link above.