### PR TITLE
Clean stack traces for .NET Core 2.1+

### DIFF
--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -1,18 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
     <Optimize>false</Optimize>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
     <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net452</TargetFrameworks>
     <Optimize>false</Optimize>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -12,6 +12,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -67,8 +67,6 @@
 
 #if NET452
             start.name.ShouldBe("Fixie.Tests (.NETFramework,Version=v4.5.2)");
-#elif NETCOREAPP2_0
-            start.name.ShouldBe("Fixie.Tests (.NETCoreApp,Version=v2.0)");
 #else
             start.name.ShouldBe("Fixie.Tests (.NETCoreApp,Version=v2.1)");
 #endif

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -67,8 +67,10 @@
 
 #if NET452
             start.name.ShouldBe("Fixie.Tests (.NETFramework,Version=v4.5.2)");
-#else
+#elif NETCOREAPP2_0
             start.name.ShouldBe("Fixie.Tests (.NETCoreApp,Version=v2.0)");
+#else
+            start.name.ShouldBe("Fixie.Tests (.NETCoreApp,Version=v2.1)");
 #endif
 
             start.build.id.ShouldBe(buildId);

--- a/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
+++ b/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
@@ -10,6 +10,7 @@
     static class ExceptionExtensions
     {
         static readonly MethodInfo CaseExecuteMethod = typeof(Case).GetMethod("Execute");
+
         static readonly MethodInfo ExceptionRethrowMethod = typeof(ExceptionDispatchInfo).GetMethod("Throw", new Type[] { });
 
         public static string LiterateStackTrace(this Exception exception)
@@ -58,6 +59,9 @@
             //
             // This assumes that stack trace lines use the "---" formatting of the rethrow hint
             // across cultures, and that the stack frame lines do *not* contain "---" across cultures.
+            //
+            // Starting in .NET Core 2.1, although the stack frames do still include ExceptionDispatchInfo.Throw()
+            // for completeness, the corresponding line is omitted from the stack trace text.
             //
             // When in doubt, return the original stack trace.
 
@@ -123,10 +127,19 @@
 
             for (int i = frames.Length - 1; i >= 0; i--)
             {
-                numberOfTrailingStackFramesToRemove++;
-
                 if (frames[i].GetMethod() == ExceptionRethrowMethod)
+                {
+                    #if NET452
+                        // .NET Framework 4.x includes an extra line in the stack
+                        // trace, for the call to ExceptionDispatchInfo.Throw() itself.
+
+                        numberOfTrailingStackFramesToRemove++;
+                    #endif
+
                     return true;
+                }
+
+                numberOfTrailingStackFramesToRemove++;
             }
 
             return false;

--- a/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
+++ b/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
@@ -10,7 +10,6 @@
     static class ExceptionExtensions
     {
         static readonly MethodInfo CaseExecuteMethod = typeof(Case).GetMethod("Execute");
-
         static readonly MethodInfo ExceptionRethrowMethod = typeof(ExceptionDispatchInfo).GetMethod("Throw", new Type[] { });
 
         public static string LiterateStackTrace(this Exception exception)


### PR DESCRIPTION
Fixie already attempted to remove internal implementation details from test failure stack traces. For instance, when a test fails due to an assertion, users would prefer to see the stack trace reporting the line of the assertion as the point of failure, rather than *first* seeing stack frames about Fixie's internal experience with the exception when we call `MethodInfo.Invoke()` and `ExceptionDispatchInfo.Throw()`. The attempt was written such that it fails safe: when we're uncertain about how to safely remove the implementation details, we report the full exception.

As of .NET Core 2.1, the original stack trace string was altered so that it already omitted the still-truly-present stack frame for `ExceptionDispatchInfo.Throw()`. Although that's a convenient improvement to stack traces in general, it pushed us into one of the "fail safe" points in our own cleanup, resulting in extra-complex test failure reporting.

This PR adjusts our cleanup of test failure exception stack traces by considering whether or not we're running under .NET Framework 4.x vs anything else, to decide whether or not *we* need to remove a line for the `ExceptionDispatchInfo.Throw()` stack frame.