### PR TITLE
Add support for F# methods that return Async<T> or Task/Task<T>.

### DIFF
--- a/src/Fixie.Tests/Cases/AsyncCaseTests.cs
+++ b/src/Fixie.Tests/Cases/AsyncCaseTests.cs
@@ -15,6 +15,27 @@
                     For<AwaitThenPassTestClass>(".Test passed"));
         }
 
+        public void ShouldPassUponSuccessfulAsyncTaskTExecution()
+        {
+            Run<AwaitThenPassAndReturnValueTestClass>()
+                .ShouldEqual(
+                    For<AwaitThenPassAndReturnValueTestClass>(".Test passed"));
+        }
+
+        public void ShouldPassUponSuccessfulTaskReturnExecution()
+        {
+            Run<TaskReturnValueTestClass>()
+                .ShouldEqual(
+                    For<TaskReturnValueTestClass>(".Test passed"));
+        }
+
+        public void ShouldPassUponSuccessfulTaskExecution()
+        {
+            Run<TaskNoReturnValueTestClass>()
+                .ShouldEqual(
+                    For<TaskNoReturnValueTestClass>(".Test passed"));
+        }
+
         public void ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsAfterAwaiting()
         {
             Run<AwaitThenFailTestClass>()
@@ -67,6 +88,38 @@
                 var result = await Divide(15, 5);
 
                 result.ShouldEqual(3);
+            }
+        }
+
+        class AwaitThenPassAndReturnValueTestClass : SampleTestClassBase
+        {
+            public async Task<bool> Test()
+            {
+                var result = await Divide(15, 5);
+
+                result.ShouldEqual(3);
+
+                return true;
+            }
+        }
+
+        class TaskReturnValueTestClass : SampleTestClassBase
+        {
+            public Task<bool> Test()
+            {
+                3.ShouldEqual(3);
+
+                return Task.Run(() => true);
+            }
+        }
+
+        class TaskNoReturnValueTestClass : SampleTestClassBase
+        {
+            public Task Test()
+            {
+                3.ShouldEqual(3);
+
+                return Task.Run(() => {});
             }
         }
 

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -89,11 +89,7 @@
 
                 return
                     (Task)startAsTask.MakeGenericMethod(resultType.GetGenericArguments())
-                    .Invoke(null,
-                            BindingFlags.Public | BindingFlags.Static,
-                            null,
-                            new object[] { result, null, null },
-                            null);
+                    .Invoke(null, new object[] { result, null, null });
             }
 
             return null;

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -34,7 +34,15 @@
 
         public static bool IsAsync(this MethodInfo method)
         {
-            return method.Has<AsyncStateMachineAttribute>();
+            var returnType = method.ReturnType;
+            return method.Has<AsyncStateMachineAttribute>() ||
+                returnType == typeof(System.Threading.Tasks.Task) ||
+                returnType.IsFSharpAsync();
+        }
+
+        internal static bool IsFSharpAsync(this Type returnType) {
+            return returnType.IsGenericType &&
+                returnType.GetGenericTypeDefinition().FullName == "Microsoft.FSharp.Control.FSharpAsync`1";
         }
 
         public static bool IsInNamespace(this Type type, string ns)

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -37,6 +37,7 @@
             var returnType = method.ReturnType;
             return method.Has<AsyncStateMachineAttribute>() ||
                 returnType == typeof(System.Threading.Tasks.Task) ||
+                (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.Task<>)) ||
                 returnType.IsFSharpAsync();
         }
 


### PR DESCRIPTION
With these changes, the following types of F# test functions seem to work as expected:

1. Returning native F# async (the signature here would be `unit -> Async<unit>`):

```
let ``it should async return the expected results``() =
    async {
        let! result = someAsyncMethod "test"
        result.ShouldBe("testtest")
    }
```

2. Or the version that returns a `Task<T>`, but doesn't have the attribute that's added for `async` C# methods (the signature here would be `unit -> Task<unit>`):

```
let ``it should async return the expected results``() =
    async {
        let! result = someAsyncMethod "test"
        result.ShouldBe("testtest")
    } |> Async.StartAsTask
```

I'm not honestly sure how to easily test this without dragging F# into the tests, or writing a second test assembly in F#.

Thoughts?

