### PR TITLE
Update deprecated nuget elements

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -23,7 +23,7 @@ function Build {
         <Copyright>$copyright</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://fixie.github.io</PackageProjectUrl>
-        <PackageIconUrl>https://raw.github.com/fixie/fixie/master/img/fixie_256.png</PackageIconUrl>
+        <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/fixie/fixie</RepositoryUrl>
         <PackageOutputPath>..\..\packages</PackageOutputPath>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -7,7 +7,7 @@
         <Copyright>Copyright (c) 2013-2019 Patrick Lioi</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://fixie.github.io</PackageProjectUrl>
-        <PackageIconUrl>https://raw.github.com/fixie/fixie/master/img/fixie_256.png</PackageIconUrl>
+        <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/fixie/fixie</RepositoryUrl>
         <PackageOutputPath>..\..\packages</PackageOutputPath>
         <IncludeSymbols>true</IncludeSymbols>

--- a/src/Fixie.Console/Fixie.Console.csproj
+++ b/src/Fixie.Console/Fixie.Console.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <None Include="prefercliruntime" Pack="true" PackagePath="" />
     <None Include="..\..\LICENSE.md" Pack="true" PackagePath="" />
+    <None Include="..\..\img\fixie_256.png" Pack="true" PackagePath="icon.png" />
   </ItemGroup>
 
 </Project>

--- a/src/Fixie/Fixie.nuspec
+++ b/src/Fixie/Fixie.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <projectUrl>https://fixie.github.io</projectUrl>
-    <iconUrl>https://raw.github.com/fixie/fixie/master/img/fixie_256.png</iconUrl>
+    <icon>icon.png</icon>
     <description>$description$</description>
     <copyright>$copyright$</copyright>
     <repository url="https://github.com/fixie/fixie" />
@@ -27,6 +27,7 @@
   </metadata>
   <files>
     <file target="" src="..\..\LICENSE.md" />
+    <file target="icon.png" src="..\..\img\fixie_256.png" />
 
     <!-- Reference Library -->
 


### PR DESCRIPTION
Per Nuget command line warnings and MS documentation (https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-an-icon-image-file), the Nuget package *icon url* elements are to be replaced with *icon* elements which refer to a local file copied into the package.