### PR TITLE
[WIP] Allow constructors to be parameterized like method calls

### DIFF
--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -319,7 +319,7 @@
             => Case<CaseTests>(methodName, parameters);
 
         static Case Case<TTestClass>(string methodName, params object[] parameters)
-            => new Case(typeof(TTestClass).GetInstanceMethod(methodName), parameters);
+            => new Case(typeof(TTestClass).GetInstanceMethod(methodName), parameters, null);
 
         void Returns()
         {

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -176,4 +176,8 @@
             }
         }
     }
+
+    class CtorParameterSourceAttribute : Attribute
+    {
+    }
 }

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -144,7 +144,7 @@
             var testClass = typeof(Generic);
             var caseMethod = testClass.GetInstanceMethod(methodName);
 
-            return new Case(caseMethod, parameters).Method.GetGenericArguments();
+            return new Case(caseMethod, parameters, null).Method.GetGenericArguments();
         }
 
         class Generic

--- a/src/Fixie.Tests/Internal/ParameterDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ParameterDiscovererTests.cs
@@ -75,7 +75,7 @@
 
         class FirstParameterSource : ParameterSource
         {
-            public IEnumerable<object[]> GetParameters(MethodInfo method)
+            public IEnumerable<object[]> GetParameters(MethodBase method)
             {
                 yield return new object[] { method.Name, 0, false };
                 yield return new object[] { method.Name, 1, true };
@@ -84,7 +84,7 @@
 
         class SecondParameterSource : ParameterSource
         {
-            public IEnumerable<object[]> GetParameters(MethodInfo method)
+            public IEnumerable<object[]> GetParameters(MethodBase method)
             {
                 yield return new object[] { method.Name, 2, false };
                 yield return new object[] { method.Name, 3, true };

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -327,8 +327,13 @@
 
         class BuggyParameterSource : ParameterSource
         {
-            public IEnumerable<object[]> GetParameters(MethodInfo method)
+            public IEnumerable<object[]> GetParameters(MethodBase method)
             {
+                if (method is ConstructorInfo)
+                {
+                    return new object[0][];
+                }
+
                 throw new Exception("Exception thrown while attempting to yield input parameters for method: " + method.Name);
             }
         }

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -9,14 +9,15 @@
     /// </summary>
     public class Case
     {
-        public Case(MethodInfo caseMethod, params object[] parameters)
+        public Case(MethodInfo caseMethod, object[] parameters, object[] classParameters)
         {
+            ClassParameters = classParameters;
             Parameters = parameters != null && parameters.Length == 0 ? null : parameters;
             Class = caseMethod.ReflectedType;
 
             Method = caseMethod.TryResolveTypeArguments(parameters);
 
-            Name = CaseNameBuilder.GetName(Class, Method, Parameters);
+            Name = CaseNameBuilder.GetName(Class, Method, Parameters, ClassParameters);
 
             Output = "";
         }
@@ -52,6 +53,12 @@
         /// For zero-argument test methods, this property is null.
         /// </summary>
         public object[] Parameters { get; }
+
+        /// <summary>
+        /// For parameterized test classes, gets the set of parameters used in the constructor.
+        /// For zero-argument constructors, this property is null.
+        /// </summary>
+        public object[] ClassParameters { get; }
 
         /// <summary>
         /// Gets the exception describing this test case's failure.

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -8,9 +8,15 @@
 
     static class CaseNameBuilder
     {
-        public static string GetName(Type testClass, MethodInfo method, object[] parameters)
+        public static string GetName(Type testClass, MethodInfo method, object[] parameters, object[] classParameters)
         {
-            var name = testClass.FullName + "." + method.Name;
+            var name = testClass.FullName;
+            if (classParameters != null && classParameters.Any())
+            {
+                name += $"({string.Join(", ", classParameters.Select(x => x.ToDisplayString()))})";
+            }
+
+            name += "." + method.Name;
 
             if (method.IsGenericMethod)
                 name += $"<{string.Join(", ", method.GetGenericArguments().Select(x => x.IsGenericParameter ? x.Name : x.FullName))}>";

--- a/src/Fixie/Internal/ParameterDiscoverer.cs
+++ b/src/Fixie/Internal/ParameterDiscoverer.cs
@@ -11,7 +11,7 @@
         public ParameterDiscoverer(Discovery discovery)
             => parameterSources = discovery.Config.ParameterSources;
 
-        public IEnumerable<object[]> GetParameters(MethodInfo method)
+        public IEnumerable<object[]> GetParameters(MethodBase method)
             => parameterSources.SelectMany(source => source.GetParameters(method));
     }
 }

--- a/src/Fixie/ParameterSource.cs
+++ b/src/Fixie/ParameterSource.cs
@@ -15,6 +15,6 @@
     /// </summary>
     public interface ParameterSource
     {
-        IEnumerable<object[]> GetParameters(MethodInfo method);
+        IEnumerable<object[]> GetParameters(MethodBase method);
     }
 }

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -11,20 +11,29 @@
     {
         readonly Action<Action<Case>> runCases;
         readonly bool isStatic;
-        internal TestClass(Type type, Action<Action<Case>> runCases) : this(type, runCases, null) { }
-
-        internal TestClass(Type type, Action<Action<Case>> runCases, MethodInfo targetMethod)
+        internal TestClass(Type type, Action<Action<Case>> runCases, ConstructorInfo constructorInfo, object[] constructorParameters) : this(type, runCases, constructorInfo, constructorParameters, null) { }
+        internal TestClass(Type type, Action<Action<Case>> runCases, ConstructorInfo constructorInfo, object[] constructorParameters, MethodInfo targetMethod)
         {
             this.runCases = runCases;
             Type = type;
+            ConstructorInfo = constructorInfo;
             TargetMethod = targetMethod;
             isStatic = Type.IsStatic();
+            ConstructorParameters = constructorParameters;
         }
 
         /// <summary>
         /// The test class to execute.
         /// </summary>
         public Type Type { get; }
+
+        public ConstructorInfo ConstructorInfo { get; }
+
+        /// <summary>
+        /// For parameterized test cases, gets the set of parameters to be passed into the test class.
+        /// For zero-argument test classes, this property is null.
+        /// </summary>
+        public object[] ConstructorParameters { get; }
 
         /// <summary>
         /// Gets the target MethodInfo identified by the
@@ -44,7 +53,12 @@
 
             try
             {
-                return Activator.CreateInstance(Type);
+                if (ConstructorParameters.Length == 0)
+                {
+                    return Activator.CreateInstance(Type);
+                }
+
+                return Activator.CreateInstance(Type, ConstructorParameters);
             }
             catch (TargetInvocationException exception)
             {


### PR DESCRIPTION
A very rough, but POC showing how code like the following could be used

```
class CtorClass
{
    [Input(50, "abc")]
    [Input(100, "def")]
    public ParameterizedTestClassWithParameterizedConstructorTestClass(int a, string b)
    {
    }

    public void ZeroArgs() { }

    public void IntArg(int i)
    {
        if (i != 0)
        throw new Exception("Expected 0, but was " + i);
    }

    [Input(1, 1, 2)]
    [Input(1, 2, 3)]
    [Input(5, 5, 11)]
    public void MultipleCasesFromAttributes(int a, int b, int expectedSum)
    {
        if (a + b != expectedSum)
            throw new Exception($"Expected sum of {expectedSum} but was {a + b}.");
    }
}
```

Which would produce the following result:
```
CtorClass(50, "abc").IntArg(0) passed,
CtorClass(50, "abc").MultipleCasesFromAttributes(1, 1, 2) passed,
CtorClass(50, "abc").MultipleCasesFromAttributes(1, 2, 3) passed,
CtorClass(50, "abc").MultipleCasesFromAttributes(5, 5, 11) failed: Expected sum of 11 but was 10.,
CtorClass(50, "abc").ZeroArgs passed,
CtorClass(100, "def").IntArg(0) passed,
CtorClass(100, "def").MultipleCasesFromAttributes(1, 1, 2) passed,
CtorClass(100, "def").MultipleCasesFromAttributes(1, 2, 3) passed,
CtorClass(100, "def").MultipleCasesFromAttributes(5, 5, 11) failed: Expected sum of 11 but was 10.,
CtorClass(100, "def").ZeroArgs passed
```