### PR TITLE
Azure DevOps API error handling

### DIFF
--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -143,11 +143,6 @@
 
         static IEnumerable<Listener> DefaultExecutionListeners(Options options)
         {
-            if (ShouldUseTeamCityListener())
-                yield return new TeamCityListener();
-            else
-                yield return new ConsoleListener();
-
             if (ShouldUseAzureListener())
                 yield return new AzureListener();
 
@@ -156,6 +151,11 @@
 
             if (options.Report != null)
                 yield return new ReportListener(SaveReport(options));
+
+            if (ShouldUseTeamCityListener())
+                yield return new TeamCityListener();
+            else
+                yield return new ConsoleListener();
         }
 
         static Action<XDocument> SaveReport(Options options)

--- a/src/Fixie/Internal/Bus.cs
+++ b/src/Fixie/Internal/Bus.cs
@@ -1,6 +1,8 @@
 ﻿namespace Fixie.Internal
 {
+    using System;
     using System.Collections.Generic;
+    using Cli;
 
     class Bus
     {
@@ -19,7 +21,22 @@
         public void Publish<TMessage>(TMessage message) where TMessage : Message
         {
             foreach (var listener in listeners)
-                (listener as Handler<TMessage>)?.Handle(message);
+            {
+                try
+                {
+                    (listener as Handler<TMessage>)?.Handle(message);
+                }
+                catch (Exception exception)
+                {
+                    using (Foreground.Yellow)
+                        Console.WriteLine(
+                            $"{listener.GetType().FullName} threw an exception while " +
+                            $"attempting to handle a message of type {typeof(TMessage).FullName}:");
+                    Console.WriteLine();
+                    Console.WriteLine(exception.ToString());
+                    Console.WriteLine();
+                }
+            }
         }
     }
 }

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -150,7 +150,7 @@
 
                 if (!httpResponse.IsSuccessStatusCode)
                 {
-                    Console.WriteLine($"{typeof(AzureListener).FullName} failed to {method} a result: {(int)httpResponse.StatusCode} {httpResponse.ReasonPhrase}");
+                    Console.WriteLine($"{typeof(AzureListener).FullName} failed to {method} a message: {(int)httpResponse.StatusCode} {httpResponse.ReasonPhrase}");
                     Console.WriteLine(body);
                 }
 

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -170,10 +170,11 @@
                 var body = httpResponse.Content.ReadAsStringAsync().Result;
 
                 if (!httpResponse.IsSuccessStatusCode)
-                {
-                    Console.WriteLine($"{typeof(AzureListener).FullName} failed to {method} a message: {(int)httpResponse.StatusCode} {httpResponse.ReasonPhrase}");
-                    Console.WriteLine(body);
-                }
+                    throw new HttpRequestException(new StringBuilder()
+                        .AppendLine($"{typeof(AzureListener).FullName} failed to {method} a message:")
+                        .AppendLine($"{(int) httpResponse.StatusCode} {httpResponse.ReasonPhrase}")
+                        .AppendLine(body)
+                        .ToString());
 
                 return body;
             }

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -151,7 +151,7 @@
 
         void PostBatch()
         {
-            send(client, HttpMethod.Post, $"{runUrl}/results?api-version={AzureDevOpsRestApiVersion}", "application/json", Serialize(batch));
+            send(client, HttpMethod.Post, $"{runUrl}/results?api-version={AzureDevOpsRestApiVersion+Guid.NewGuid()}", "application/json", Serialize(batch));
             batch.Clear();
         }
 

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -160,7 +160,6 @@
                 PostBatch();
         }
 
-        int failuresToSimulate = 0;
         void PostBatch()
         {
             var attempt = 1;
@@ -171,9 +170,7 @@
             {
                 try
                 {
-                    var failureSuffix = attempt <= failuresToSimulate ? Guid.NewGuid().ToString() : "";
-
-                    send(client, HttpMethod.Post, $"{runUrl}/results?api-version={AzureDevOpsRestApiVersion + failureSuffix}", "application/json", Serialize(batch));
+                    send(client, HttpMethod.Post, $"{runUrl}/results?api-version={AzureDevOpsRestApiVersion}", "application/json", Serialize(batch));
                     batch.Clear();
 
                     if (attempt > 1)
@@ -181,8 +178,6 @@
                         WriteLine($"Successfully submitted test result batch to Azure DevOps API on attempt #{attempt}.");
                         WriteLine();
                     }
-
-                    failuresToSimulate++;
 
                     return;
                 }


### PR DESCRIPTION
We have had reports of sporadic failures when communicating with the Azure DevOps API. These exceptions were poorly handled, causing the entire test run to crash.

This first improves system stability for _all_ test result event listeners including the `AzureListener` so that any exception thrown reporting an event to a sink will log to the console and proceed with the remainder of the test run. In other words, plain console reporting continues and is complete, while a buggy or otherwise problematic reporting sink no longer causes the run to crash.

Specifically for Azure DevOps, we are now also mitigating the risks of these API calls failing in the first place:

1. As the API intends, we now submit test results in batches rather than one whole round trip per test case, in the hopes that the sporadic failures were a matter of overwhelming the API with overly chatty requests. At a minimum, this should help with performance during successful attempts.
2. In the event of failed requests, we enter a retry loop for a fixed number of attempts. After each attempt, we sleep for a brief cool down period.
3. If we eventually succeed during one of these retries, we proceed under the assumption that the API is in fact available.
4. If, instead, we ever reach our limit of retries, we consider the API to be unavailable for the remainder of the test run. We do so because we can safely assume that, whatever the problem, it will continue to happen for every test result batch from here onward, and the retry cool-down period would result in extremely long run times with no benefit.
5. Even in the catastrophic case that the API is considered unavailable, **all tests run with full results in the console output and with the usual process exit code**, so no information is lost. The Azure DevOps "Tests" summary, though, would appear incomplete.