### PR TITLE
Listener Factory Methods

### DIFF
--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -147,8 +147,8 @@
             if (Try(AppVeyorListener.Create, out var appVeyor))
                 yield return appVeyor;
 
-            if (options.Report != null)
-                yield return new ReportListener(SaveReport(options));
+            if (Try(() => ReportListener.Create(options), out var report))
+                yield return report;
 
             if (ShouldUseTeamCityListener())
                 yield return new TeamCityListener();
@@ -161,16 +161,6 @@
             listener = create();
 
             return listener != null;
-        }
-
-        static Action<XDocument> SaveReport(Options options)
-        {
-            return report => ReportListener.Save(report, FullPath(options.Report));
-        }
-
-        static string FullPath(string absoluteOrRelativePath)
-        {
-            return Path.Combine(Directory.GetCurrentDirectory(), absoluteOrRelativePath);
         }
 
         static bool ShouldUseTeamCityListener()

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -156,7 +156,7 @@
                 yield return new ConsoleListener();
         }
 
-        static bool Try<T>(Func<T> create, out T listener)
+        static bool Try<T>(Func<T> create, out T? listener)
         {
             listener = create();
 

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -141,8 +141,8 @@
 
         static IEnumerable<Listener> DefaultExecutionListeners(Options options)
         {
-            if (ShouldUseAzureListener())
-                yield return new AzureListener();
+            if (TryCreate(out AzureListener azure))
+                yield return azure;
 
             if (ShouldUseAppVeyorListener())
                 yield return new AppVeyorListener();
@@ -156,6 +156,13 @@
                 yield return new ConsoleListener();
         }
 
+        static bool TryCreate(out AzureListener listener)
+        {
+            listener = AzureListener.Create();
+
+            return listener != null;
+        }
+
         static Action<XDocument> SaveReport(Options options)
         {
             return report => ReportListener.Save(report, FullPath(options.Report));
@@ -164,36 +171,6 @@
         static string FullPath(string absoluteOrRelativePath)
         {
             return Path.Combine(Directory.GetCurrentDirectory(), absoluteOrRelativePath);
-        }
-
-        static bool ShouldUseAzureListener()
-        {
-            var runningUnderAzure = Environment.GetEnvironmentVariable("TF_BUILD") == "True";
-
-            if (runningUnderAzure)
-            {
-                var accessTokenIsAvailable =
-                    !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN"));
-
-                if (accessTokenIsAvailable)
-                    return true;
-
-                using (Foreground.Yellow)
-                {
-                    WriteLine("The Azure DevOps access token has not been made available to this process, so");
-                    WriteLine("test results will not be collected. To resolve this issue, review your pipeline");
-                    WriteLine("definition to ensure that the access token is made available as the environment");
-                    WriteLine("variable SYSTEM_ACCESSTOKEN.");
-                    WriteLine();
-                    WriteLine("From https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#systemaccesstoken");
-                    WriteLine();
-                    WriteLine("  env:");
-                    WriteLine("    SYSTEM_ACCESSTOKEN: $(System.AccessToken)");
-                    WriteLine();
-                }
-            }
-
-            return false;
         }
 
         static bool ShouldUseTeamCityListener()

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -144,8 +144,8 @@
             if (TryCreate(out AzureListener azure))
                 yield return azure;
 
-            if (ShouldUseAppVeyorListener())
-                yield return new AppVeyorListener();
+            if (TryCreate(out AppVeyorListener appVeyor))
+                yield return appVeyor;
 
             if (options.Report != null)
                 yield return new ReportListener(SaveReport(options));
@@ -163,6 +163,13 @@
             return listener != null;
         }
 
+        static bool TryCreate(out AppVeyorListener listener)
+        {
+            listener = AppVeyorListener.Create();
+
+            return listener != null;
+        }
+
         static Action<XDocument> SaveReport(Options options)
         {
             return report => ReportListener.Save(report, FullPath(options.Report));
@@ -176,11 +183,6 @@
         static bool ShouldUseTeamCityListener()
         {
             return Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null;
-        }
-
-        static bool ShouldUseAppVeyorListener()
-        {
-            return Environment.GetEnvironmentVariable("APPVEYOR") == "True";
         }
     }
 }

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -141,10 +141,10 @@
 
         static IEnumerable<Listener> DefaultExecutionListeners(Options options)
         {
-            if (TryCreate(out AzureListener azure))
+            if (Try(AzureListener.Create, out var azure))
                 yield return azure;
 
-            if (TryCreate(out AppVeyorListener appVeyor))
+            if (Try(AppVeyorListener.Create, out var appVeyor))
                 yield return appVeyor;
 
             if (options.Report != null)
@@ -156,16 +156,9 @@
                 yield return new ConsoleListener();
         }
 
-        static bool TryCreate(out AzureListener listener)
+        static bool Try<T>(Func<T> create, out T listener)
         {
-            listener = AzureListener.Create();
-
-            return listener != null;
-        }
-
-        static bool TryCreate(out AppVeyorListener listener)
-        {
-            listener = AppVeyorListener.Create();
+            listener = create();
 
             return listener != null;
         }

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -2,11 +2,10 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO.Pipes;
     using System.Linq;
     using System.Reflection;
-    using System.Xml.Linq;
     using Cli;
     using Listeners;
     using static System.Console;
@@ -156,7 +155,7 @@
                 yield return new ConsoleListener();
         }
 
-        static bool Try<T>(Func<T> create, out T? listener)
+        static bool Try<T>(Func<T?> create, [NotNullWhen(true)] out T? listener) where T : class
         {
             listener = create();
 

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -150,8 +150,8 @@
             if (Try(() => ReportListener.Create(options), out var report))
                 yield return report;
 
-            if (ShouldUseTeamCityListener())
-                yield return new TeamCityListener();
+            if (Try(TeamCityListener.Create, out var teamCity))
+                yield return teamCity;
             else
                 yield return new ConsoleListener();
         }
@@ -161,11 +161,6 @@
             listener = create();
 
             return listener != null;
-        }
-
-        static bool ShouldUseTeamCityListener()
-        {
-            return Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null;
         }
     }
 }

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -11,7 +11,7 @@
     using static System.Environment;
     using static Serialization;
 
-    public class AppVeyorListener :
+    class AppVeyorListener :
         Handler<AssemblyStarted>,
         Handler<CaseSkipped>,
         Handler<CasePassed>,

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -25,6 +25,14 @@
 
         static readonly HttpClient Client;
 
+        internal static AppVeyorListener Create()
+        {
+            if (GetEnvironmentVariable("APPVEYOR") == "True")
+                return new AppVeyorListener();
+
+            return null;
+        }
+
         static AppVeyorListener()
         {
             Client = new HttpClient();

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -25,7 +25,7 @@
 
         static readonly HttpClient Client;
 
-        internal static AppVeyorListener Create()
+        internal static AppVeyorListener? Create()
         {
             if (GetEnvironmentVariable("APPVEYOR") == "True")
                 return new AppVeyorListener();

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -39,7 +39,7 @@
         readonly List<Result> batch;
         bool apiUnavailable;
 
-        internal static AzureListener Create()
+        internal static AzureListener? Create()
         {
             if (ShouldUseAzureListener())
                 return new AzureListener();

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -15,7 +15,7 @@
     using static Serialization;
     using static System.Console;
 
-    public class AzureListener :
+    class AzureListener :
         Handler<AssemblyStarted>,
         Handler<CaseSkipped>,
         Handler<CasePassed>,

--- a/src/Fixie/Internal/Listeners/ConsoleListener.cs
+++ b/src/Fixie/Internal/Listeners/ConsoleListener.cs
@@ -5,7 +5,7 @@
     using Cli;
     using Internal;
 
-    public class ConsoleListener :
+    class ConsoleListener :
         Handler<CaseSkipped>,
         Handler<CaseFailed>,
         Handler<AssemblyCompleted>

--- a/src/Fixie/Internal/Listeners/PipeListener.cs
+++ b/src/Fixie/Internal/Listeners/PipeListener.cs
@@ -4,7 +4,7 @@
     using System.IO.Pipes;
     using Internal;
 
-    public class PipeListener :
+    class PipeListener :
         Handler<MethodDiscovered>,
         Handler<CaseStarted>,
         Handler<CaseSkipped>,

--- a/src/Fixie/Internal/Listeners/ReportListener.cs
+++ b/src/Fixie/Internal/Listeners/ReportListener.cs
@@ -6,7 +6,7 @@
     using System.IO;
     using System.Xml.Linq;
 
-    public class ReportListener :
+    class ReportListener :
         Handler<CaseSkipped>,
         Handler<CasePassed>,
         Handler<CaseFailed>,

--- a/src/Fixie/Internal/Listeners/ReportListener.cs
+++ b/src/Fixie/Internal/Listeners/ReportListener.cs
@@ -18,7 +18,7 @@
         List<XElement> currentClass = new List<XElement>();
         List<XElement> classes = new List<XElement>();
 
-        internal static ReportListener Create(Options options)
+        internal static ReportListener? Create(Options options)
         {
             if (options.Report != null)
                 return new ReportListener(SaveReport(options));

--- a/src/Fixie/Internal/Listeners/ReportListener.cs
+++ b/src/Fixie/Internal/Listeners/ReportListener.cs
@@ -18,6 +18,24 @@
         List<XElement> currentClass = new List<XElement>();
         List<XElement> classes = new List<XElement>();
 
+        internal static ReportListener Create(Options options)
+        {
+            if (options.Report != null)
+                return new ReportListener(SaveReport(options));
+
+            return null;
+        }
+
+        static Action<XDocument> SaveReport(Options options)
+        {
+            return report => Save(report, FullPath(options.Report));
+        }
+
+        static string FullPath(string absoluteOrRelativePath)
+        {
+            return Path.Combine(Directory.GetCurrentDirectory(), absoluteOrRelativePath);
+        }
+
         public ReportListener(Action<XDocument> save)
         {
             this.save = save;

--- a/src/Fixie/Internal/Listeners/TeamCityListener.cs
+++ b/src/Fixie/Internal/Listeners/TeamCityListener.cs
@@ -13,6 +13,14 @@
         Handler<CaseFailed>,
         Handler<AssemblyCompleted>
     {
+        internal static TeamCityListener Create()
+        {
+            if (GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null)
+                return new TeamCityListener();
+
+            return null;
+        }
+
         public void Handle(AssemblyStarted message)
         {
             Message("testSuiteStarted name='{0}'", message.Assembly.GetName().Name);

--- a/src/Fixie/Internal/Listeners/TeamCityListener.cs
+++ b/src/Fixie/Internal/Listeners/TeamCityListener.cs
@@ -13,7 +13,7 @@
         Handler<CaseFailed>,
         Handler<AssemblyCompleted>
     {
-        internal static TeamCityListener Create()
+        internal static TeamCityListener? Create()
         {
             if (GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null)
                 return new TeamCityListener();

--- a/src/Fixie/Internal/Listeners/TeamCityListener.cs
+++ b/src/Fixie/Internal/Listeners/TeamCityListener.cs
@@ -6,7 +6,7 @@
     using Internal;
     using static System.Environment;
 
-    public class TeamCityListener :
+    class TeamCityListener :
         Handler<AssemblyStarted>,
         Handler<CaseSkipped>,
         Handler<CasePassed>,


### PR DESCRIPTION
While applying the "Nullable Reference Types" feature to the Solution, some of the warnings suggested a design improvement at the point where we conditionally construct and enlist our many `Listener` types.

Here, we focus on refactoring to a Factory Method pattern to consolidate the knowledge of each third-party reporting sink, and address only those Nullable Reference Type warnings introduced by the refactoring.