### PR TITLE
Azure DevOps Integration

### DIFF
--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -20,6 +20,12 @@ namespace Fixie.Tests.Assertions
                 throw new AssertException(ComparisonFailure(actual, minimum, ">="));
         }
 
+        public static void ShouldBeGreaterThanOrEqualTo(this double actual, double minimum)
+        {
+            if (actual < minimum)
+                throw new AssertException(ComparisonFailure(actual, minimum, ">="));
+        }
+
         public static void ShouldBeGreaterThanOrEqualTo(this TimeSpan actual, TimeSpan minimum)
         {
             if (actual < minimum)

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -16,6 +16,10 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectCapability Include="TestContainer" />
   </ItemGroup>

--- a/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
@@ -19,7 +19,7 @@
                 uri.ShouldBe("http://localhost:4567/api/tests");
                 mediaType.ShouldBe("application/json");
 
-                results.Add(Deserialize(content));
+                results.Add(Deserialize<AppVeyorListener.TestResult>(content));
             });
 
             using (var console = new RedirectedConsole())
@@ -99,12 +99,12 @@
             pass.StdOut.Lines().ShouldBe("Console.Out: Pass", "Console.Error: Pass");
         }
 
-        static AppVeyorListener.TestResult Deserialize(string content)
+        static T Deserialize<T>(string content)
         {
-            var deserializer = new DataContractJsonSerializer(typeof(AppVeyorListener.TestResult));
+            var deserializer = new DataContractJsonSerializer(typeof(T));
 
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(content)))
-                return (AppVeyorListener.TestResult) deserializer.ReadObject(stream);
+                return (T) deserializer.ReadObject(stream);
         }
     }
 }

--- a/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
@@ -1,12 +1,10 @@
 ﻿namespace Fixie.Tests.Internal.Listeners
 {
     using System.Collections.Generic;
-    using System.IO;
-    using System.Runtime.Serialization.Json;
-    using System.Text;
     using Assertions;
     using Fixie.Internal;
     using Fixie.Internal.Listeners;
+    using static Fixie.Internal.Serialization;
 
     public class AppVeyorListenerTests : MessagingTests
     {
@@ -97,14 +95,6 @@
             pass.ErrorMessage.ShouldBe(null);
             pass.ErrorStackTrace.ShouldBe(null);
             pass.StdOut.Lines().ShouldBe("Console.Out: Pass", "Console.Error: Pass");
-        }
-
-        static T Deserialize<T>(string content)
-        {
-            var deserializer = new DataContractJsonSerializer(typeof(T));
-
-            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(content)))
-                return (T) deserializer.ReadObject(stream);
         }
     }
 }

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -1,0 +1,129 @@
+﻿namespace Fixie.Tests.Internal.Listeners
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Assertions;
+    using Fixie.Internal;
+    using Fixie.Internal.Listeners;
+    using static Fixie.Internal.Serialization;
+
+    public class AzureListenerTests : MessagingTests
+    {
+        public void ShouldReportResultsToAzureDevOpsApi()
+        {
+            AzureListener.CreateRun start = null;
+            var results = new List<AzureListener.Result>();
+            var project = Guid.NewGuid().ToString();
+            var accessToken = Guid.NewGuid().ToString();
+            var buildId = Guid.NewGuid().ToString();
+            var runUrl = "http://localhost:4567/run/" + Guid.NewGuid();
+
+            bool first = true;
+            var listener = new AzureListener("http://localhost:4567", project, accessToken, buildId, (client, uri, mediaType, content) =>
+            {
+                var actualHeader = client.DefaultRequestHeaders.Accept.Single();
+                actualHeader.MediaType.ShouldBe("application/json");
+
+                var actualAuthorization = client.DefaultRequestHeaders.Authorization;
+                actualAuthorization.Scheme.ShouldBe("Bearer");
+                actualAuthorization.Parameter.ShouldBe(accessToken);
+
+                mediaType.ShouldBe("application/json");
+
+                if (first)
+                {
+                    first = false;
+
+                    uri.ShouldBe($"http://localhost:4567/{project}/_apis/test/runs?api-version=5.0");
+
+                    start = Deserialize<AzureListener.CreateRun>(content);
+
+                    return Serialize(new AzureListener.TestRun { url = runUrl });
+                }
+
+                uri.ShouldBe($"{runUrl}/results?api-version=5.0");
+
+                results.Add(Deserialize<AzureListener.Result[]>(content).Single());
+
+                return null;
+            });
+
+            using (var console = new RedirectedConsole())
+            {
+                Run(listener);
+
+                console.Lines()
+                    .ShouldBe(
+                        "Console.Out: Fail",
+                        "Console.Error: Fail",
+                        "Console.Out: FailByAssertion",
+                        "Console.Error: FailByAssertion",
+                        "Console.Out: Pass",
+                        "Console.Error: Pass");
+            }
+
+            
+
+#if NET452
+            start.name.ShouldBe("Fixie.Tests (.NETFramework,Version=v4.5.2)");
+#else
+            start.name.ShouldBe("Fixie.Tests (.NETCoreApp,Version=v2.0)");
+#endif
+
+            start.build.id.ShouldBe(buildId);
+            start.isAutomated.ShouldBe(true);
+
+            results.Count.ShouldBe(5);
+
+            var fail = results[0];
+            var failByAssertion = results[1];
+            var pass = results[2];
+            var skipWithReason = results[3];
+            var skipWithoutReason = results[4];
+
+            skipWithReason.automatedTestName.ShouldBe(TestClass + ".SkipWithReason");
+            skipWithReason.testCaseTitle.ShouldBe(TestClass + ".SkipWithReason");
+            skipWithReason.outcome.ShouldBe("None");
+            skipWithReason.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+            skipWithReason.errorMessage.ShouldBe("⚠ Skipped with reason.");
+            skipWithReason.stackTrace.ShouldBe(null);
+
+            skipWithoutReason.automatedTestName.ShouldBe(TestClass + ".SkipWithoutReason");
+            skipWithoutReason.testCaseTitle.ShouldBe(TestClass + ".SkipWithoutReason");
+            skipWithoutReason.outcome.ShouldBe("None");
+            skipWithoutReason.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+            skipWithoutReason.errorMessage.ShouldBe(null);
+            skipWithoutReason.stackTrace.ShouldBe(null);
+
+            fail.automatedTestName.ShouldBe(TestClass + ".Fail");
+            fail.testCaseTitle.ShouldBe(TestClass + ".Fail");
+            fail.outcome.ShouldBe("Failed");
+            fail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+            fail.errorMessage.ShouldBe("'Fail' failed!");
+            fail.stackTrace
+                .CleanStackTraceLineNumbers()
+                .Lines()
+                .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
+
+            failByAssertion.automatedTestName.ShouldBe(TestClass + ".FailByAssertion");
+            failByAssertion.testCaseTitle.ShouldBe(TestClass + ".FailByAssertion");
+            failByAssertion.outcome.ShouldBe("Failed");
+            failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+            failByAssertion.errorMessage.Lines().ShouldBe(
+                "Expected: 2",
+                "Actual:   1");
+            failByAssertion.stackTrace
+                .CleanStackTraceLineNumbers()
+                .Lines()
+                .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
+
+            pass.automatedTestName.ShouldBe(TestClass + ".Pass");
+            pass.testCaseTitle.ShouldBe(TestClass + ".Pass");
+            pass.outcome.ShouldBe("Passed");
+            pass.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+            pass.errorMessage.ShouldBe(null);
+            pass.stackTrace.ShouldBe(null);
+        }
+    }
+}

--- a/src/Fixie/Internal/AzureListener.cs
+++ b/src/Fixie/Internal/AzureListener.cs
@@ -1,0 +1,6 @@
+﻿namespace Fixie.Internal
+{
+    public class AzureListener : Listener
+    {
+    }
+}

--- a/src/Fixie/Internal/AzureListener.cs
+++ b/src/Fixie/Internal/AzureListener.cs
@@ -1,6 +1,0 @@
-﻿namespace Fixie.Internal
-{
-    public class AzureListener : Listener
-    {
-    }
-}

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -91,13 +91,13 @@
             postAction(uri, "application/json", Serialize(testResult));
         }
 
-        static string Serialize(TestResult testResult)
+        static string Serialize<T>(T message)
         {
-            var serializer = new DataContractJsonSerializer(typeof(TestResult));
+            var serializer = new DataContractJsonSerializer(typeof(T));
 
             using (var stream = new MemoryStream())
             {
-                serializer.WriteObject(stream, testResult);
+                serializer.WriteObject(stream, message);
                 return Encoding.UTF8.GetString(stream.ToArray());
             }
         }

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -4,10 +4,10 @@
     using System.IO;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using System.Runtime.Serialization.Json;
     using System.Text;
     using Internal;
     using static System.Environment;
+    using static Serialization;
 
     public class AppVeyorListener :
         Handler<AssemblyStarted>,
@@ -89,17 +89,6 @@
             customize(testResult);
 
             postAction(uri, "application/json", Serialize(testResult));
-        }
-
-        static string Serialize<T>(T message)
-        {
-            var serializer = new DataContractJsonSerializer(typeof(T));
-
-            using (var stream = new MemoryStream())
-            {
-                serializer.WriteObject(stream, message);
-                return Encoding.UTF8.GetString(stream.ToArray());
-            }
         }
 
         static void Post(string uri, string mediaType, string content)

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -1,0 +1,173 @@
+﻿namespace Fixie.Internal.Listeners
+{
+    using System;
+    using System.IO;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Reflection;
+    using System.Runtime.Versioning;
+    using System.Text;
+    using Internal;
+    using static System.Environment;
+    using static Serialization;
+
+    public class AzureListener :
+        Handler<AssemblyStarted>,
+        Handler<CaseSkipped>,
+        Handler<CasePassed>,
+        Handler<CaseFailed>
+    {
+        const string AzureDevOpsRestApiVersion = "5.0";
+
+        public delegate string ApiAction(HttpClient client, string uri, string mediaType, string content);
+
+        readonly string collectionUri;
+        readonly string project;
+        readonly string buildId;
+        readonly ApiAction postAction;
+        readonly HttpClient client;
+
+        string runUrl;
+
+        public AzureListener()
+            : this(
+                GetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"),
+                GetEnvironmentVariable("SYSTEM_TEAMPROJECT"),
+                GetEnvironmentVariable("SYSTEM_ACCESSTOKEN"),
+                GetEnvironmentVariable("BUILD_BUILDID"),
+                Post)
+        {
+        }
+
+        public AzureListener(string collectionUri, string project, string accessToken, string buildId, ApiAction postAction)
+        {
+            this.collectionUri = collectionUri;
+            this.project = project;
+            this.buildId = buildId;
+            this.postAction = postAction;
+            
+            client = new HttpClient();
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        }
+
+        public void Handle(AssemblyStarted message)
+        {
+            var runName = Path.GetFileNameWithoutExtension(message.Assembly.Location);
+
+            var framework = Assembly.GetEntryAssembly()?
+                .GetCustomAttribute<TargetFrameworkAttribute>()?
+                .FrameworkName;
+
+            if (!string.IsNullOrEmpty(framework))
+                runName = $"{runName} ({framework})";
+            
+            var start = new CreateRun
+            {
+                name = runName,
+                build = new CreateRun.BuildDetail
+                {
+                    id = buildId
+                },
+                isAutomated = true
+            };
+
+            var runsUri = new Uri(new Uri(collectionUri), $"{project}/_apis/test/runs").ToString();
+
+            var response = postAction(client, $"{runsUri}?api-version={AzureDevOpsRestApiVersion}", "application/json", Serialize(start));
+
+            runUrl = Deserialize<TestRun>(response).url;
+        }
+
+        public void Handle(CaseSkipped message)
+        {
+            Post(message, x =>
+            {
+                x.outcome = "None";
+                x.errorMessage = message.Reason;
+            });
+        }
+
+        public void Handle(CasePassed message)
+        {
+            Post(message, x =>
+            {
+                x.outcome = "Passed";
+            });
+        }
+
+        public void Handle(CaseFailed message)
+        {
+            Post(message, x =>
+            {
+                x.outcome = "Failed";
+                x.errorMessage = message.Exception.Message;
+                x.stackTrace =
+                    message.Exception.TypeName() +
+                    NewLine +
+                    message.Exception.LiterateStackTrace();
+            });
+        }
+
+        void Post(CaseCompleted message, Action<Result> customize)
+        {
+            var result = new Result
+            {
+                automatedTestName = message.Name,
+                testCaseTitle = message.Name,
+                durationInMs = message.Duration.TotalMilliseconds
+            };
+
+            customize(result);
+
+            postAction(client, $"{runUrl}/results?api-version={AzureDevOpsRestApiVersion}", "application/json", Serialize(new[]{result}));
+        }
+
+        static string Post(HttpClient client, string uri, string mediaType, string content)
+        {
+            var task = client.PostAsync(uri, new StringContent(content, Encoding.UTF8, mediaType));
+            
+            task.Wait();
+
+            using (var httpResponse = task.Result)
+            {
+                var body = httpResponse.Content.ReadAsStringAsync().Result;
+
+                if (!httpResponse.IsSuccessStatusCode)
+                {
+                    Console.WriteLine($"{typeof(AzureListener).FullName} failed to POST a result: {(int)httpResponse.StatusCode} {httpResponse.ReasonPhrase}");
+                    Console.WriteLine(body);
+                }
+
+                return body;
+            }
+        }
+
+        public class CreateRun
+        {
+            public string name { get; set; }
+            public BuildDetail build { get; set; }
+            public bool isAutomated { get; set; }
+
+            public class BuildDetail
+            {
+                public string id { get; set; }
+            }
+        }
+
+        public class TestRun
+        {
+            public string url { get; set; }
+        }
+
+        public class Result
+        {
+            public string automatedTestName { get; set; }
+            public string testCaseTitle { get; set; }
+            public double durationInMs { get; set; }
+            public string outcome { get; set; }
+            public string errorMessage { get; set; }
+            public string stackTrace { get; set; }
+        }
+    }
+}

--- a/src/Fixie/Internal/Serialization.cs
+++ b/src/Fixie/Internal/Serialization.cs
@@ -1,0 +1,28 @@
+﻿namespace Fixie.Internal
+{
+    using System.IO;
+    using System.Runtime.Serialization.Json;
+    using System.Text;
+
+    static class Serialization
+    {
+        public static string Serialize<T>(T message)
+        {
+            var serializer = new DataContractJsonSerializer(typeof(T));
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.WriteObject(stream, message);
+                return Encoding.UTF8.GetString(stream.ToArray());
+            }
+        }
+
+        public static T Deserialize<T>(string message)
+        {
+            var deserializer = new DataContractJsonSerializer(typeof(T));
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(message)))
+                return (T)deserializer.ReadObject(stream);
+        }
+    }
+}


### PR DESCRIPTION
When running under Azure DevOps, test results are reported to the Azure DevOps REST API. This requires the end user set up one environment variable in order to grant access to that API. When the environment variable is not set up, the console output includes an explanation with guidance from Azure DevOps' own documentation.

Overall, the implementation mimics that of the existing AppVeyor support.