### PR TITLE
Enable Nullable Reference Types

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -28,6 +28,7 @@ function Build {
         <PackageOutputPath>..\..\packages</PackageOutputPath>
         <IncludeSymbols>true</IncludeSymbols>
         <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 </Project>
 "@

--- a/build.ps1
+++ b/build.ps1
@@ -29,6 +29,7 @@ function Build {
         <IncludeSymbols>true</IncludeSymbols>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>
 "@

--- a/build/Fixie.Program.cs
+++ b/build/Fixie.Program.cs
@@ -6,6 +6,6 @@
     class Program
     {
         [STAThread]
-        static int Main(string[] arguments) => AssemblyRunner.Main(arguments);
+        static int Main(string[] arguments) => AssemblyRunner.Main(typeof(Program).Assembly, arguments);
     }
 }

--- a/build/Fixie.Program.fs
+++ b/build/Fixie.Program.fs
@@ -5,4 +5,4 @@ open Fixie.Internal
 
 [<STAThread; EntryPoint>]
 let main arguments =
-    AssemblyRunner.Main(arguments)
+    AssemblyRunner.Main(typeof<Program>.Assembly, arguments)

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -13,5 +13,6 @@
         <IncludeSymbols>true</IncludeSymbols>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -12,5 +12,6 @@
         <PackageOutputPath>..\..\packages</PackageOutputPath>
         <IncludeSymbols>true</IncludeSymbols>
         <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 </Project>

--- a/src/Fixie.Cli/NamedArgument.cs
+++ b/src/Fixie.Cli/NamedArgument.cs
@@ -10,19 +10,19 @@ namespace Fixie.Cli
             IsArray = type.IsArray;
 
             ItemType = IsArray
-                ? type.GetElementType()
+                ? type.GetElementType()!
                 : type;
 
             Identifier = identifier;
             Name = Normalize(Identifier);
-            Values = new List<object>();
+            Values = new List<object?>();
         }
 
         public bool IsArray { get; }
         public Type ItemType { get; }
         public string Identifier { get; }
         public string Name { get; }
-        public List<object> Values { get; }
+        public List<object?> Values { get; }
 
         public static string Normalize(string namedArgumentKey)
             => namedArgumentKey.ToLower().Replace("-", "");

--- a/src/Fixie.Cli/Parser.cs
+++ b/src/Fixie.Cli/Parser.cs
@@ -18,7 +18,7 @@
             var positionalArguments = ScanPositionalArguments(type);
             var namedArguments = ScanNamedArguments(type);
 
-            var paramsPositionalArgumentValues = new List<object>();
+            var paramsPositionalArgumentValues = new List<object?>();
 
             var queue = new Queue<string>(arguments);
             while (queue.Any())
@@ -74,7 +74,7 @@
             foreach (var positionalArgument in positionalArguments)
             {
                 //Bind all of paramsPositionalArgumentValues to this argument.
-                var itemType = positionalArgument.Type.GetElementType();
+                var itemType = positionalArgument.Type.GetElementType()!;
 
                 paramsPositionalArgumentValues =
                     paramsPositionalArgumentValues
@@ -87,7 +87,7 @@
             Model = Create(type, positionalArguments, namedArguments);
         }
 
-        static object Convert(Type type, string userFacingName, object value)
+        static object? Convert(Type type, string userFacingName, object? value)
         {
             if (type == typeof(bool?) || type == typeof(bool))
             {
@@ -158,7 +158,7 @@
                 GetConstructor(type)
                 .GetParameters()
                 .Where(p => p.GetCustomAttribute<ParamArrayAttribute>() == null)
-                .Select(p => new NamedArgument(p.ParameterType, p.Name))
+                .Select(p => new NamedArgument(p.ParameterType, p.Name!))
                 .ToArray();
 
             var dictionary = new Dictionary<string, NamedArgument>();
@@ -183,7 +183,7 @@
 
             var declaredParameters = constructor.GetParameters();
 
-            var actualParameters = new List<object>();
+            var actualParameters = new List<object?>();
 
             foreach (var declaredParameter in declaredParameters)
             {
@@ -191,7 +191,7 @@
 
                 if (named)
                 {
-                    var key = NamedArgument.Normalize(declaredParameter.Name);
+                    var key = NamedArgument.Normalize(declaredParameter.Name!);
 
                     var namedArgument = namedArguments[key];
 
@@ -211,7 +211,7 @@
             return constructor.Invoke(actualParameters.ToArray());
         }
 
-        static object Default(Type type)
+        static object? Default(Type type)
             => type.IsValueType ? Activator.CreateInstance(type) : null;
 
         static ConstructorInfo GetConstructor(Type type)
@@ -220,7 +220,7 @@
         static bool IsNamedArgumentKey(string item)
             => item.StartsWith("--");
 
-        static Array CreateTypedArray(Type itemType, IReadOnlyList<object> values)
+        static Array CreateTypedArray(Type itemType, IReadOnlyList<object?> values)
         {
             Array destinationArray = Array.CreateInstance(itemType, values.Count);
             Array.Copy(values.ToArray(), destinationArray, values.Count);

--- a/src/Fixie.Cli/PositionalArgument.cs
+++ b/src/Fixie.Cli/PositionalArgument.cs
@@ -8,11 +8,11 @@
         public PositionalArgument(ParameterInfo parameter)
         {
             Type = parameter.ParameterType;
-            Name = parameter.Name;
+            Name = parameter.Name!;
         }
 
         public Type Type { get; }
         public string Name { get; }
-        public object Value { get; set; }
+        public object? Value { get; set; }
     }
 }

--- a/src/Fixie.Console/Options.cs
+++ b/src/Fixie.Console/Options.cs
@@ -3,10 +3,10 @@
     public class Options
     {
         public Options(
-            string configuration,
+            string? configuration,
             bool noBuild,
-            string framework,
-            string report)
+            string? framework,
+            string? report)
         {
             Configuration = configuration ?? "Debug";
             NoBuild = noBuild;
@@ -17,7 +17,7 @@
         public string Configuration { get; }
         public bool NoBuild { get; }
         public bool ShouldBuild => !NoBuild;
-        public string Framework { get; }
-        public string Report { get; }
+        public string? Framework { get; }
+        public string? Report { get; }
     }
 }

--- a/src/Fixie.Console/Shell.cs
+++ b/src/Fixie.Console/Shell.cs
@@ -47,7 +47,7 @@
             }
         }
 
-        static int MsBuild(string project, string target, string configuration = null, string targetFramework = null, string outputPath = null)
+        static int MsBuild(string project, string target, string? configuration = null, string? targetFramework = null, string? outputPath = null)
         {
             var arguments = new List<string>
             {

--- a/src/Fixie.TestAdapter/DiscoveryRecorder.cs
+++ b/src/Fixie.TestAdapter/DiscoveryRecorder.cs
@@ -26,7 +26,7 @@
         {
             var test = testDiscovered.Test;
 
-            SourceLocation sourceLocation = null;
+            SourceLocation? sourceLocation = null;
 
             try
             {

--- a/src/Fixie.TestAdapter/ExecutionRecorder.cs
+++ b/src/Fixie.TestAdapter/ExecutionRecorder.cs
@@ -53,7 +53,7 @@
             });
         }
 
-        void Record(PipeMessage.CaseCompleted result, Action<TestResult> customize = null)
+        void Record(PipeMessage.CaseCompleted result, Action<TestResult> customize)
         {
             var testCase = ToVsTestCase(result.Test);
 
@@ -64,7 +64,7 @@
                 ComputerName = MachineName
             };
 
-            customize?.Invoke(testResult);
+            customize(testResult);
 
             AttachCapturedConsoleOutput(result.Output, testResult);
 

--- a/src/Fixie.TestAdapter/RunnerException.cs
+++ b/src/Fixie.TestAdapter/RunnerException.cs
@@ -24,7 +24,7 @@
                 .AppendLine()
                 .AppendLine(exception.Message)
                 .AppendLine()
-                .AppendLine(exception.TypeName())
+                .AppendLine(exception.GetType().FullName)
                 .AppendLine(exception.StackTrace)
                 .ToString())
         {

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -21,13 +21,13 @@ namespace Fixie.TestAdapter
             if (fixieAssemblies.Contains(Path.GetFileName(assemblyPath)))
                 return false;
 
-            return File.Exists(Path.Combine(Path.GetDirectoryName(assemblyPath), "Fixie.dll"));
+            return File.Exists(Path.Combine(Path.GetDirectoryName(assemblyPath)!, "Fixie.dll"));
         }
 
         public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle = null)
         {
             var assemblyFullPath = Path.GetFullPath(assemblyPath);
-            var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath);
+            var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath)!;
 
             return Start(frameworkHandle, assemblyDirectory, assemblyPath);
         }

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -24,7 +24,7 @@ namespace Fixie.TestAdapter
             return File.Exists(Path.Combine(Path.GetDirectoryName(assemblyPath), "Fixie.dll"));
         }
 
-        public static Process? Start(string assemblyPath, IFrameworkHandle frameworkHandle = null)
+        public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle = null)
         {
             var assemblyFullPath = Path.GetFullPath(assemblyPath);
             var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath);
@@ -40,7 +40,7 @@ namespace Fixie.TestAdapter
             return null;
         }
 
-        static Process? Start(IFrameworkHandle frameworkHandle, string workingDirectory, string assemblyPath)
+        static Process? Start(IFrameworkHandle? frameworkHandle, string workingDirectory, string assemblyPath)
         {
             var serializedArguments = CommandLine.Serialize(new[] { assemblyPath });
 

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -55,7 +55,7 @@ namespace Fixie.TestAdapter
 
                 var environmentVariables = new Dictionary<string, string>
                 {
-                    ["FIXIE_NAMED_PIPE"] = Environment.GetEnvironmentVariable("FIXIE_NAMED_PIPE")
+                    ["FIXIE_NAMED_PIPE"] = Environment.GetEnvironmentVariable("FIXIE_NAMED_PIPE")!
                 };
 
                 frameworkHandle?

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -24,7 +24,7 @@ namespace Fixie.TestAdapter
             return File.Exists(Path.Combine(Path.GetDirectoryName(assemblyPath), "Fixie.dll"));
         }
 
-        public static Process Start(string assemblyPath, IFrameworkHandle frameworkHandle = null)
+        public static Process? Start(string assemblyPath, IFrameworkHandle frameworkHandle = null)
         {
             var assemblyFullPath = Path.GetFullPath(assemblyPath);
             var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath);
@@ -32,7 +32,7 @@ namespace Fixie.TestAdapter
             return Start(frameworkHandle, assemblyDirectory, assemblyPath);
         }
 
-        public static int? TryGetExitCode(this Process process)
+        public static int? TryGetExitCode(this Process? process)
         {
             if (process != null && process.WaitForExit(5000))
                 return process.ExitCode;
@@ -40,7 +40,7 @@ namespace Fixie.TestAdapter
             return null;
         }
 
-        static Process Start(IFrameworkHandle frameworkHandle, string workingDirectory, string assemblyPath)
+        static Process? Start(IFrameworkHandle frameworkHandle, string workingDirectory, string assemblyPath)
         {
             var serializedArguments = CommandLine.Serialize(new[] { assemblyPath });
 

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -29,10 +29,7 @@
 
                 HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
 
-                var runAllTests = new PipeMessage.ExecuteTests
-                {
-                    Filter = new PipeMessage.Test[] { }
-                };
+                var runAllTests = new PipeMessage.ExecuteTests();
 
                 foreach (var assemblyPath in sources)
                     RunTests(log, frameworkHandle, assemblyPath, pipe => pipe.Send(runAllTests));
@@ -64,20 +61,14 @@
 
                     RunTests(log, frameworkHandle, assemblyPath, pipe =>
                     {
-                        pipe.Send(new PipeMessage.ExecuteTests
-                        {
-                            Filter = assemblyGroup.Select(x =>
+                        pipe.Send(new PipeMessage.ExecuteTests(
+                            assemblyGroup.Select(x =>
                             {
                                 var test = new Test(x.FullyQualifiedName);
 
-                                return new PipeMessage.Test
-                                {
-                                    Class = test.Class,
-                                    Method = test.Method,
-                                    Name = test.Name
-                                };
+                                return new PipeMessage.Test(test);
                             }).ToArray()
-                        });
+                        ));
                     });
                 }
             }
@@ -158,14 +149,9 @@
                         var exception = new TestProcessExitException(process.TryGetExitCode());
 
                         if (lastCaseStarted != null)
-                        {
-                            recorder.Record(new PipeMessage.CaseFailed
-                            {
-                                Test = lastCaseStarted.Test,
-                                Name = lastCaseStarted.Name,
-                                Exception = new PipeMessage.Exception(exception)
-                            });
-                        }
+                            recorder.Record(
+                                new PipeMessage.CaseFailed(lastCaseStarted,
+                                    new PipeMessage.Exception(exception)));
 
                         throw exception;
                     }

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -111,7 +111,7 @@
 
                 var recorder = new ExecutionRecorder(frameworkHandle, assemblyPath);
 
-                PipeMessage.CaseStarted lastCaseStarted = null;
+                PipeMessage.CaseStarted? lastCaseStarted = null;
 
                 while (true)
                 {

--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -14,12 +14,12 @@ namespace Fixie.Tests.Assertions
         {
         }
 
-        public AssertException(object expected, object actual, string userMessage = null)
+        public AssertException(object? expected, object? actual, string? userMessage = null)
             : base(ExpectationMessage(expected, actual, userMessage))
         {
         }
 
-        static string ExpectationMessage(object expected, object actual, string userMessage)
+        static string ExpectationMessage(object? expected, object? actual, string? userMessage)
         {
             var message = new StringBuilder();
 
@@ -47,7 +47,7 @@ namespace Fixie.Tests.Assertions
             return message.ToString();
         }
 
-        static string ConvertToString(object value)
+        static string? ConvertToString(object value)
         {
             if (value is Array valueArray)
             {
@@ -66,9 +66,9 @@ namespace Fixie.Tests.Assertions
         static string FormatMultiLine(string value)
             => value.Replace(NewLine, NewLine + "          ");
 
-        public override string StackTrace => FilterStackTrace(base.StackTrace);
+        public override string? StackTrace => FilterStackTrace(base.StackTrace);
 
-        static string FilterStackTrace(string stackTrace)
+        static string? FilterStackTrace(string? stackTrace)
         {
             if (stackTrace == null)
                 return null;
@@ -82,12 +82,12 @@ namespace Fixie.Tests.Assertions
                     results.Add(line);
             }
 
-            return string.Join(Environment.NewLine, results.ToArray());
+            return string.Join(NewLine, results.ToArray());
         }
 
         static string[] Lines(string input)
         {
-            return input.Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+            return input.Split(new[] {NewLine}, StringSplitOptions.None);
         }
     }
 }

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -65,7 +65,7 @@ namespace Fixie.Tests.Assertions
                 throw new AssertException(expected, actual);
         }
 
-        public static void ShouldBe<T>(this T actual, T expected, string userMessage = null)
+        public static void ShouldBe<T>(this T actual, T expected, string? userMessage = null)
         {
             if (!expected.Is(actual))
                 throw new AssertException(expected, actual, userMessage);
@@ -83,30 +83,25 @@ namespace Fixie.Tests.Assertions
                 throw new AssertException("Collection was not empty.");
         }
 
-        static string Format(object value)
+        static string Format(object? value)
         {
             return value?.ToString() ?? "(null)";
         }
 
         public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage) where TException : Exception
         {
-            bool threw = false;
-            Exception exception = null;
-
             try
             {
                 shouldThrow();
             }
             catch (Exception actual)
             {
-                threw = true;
                 actual.ShouldBeType<TException>();
                 actual.Message.ShouldBe(expectedMessage);
-                exception = actual;
+                return (TException)actual;
             }
 
-            threw.ShouldBe(true);
-            return (TException)exception;
+            throw new AssertException("Expected an exception to be thrown.");
         }
 
         static bool Is<T>(this T x, T y)

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -74,12 +74,6 @@ namespace Fixie.Tests.Assertions
                 throw new AssertException(expected, actual, userMessage);
         }
 
-        public static void ShouldNotBe<T>(this T actual, T expected)
-        {
-            if (expected.Is(actual))
-                throw new AssertException($"Unexpected: {Format(expected)}");
-        }
-
         public static void ShouldBeEmpty<T>(this IEnumerable<T> collection)
         {
             if (collection.Any())

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -37,9 +37,12 @@ namespace Fixie.Tests.Assertions
             return $"Expected: {Format(left)} {operation} {Format(right)}{NewLine}but it was not";
         }
 
-        public static void ShouldBeType<T>(this object actual)
+        public static T ShouldBe<T>(this object? actual)
         {
-            (actual?.GetType()).ShouldBe(typeof(T));
+            if (actual is T typed)
+                return typed;
+
+            throw new AssertException(typeof(T), actual?.GetType());
         }
 
         public static void ShouldBe<T>(this IEnumerable<T> actual, params T[] expected)
@@ -96,8 +99,9 @@ namespace Fixie.Tests.Assertions
             }
             catch (Exception actual)
             {
-                actual.ShouldBeType<TException>();
-                actual.Message.ShouldBe(expectedMessage);
+                actual
+                    .ShouldBe<TException>()
+                    .Message.ShouldBe(expectedMessage);
                 return (TException)actual;
             }
 

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -59,7 +59,7 @@ namespace Fixie.Tests.Assertions
                 throw new AssertException(expected, actual);
         }
 
-        public static void ShouldBe(this string actual, string expected)
+        public static void ShouldBe(this string? actual, string? expected)
         {
             if (actual != expected)
                 throw new AssertException(expected, actual);

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -47,28 +47,22 @@ namespace Fixie.Tests.Assertions
             actual.ToArray().ShouldBe(expected);
         }
 
-        public static void ShouldBe(this bool actual, bool expected, string userMessage = null)
+        public static void ShouldBe(this bool actual, bool expected)
         {
             if (actual != expected)
-                throw new AssertException(expected, actual, userMessage);
+                throw new AssertException(expected, actual);
         }
 
-        public static void ShouldBe(this int actual, int expected, string userMessage = null)
+        public static void ShouldBe(this int actual, int expected)
         {
             if (actual != expected)
-                throw new AssertException(expected, actual, userMessage);
+                throw new AssertException(expected, actual);
         }
 
-        public static void ShouldBe(this string actual, string expected, string userMessage = null)
+        public static void ShouldBe(this string actual, string expected)
         {
             if (actual != expected)
-                throw new AssertException(expected, actual, userMessage);
-        }
-
-        public static void ShouldBe<T>(this T? actual, T? expected, string userMessage = null) where T : struct
-        {
-            if (!Nullable.Equals(actual, expected))
-                throw new AssertException(expected, actual, userMessage);
+                throw new AssertException(expected, actual);
         }
 
         public static void ShouldBe<T>(this T actual, T expected, string userMessage = null)

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -225,8 +225,9 @@
             @case.Exception.ShouldBe(null);
             @case.Fail("Failure Reason A");
             @case.Fail("Failure Reason B");
-            @case.Exception.ShouldBeType<Exception>();
-            @case.Exception.Message.ShouldBe("Failure Reason B");
+            @case.Exception
+                .ShouldBe<Exception>()
+                .Message.ShouldBe("Failure Reason B");
         }
 
         public void ShouldProtectAgainstLoggingNullExceptions()
@@ -235,10 +236,11 @@
 
             @case.Exception.ShouldBe(null);
             @case.Fail((Exception) null);
-            @case.Exception.ShouldBeType<Exception>();
-            @case.Exception.Message.ShouldBe(
-                "The custom test class lifecycle did not provide " +
-                "an Exception for this test case failure.");
+            @case.Exception
+                .ShouldBe<Exception>()
+                .Message.ShouldBe(
+                    "The custom test class lifecycle did not provide " +
+                    "an Exception for this test case failure.");
         }
 
         public void CanForceAnyTestProcessingState()

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -235,7 +235,7 @@
             var @case = Case("Returns");
 
             @case.Exception.ShouldBe(null);
-            @case.Fail((Exception) null);
+            @case.Fail((Exception) null!);
             @case.Exception
                 .ShouldBe<Exception>()
                 .Message.ShouldBe(

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -261,7 +261,7 @@
             //Indicate a failure, replacing the assumed skip.
             @case.Fail("Failure");
             @case.State.ShouldBe(CaseState.Failed);
-            @case.Exception.Message.ShouldBe("Failure");
+            (@case.Exception?.Message).ShouldBe("Failure");
             @case.SkipReason.ShouldBe(null);
 
             //Indicate a pass, suppressing the above failure.
@@ -285,7 +285,7 @@
             //Indicate a failure, replacing the assumed pass.
             @case.Fail("Failure");
             @case.State.ShouldBe(CaseState.Failed);
-            @case.Exception.Message.ShouldBe("Failure");
+            (@case.Exception?.Message).ShouldBe("Failure");
             @case.SkipReason.ShouldBe(null);
 
             //Indicate a skip, suppressing the above failure.
@@ -295,9 +295,9 @@
             @case.SkipReason.ShouldBe("Reason");
 
             //Indicate a failure, suppressing the above skip, but with a surprisingly-null Exception.
-            @case.Fail((Exception) null);
+            @case.Fail((Exception) null!);
             @case.State.ShouldBe(CaseState.Failed);
-            @case.Exception.Message.ShouldBe(
+            (@case.Exception?.Message).ShouldBe(
                 "The custom test class lifecycle did not provide " +
                 "an Exception for this test case failure.");
             @case.SkipReason.ShouldBe(null);

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -315,10 +315,10 @@
             }
         }
 
-        static Case Case(string methodName, params object[] parameters)
+        static Case Case(string methodName, params object?[] parameters)
             => Case<CaseTests>(methodName, parameters);
 
-        static Case Case<TTestClass>(string methodName, params object[] parameters)
+        static Case Case<TTestClass>(string methodName, params object?[] parameters)
             => new Case(typeof(TTestClass).GetInstanceMethod(methodName), parameters);
 
         void Returns()

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -15,9 +15,9 @@
 
         public void ShouldIncludeParameterValuesInNameWhenTheUnderlyingMethodHasParameters()
         {
-            var @case = Case("Parameterized", 123, true, 'a', "with \"quotes\"", "long \"string\" gets truncated", null, this);
+            var @case = Case("Parameterized", 123, true, 'a', "with \"quotes\"", "long \"string\" gets truncated", null, this, new ObjectWithNullStringRepresentation());
 
-            @case.Name.ShouldBe("Fixie.Tests.CaseTests.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseTests)");
+            @case.Name.ShouldBe("Fixie.Tests.CaseTests.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseTests, Fixie.Tests.CaseTests+ObjectWithNullStringRepresentation)");
         }
 
         public void ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()
@@ -159,7 +159,7 @@
             method.Name.ShouldBe("Returns");
             method.GetParameters().ShouldBeEmpty();
 
-            method = Case("Parameterized", 123, true, 'a', "s", null, this).Method;
+            method = Case("Parameterized", 123, true, 'a', "s", null, this, new ObjectWithNullStringRepresentation()).Method;
             method.Name.ShouldBe("Parameterized");
             method.GetParameters()
                 .Select(x => x.ParameterType)
@@ -167,7 +167,8 @@
                     typeof(int), typeof(bool),
                     typeof(char), typeof(string),
                     typeof(string), typeof(object),
-                    typeof(CaseTests));
+                    typeof(CaseTests),
+                    typeof(ObjectWithNullStringRepresentation));
 
             method = Case("Generic", 123, true, "a", "b").Method;
             method.Name.ShouldBe("Generic");
@@ -332,7 +333,7 @@
             throw new FailureException();
         }
 
-        void Parameterized(int i, bool b, char ch, string s1, string s2, object obj, CaseTests complex)
+        void Parameterized(int i, bool b, char ch, string s1, string s2, object obj, CaseTests complex, ObjectWithNullStringRepresentation nullStringRepresentation)
         {
         }
 
@@ -350,6 +351,11 @@
 
         void ConstrainedGeneric<T>(T t) where T : struct
         {
+        }
+
+        class ObjectWithNullStringRepresentation
+        {
+            public override string? ToString() => null;
         }
     }
 }

--- a/src/Fixie.Tests/Cases/AsyncCaseTests.cs
+++ b/src/Fixie.Tests/Cases/AsyncCaseTests.cs
@@ -158,7 +158,7 @@
 
         class NullTaskTestClass
         {
-            public Task Test()
+            public Task? Test()
             {
                 // Although unlikely, we must ensure that
                 // we don't attempt to wait on a Task that

--- a/src/Fixie.Tests/Cases/AsyncCaseTests.cs
+++ b/src/Fixie.Tests/Cases/AsyncCaseTests.cs
@@ -95,7 +95,7 @@
 
         abstract class SampleTestClassBase
         {
-            protected static void ThrowException([CallerMemberName] string member = null)
+            protected static void ThrowException([CallerMemberName] string member = default!)
             {
                 throw new FailureException(member);
             }

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -111,7 +111,7 @@ namespace Fixie.Tests.Cases
 
             public string String() => "ABC";
 
-            public string StringNull() => null;
+            public string? StringNull() => null;
         }
 
         class SampleAsyncTestClass
@@ -128,7 +128,7 @@ namespace Fixie.Tests.Cases
 
             public async Task<string> String()=> await Awaitable("ABC");
 
-            public async Task<string> StringNull() => await Awaitable<string>(null);
+            public async Task<string?> StringNull() => await Awaitable<string?>(null);
 
             static Task<T> Awaitable<T>(T value)
                 => Task.Run(() => value);

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -133,7 +133,7 @@ namespace Fixie.Tests.Cases
             static Task<T> Awaitable<T>(T value)
                 => Task.Run(() => value);
 
-            static void ThrowException([CallerMemberName] string member = null)
+            static void ThrowException([CallerMemberName] string member = default!)
                 => throw new FailureException(member);
         }
 

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -51,16 +51,14 @@
 
         public void ShouldFailWithClearExplanationWhenParameterCountsAreMismatched()
         {
-            FixedParameterSource.Parameters = new[]
+            discovery.Parameters.Add(new FixedParameterSource(new[]
             {
                 new object[] { },
                 new object[] { 0 },
                 new object[] { 0, 1 },
                 new object[] { 0, 1, 2 },
                 new object[] { 0, 1, 2, 3 }
-            };
-
-            discovery.Parameters.Add<FixedParameterSource>();
+            }));
 
             Run<ParameterizedTestClass>(discovery, execution)
                 .ShouldBe(
@@ -232,15 +230,16 @@
 
         class FixedParameterSource : ParameterSource
         {
-            public static object[][] Parameters { get; set; }
+            readonly object[][] parameters;
+
+            public FixedParameterSource(object[][] parameters)
+                => this.parameters = parameters;
 
             public IEnumerable<object[]> GetParameters(MethodInfo method)
-            {
-                return Parameters;
-            }
+                => parameters;
         }
 
-        static object Default(Type type)
+        static object? Default(Type type)
         {
             return type.IsValueType ? Activator.CreateInstance(type) : null;
         }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -322,7 +322,7 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            static string Format(object obj)
+            static string Format(object? obj)
             {
                 return obj?.ToString() ?? "[null]";
             }
@@ -343,12 +343,12 @@
         [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
         class InputAttribute : Attribute
         {
-            public InputAttribute(params object[] parameters)
+            public InputAttribute(params object?[] parameters)
             {
                 Parameters = parameters;
             }
 
-            public object[] Parameters { get; }
+            public object?[] Parameters { get; }
         }
     }
 }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -171,7 +171,7 @@
 
         class InputAttributeParameterSource : ParameterSource
         {
-            public IEnumerable<object[]> GetParameters(MethodInfo method)
+            public IEnumerable<object?[]> GetParameters(MethodInfo method)
             {
                 var inputAttributes = method.GetCustomAttributes<InputAttribute>(true).ToArray();
 
@@ -183,7 +183,7 @@
 
         class InputAttributeOrDefaultParameterSource : ParameterSource
         {
-            public virtual IEnumerable<object[]> GetParameters(MethodInfo method)
+            public virtual IEnumerable<object?[]> GetParameters(MethodInfo method)
             {
                 var parameters = method.GetParameters();
 
@@ -221,7 +221,7 @@
 
         class EagerBuggyParameterSource : InputAttributeOrDefaultParameterSource
         {
-            public override IEnumerable<object[]> GetParameters(MethodInfo method)
+            public override IEnumerable<object?[]> GetParameters(MethodInfo method)
             {
                 if (method.Name == nameof(ParameterizedTestClass.IntArg))
                     throw new Exception("Exception thrown while attempting to eagerly build input parameters for method: " + method.Name);

--- a/src/Fixie.Tests/Cli/ParserTests.cs
+++ b/src/Fixie.Tests/Cli/ParserTests.cs
@@ -101,15 +101,15 @@
 
         public void ShouldLeaveDefaultValuesForMissingNamedArguments()
         {
-            Parse<ModelWithConstructor<string>>("--first", "value1", "--second", "value2")
-                .ShouldSucceed(new ModelWithConstructor<string>("value1", "value2", null));
+            Parse<ModelWithConstructor<string?>>("--first", "value1", "--second", "value2")
+                .ShouldSucceed(new ModelWithConstructor<string?>("value1", "value2", null));
 
             Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2")
                 .ShouldSucceed(new ModelWithConstructor<int>(1, 2, 0));
 
             //Unspecified params[] default to an empty array.
-            Parse<ModelWithParams<string>>("--first", "first", "--second", "second")
-                .ShouldSucceed(new ModelWithParams<string>("first", "second", null));
+            Parse<ModelWithParams<string?>>("--first", "first", "--second", "second")
+                .ShouldSucceed(new ModelWithParams<string?>("first", "second", null));
 
             Parse<ModelWithParams<int>>("--first", "1", "--second", "2")
                 .ShouldSucceed(new ModelWithParams<int>(1, 2, 0));
@@ -372,7 +372,7 @@
         class Complex
         {
             public Complex(
-                string @string,
+                string? @string,
                 int integer,
                 bool @bool,
                 int? nullableInteger,
@@ -389,7 +389,7 @@
                 Integers = integers;
             }
 
-            public string String { get; }
+            public string? String { get; }
             public int Integer { get; }
             public bool Bool { get; }
             public int? NullableInteger { get; }
@@ -433,7 +433,7 @@
         class ComplexWithParams
         {
             public ComplexWithParams(
-                string @string,
+                string? @string,
                 int integer,
                 bool @bool,
                 int? nullableInteger,
@@ -452,7 +452,7 @@
                 Rest = rest;
             }
 
-            public string String { get; }
+            public string? String { get; }
             public int Integer { get; }
             public bool Bool { get; }
             public int? NullableInteger { get; }

--- a/src/Fixie.Tests/Cli/ParserTests.cs
+++ b/src/Fixie.Tests/Cli/ParserTests.cs
@@ -527,9 +527,6 @@
 
             static void ShouldMatch(T actual, T expected)
             {
-                expected.ShouldNotBe(null);
-                actual.ShouldNotBe(null);
-
                 foreach (var property in typeof(T).GetProperties())
                 {
                     var actualValue = property.GetValue(actual);

--- a/src/Fixie.Tests/FailureException.cs
+++ b/src/Fixie.Tests/FailureException.cs
@@ -5,7 +5,7 @@
 
     public class FailureException : Exception
     {
-        public FailureException([CallerMemberName] string member = null)
+        public FailureException([CallerMemberName] string member = default!)
             : base($"'{member}' failed!") { }
     }
 }

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -137,7 +137,9 @@
                 "Exception thrown while attempting to run a custom class-discovery predicate. " +
                 "Check the inner exception for more details.");
 
-            exception.InnerException.Message.ShouldBe("Unsafe class-discovery predicate threw!");
+            exception.InnerException
+                .ShouldBe<Exception>()
+                .Message.ShouldBe("Unsafe class-discovery predicate threw!");
         }
 
         static IEnumerable<Type> DiscoveredTestClasses(Discovery discovery)

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -11,135 +11,135 @@
 
         public void ShouldResolveNothingWhenThereAreNoInputParameters()
         {
-            Resolve("NoParameters", new object[] { })
+            Resolve("NoParameters")
                 .ShouldBe(Empty);
         }
 
         public void ShouldResolveNothingWhenThereAreNoGenericParameters()
         {
-            Resolve("NoGenericArguments", new object[] {0, ""})
+            Resolve("NoGenericArguments", 0, "")
                 .ShouldBe(Empty);
         }
 
         public void ShouldResolveToObjectWhenGenericTypeHasNoMatchingParameters()
         {
-            Resolve("NoMatchingParameters", new object[] { 0, "" })
+            Resolve("NoMatchingParameters", 0, "")
                 .ShouldBe(typeof(object));
         }
 
         public void ShouldResolveToObjectWhenGenericTypeHasOneNullMatchingParameter()
         {
-            Resolve("OneMatchingParameter", new object[] { null })
+            Resolve("OneMatchingParameter", new object?[] { null })
                 .ShouldBe(typeof(object));
         }
 
         public void ShouldResolveToConcreteTypeOfValueWhenGenericTypeHasOneNonNullMatchingParameter()
         {
-            Resolve("OneMatchingParameter", new object[] { 1.2m })
+            Resolve("OneMatchingParameter", 1.2m)
                 .ShouldBe(typeof(decimal));
 
-            Resolve("OneMatchingParameter", new object[] { "string" })
+            Resolve("OneMatchingParameter", "string")
                 .ShouldBe(typeof(string));
         }
 
         public void ShouldResolveToObjectWhenGenericTypeHasMultipleMatchingParametersOfInconsistentConcreteTypes()
         {
-            Resolve("MultipleMatchingParameter", new object[] { 1.2m, "string", 0 })
+            Resolve("MultipleMatchingParameter", 1.2m, "string", 0)
                 .ShouldBe(typeof(object));
             
-            Resolve("MultipleMatchingParameter", new object[] { 1.2m, "string a", "string b" })
+            Resolve("MultipleMatchingParameter", 1.2m, "string a", "string b")
                 .ShouldBe(typeof(object));
         }
 
         public void ShouldResolveToConcreteTypeOfValuesWhenGenericTypeHasMultipleMatchingParametersOfTheExactSameConcreteType()
         {
-            Resolve("MultipleMatchingParameter", new object[] { 1.2m, 2.3m, 3.4m })
+            Resolve("MultipleMatchingParameter", 1.2m, 2.3m, 3.4m)
                 .ShouldBe(typeof(decimal));
 
-            Resolve("MultipleMatchingParameter", new object[] { "string a", "string b", "string c" })
+            Resolve("MultipleMatchingParameter", "string a", "string b", "string c")
                 .ShouldBe(typeof(string));
         }
 
         public void ShouldResolveToObjectWhenGenericTypeHasMultipleMatchingParametersButAllAreNull()
         {
-            Resolve("MultipleMatchingParameter", new object[] { null, null, null })
+            Resolve("MultipleMatchingParameter", null, null, null)
                 .ShouldBe(typeof(object));
         }
 
         public void ShouldTreatNullsAsTypeCompatibleWithReferenceTypes()
         {
-            Resolve("MultipleMatchingParameter", new object[] { null, "string b", "string c" })
+            Resolve("MultipleMatchingParameter", null, "string b", "string c")
                 .ShouldBe(typeof(string));
 
-            Resolve("MultipleMatchingParameter", new object[] { "string a", null, "string c" })
+            Resolve("MultipleMatchingParameter", "string a", null, "string c")
                 .ShouldBe(typeof(string));
 
-            Resolve("MultipleMatchingParameter", new object[] { "string a", "string b", null })
+            Resolve("MultipleMatchingParameter", "string a", "string b", null)
                 .ShouldBe(typeof(string));
         }
 
         public void ShouldTreatNullAsTypeIncompatibleWithValueTypes()
         {
-            Resolve("MultipleMatchingParameter", new object[] { null, 2.3m, 3.4m })
+            Resolve("MultipleMatchingParameter", null, 2.3m, 3.4m)
                 .ShouldBe(typeof(object));
 
-            Resolve("MultipleMatchingParameter", new object[] { 1.2m, null, 3.4m })
+            Resolve("MultipleMatchingParameter", 1.2m, null, 3.4m)
                 .ShouldBe(typeof(object));
 
-            Resolve("MultipleMatchingParameter", new object[] { 1.2m, 2.3m, null })
+            Resolve("MultipleMatchingParameter", 1.2m, 2.3m, null)
                 .ShouldBe(typeof(object));
         }
 
         public void ShouldResolveAllGenericArguments()
         {
-            Resolve("MultipleGenericArguments", new object[] { null, 1.2m, "string", 0 })
+            Resolve("MultipleGenericArguments", null, 1.2m, "string", 0)
                 .ShouldBe(typeof(object), typeof(object), typeof(object));
 
-            Resolve("MultipleGenericArguments", new object[] {false, 1.2m, "string", 0 })
+            Resolve("MultipleGenericArguments", false, 1.2m, "string", 0)
                 .ShouldBe(typeof(object), typeof(bool), typeof(object));
 
-            Resolve("MultipleGenericArguments", new object[] { false, 1.2m, "string a", "string b" })
+            Resolve("MultipleGenericArguments", false, 1.2m, "string a", "string b")
                 .ShouldBe(typeof(object), typeof(bool), typeof(object));
 
-            Resolve("MultipleGenericArguments", new object[] {false, 1.2m, 2.3m, 3.4m })
+            Resolve("MultipleGenericArguments", false, 1.2m, 2.3m, 3.4m)
                 .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
 
-            Resolve("MultipleGenericArguments", new object[] {false, "string a", "string b", "string c" })
+            Resolve("MultipleGenericArguments", false, "string a", "string b", "string c")
                 .ShouldBe(typeof(object), typeof(bool), typeof(string));
 
-            Resolve("MultipleGenericArguments", new object[] { false, null, null, null })
+            Resolve("MultipleGenericArguments", false, null, null, null)
                 .ShouldBe(typeof(object), typeof(bool), typeof(object));
             
-            Resolve("MultipleGenericArguments", new object[] { false, "string a", "string b", null })
+            Resolve("MultipleGenericArguments", false, "string a", "string b", null)
                 .ShouldBe(typeof(object), typeof(bool), typeof(string));
 
-            Resolve("MultipleGenericArguments", new object[] { false, 1.2m, 2.3m, null })
+            Resolve("MultipleGenericArguments", false, 1.2m, 2.3m, null)
                 .ShouldBe(typeof(object), typeof(bool), typeof(object));
         }
 
         public void ShouldResolveToObjectWhenInputParameterCountDoesNotMatchDeclaredParameterCount()
         {
-            Resolve("MultipleGenericArguments", new object[] { 1 }).ShouldBe(typeof(object), typeof(object), typeof(object));
-            Resolve("MultipleGenericArguments", new object[] { 1, true, false, true, false }).ShouldBe(typeof(object), typeof(object), typeof(object));
+            Resolve("MultipleGenericArguments", 1).ShouldBe(typeof(object), typeof(object), typeof(object));
+            Resolve("MultipleGenericArguments", 1, true, false, true, false).ShouldBe(typeof(object), typeof(object), typeof(object));
         }
 
         public void ShouldResolveGenericArgumentsWhenGenericConstraintsAreSatisfied()
         {
-            Resolve("ConstrainedGeneric", new object[] { 1 })
+            Resolve("ConstrainedGeneric", 1)
                 .ShouldBe(typeof(int));
 
-            Resolve("ConstrainedGeneric", new object[] { true })
+            Resolve("ConstrainedGeneric", true)
                 .ShouldBe(typeof(bool));
         }
 
         public void ShouldLeaveGenericTypeParameterWhenGenericTypeParametersCannotBeResolved()
         {
-            var unresolved = Resolve("ConstrainedGeneric", new object[] { "Incompatible" }).Single();
+            var unresolved = Resolve("ConstrainedGeneric", "Incompatible").Single();
             unresolved.Name.ShouldBe("T");
             unresolved.IsGenericParameter.ShouldBe(true);
         }
 
-        static IEnumerable<Type> Resolve(string methodName, object[] parameters)
+        static IEnumerable<Type> Resolve(string methodName, params object?[] parameters)
         {
             var testClass = typeof(Generic);
             var caseMethod = testClass.GetInstanceMethod(methodName);

--- a/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
@@ -44,7 +44,7 @@
             fail.Method.Name.ShouldBe("Fail");
             fail.Output.Lines().ShouldBe("Console.Out: Fail", "Console.Error: Fail");
             fail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-            fail.Exception.ShouldBeType<FailureException>();
+            fail.Exception.ShouldBe<FailureException>();
             fail.Exception.LiterateStackTrace()
                 .CleanStackTraceLineNumbers()
                 .ShouldBe(At("Fail()"));
@@ -55,7 +55,7 @@
             failByAssertion.Method.Name.ShouldBe("FailByAssertion");
             failByAssertion.Output.Lines().ShouldBe("Console.Out: FailByAssertion", "Console.Error: FailByAssertion");
             failByAssertion.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-            failByAssertion.Exception.ShouldBeType<AssertException>();
+            failByAssertion.Exception.ShouldBe<AssertException>();
             failByAssertion.Exception.LiterateStackTrace()
                 .CleanStackTraceLineNumbers()
                 .ShouldBe(At("FailByAssertion()"));

--- a/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
@@ -4,7 +4,6 @@
     using Assertions;
     using Fixie.Internal;
     using Fixie.Internal.Listeners;
-    using static Fixie.Internal.Serialization;
 
     public class AppVeyorListenerTests : MessagingTests
     {
@@ -12,12 +11,10 @@
         {
             var results = new List<AppVeyorListener.TestResult>();
 
-            var listener = new AppVeyorListener("http://localhost:4567", (uri, mediaType, content) =>
+            var listener = new AppVeyorListener("http://localhost:4567", (uri, content) =>
             {
                 uri.ShouldBe("http://localhost:4567/api/tests");
-                mediaType.ShouldBe("application/json");
-
-                results.Add(Deserialize<AppVeyorListener.TestResult>(content));
+                results.Add(content);
             });
 
             using (var console = new RedirectedConsole())
@@ -66,7 +63,7 @@
             fail.Outcome.ShouldBe("Failed");
             int.Parse(fail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
             fail.ErrorMessage.ShouldBe("'Fail' failed!");
-            fail.ErrorStackTrace
+            fail.ErrorStackTrace!
                 .CleanStackTraceLineNumbers()
                 .Lines()
                 .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
@@ -75,10 +72,10 @@
             failByAssertion.TestName.ShouldBe(TestClass + ".FailByAssertion");
             failByAssertion.Outcome.ShouldBe("Failed");
             int.Parse(failByAssertion.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            failByAssertion.ErrorMessage.Lines().ShouldBe(
+            failByAssertion.ErrorMessage!.Lines().ShouldBe(
                 "Expected: 2",
                 "Actual:   1");
-            failByAssertion.ErrorStackTrace
+            failByAssertion.ErrorStackTrace!
                 .CleanStackTraceLineNumbers()
                 .Lines()
                 .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -54,7 +54,7 @@
                     return Serialize(new AzureListener.TestRun { url = runUrl });
                 }
 
-                return null;
+                return "";
             }, batchSize);
 
             using (var console = new RedirectedConsole())

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -13,9 +13,16 @@
     {
         class Request
         {
-            public HttpMethod Method { get; set; }
-            public string Uri { get; set; }
-            public string Content { get; set; }
+            public Request(HttpMethod method, string uri, string content)
+            {
+                Method = method;
+                Uri = uri;
+                Content = content;
+            }
+
+            public HttpMethod Method { get; }
+            public string Uri { get; }
+            public string Content { get; }
         }
 
         public void ShouldReportResultsToAzureDevOpsApi()
@@ -39,7 +46,7 @@
 
                 mediaType.ShouldBe("application/json");
 
-                requests.Add(new Request { Method = method, Uri = uri, Content = content });
+                requests.Add(new Request(method, uri, content));
 
                 if (first)
                 {

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -11,9 +11,9 @@
 
     public class AzureListenerTests : MessagingTests
     {
-        class Request
+        class Request<TContent>
         {
-            public Request(HttpMethod method, string uri, string content)
+            public Request(HttpMethod method, string uri, TContent content)
             {
                 Method = method;
                 Uri = uri;
@@ -22,7 +22,7 @@
 
             public HttpMethod Method { get; }
             public string Uri { get; }
-            public string Content { get; }
+            public TContent Content { get; }
         }
 
         public void ShouldReportResultsToAzureDevOpsApi()
@@ -31,11 +31,10 @@
             var accessToken = Guid.NewGuid().ToString();
             var buildId = Guid.NewGuid().ToString();
             var runUrl = "http://localhost:4567/run/" + Guid.NewGuid();
-            var requests = new List<Request>();
+            var requests = new List<object>();
             var batchSize = 2;
 
-            bool first = true;
-            var listener = new AzureListener("http://localhost:4567", project, accessToken, buildId, (client, method, uri, mediaType, content) =>
+            Action<HttpClient> assertCommonHttpConcerns = client =>
             {
                 var actualHeader = client.DefaultRequestHeaders.Accept.Single();
                 actualHeader.MediaType.ShouldBe("application/json");
@@ -43,19 +42,27 @@
                 var actualAuthorization = client.DefaultRequestHeaders.Authorization;
                 actualAuthorization.Scheme.ShouldBe("Bearer");
                 actualAuthorization.Parameter.ShouldBe(accessToken);
+            };
 
-                mediaType.ShouldBe("application/json");
-
-                requests.Add(new Request(method, uri, content));
-
-                if (first)
+            var listener = new AzureListener("http://localhost:4567", project, accessToken, buildId,
+                (client, method, uri, content) =>
                 {
-                    first = false;
-                    return Serialize(new AzureListener.TestRun { url = runUrl });
-                }
-
-                return "";
-            }, batchSize);
+                    assertCommonHttpConcerns(client);
+                    requests.Add(new Request<AzureListener.CreateRun>(method, uri, content));
+                    return Serialize(new AzureListener.TestRun {url = runUrl});
+                },
+                (client, method, uri, content) =>
+                {
+                    assertCommonHttpConcerns(client);
+                    requests.Add(new Request<IReadOnlyList<AzureListener.Result>>(method, uri, content));
+                    return "";
+                },
+                (client, method, uri, content) =>
+                {
+                    assertCommonHttpConcerns(client);
+                    requests.Add(new Request<AzureListener.CompleteRun>(method, uri, content));
+                    return "";
+                }, batchSize);
 
             using (var console = new RedirectedConsole())
             {
@@ -71,28 +78,31 @@
                         "Console.Error: Pass");
             }
 
-            var firstRequest = requests.First();
+            var firstRequest = (Request<AzureListener.CreateRun>)requests.First();
             firstRequest.Method.ShouldBe(HttpMethod.Post);
             firstRequest.Uri.ShouldBe($"http://localhost:4567/{project}/_apis/test/runs?api-version=5.0");
 
-            var createRun = Deserialize<AzureListener.CreateRun>(firstRequest.Content);
-
+            var createRun = firstRequest.Content;
             createRun.name.ShouldBe("Fixie.Tests (.NETCoreApp,Version=v3.1)");
             createRun.build.id.ShouldBe(buildId);
             createRun.isAutomated.ShouldBe(true);
 
-            var resultBatches = requests.Skip(1).Take(requests.Count - 2).Select(request =>
-            {
-                request.Method.ShouldBe(HttpMethod.Post);
-                request.Uri.ShouldBe($"{runUrl}/results?api-version=5.0");
+            var resultBatches = requests
+                .Skip(1)
+                .Take(requests.Count - 2)
+                .Cast<Request<IReadOnlyList<AzureListener.Result>>>()
+                .Select(request =>
+                {
+                    request.Method.ShouldBe(HttpMethod.Post);
+                    request.Uri.ShouldBe($"{runUrl}/results?api-version=5.0");
 
-                return Deserialize<AzureListener.Result[]>(request.Content);
-            }).ToList();
+                    return request.Content;
+                }).ToList();
 
             resultBatches.Count.ShouldBe(3);
-            resultBatches[0].Length.ShouldBe(2);
-            resultBatches[1].Length.ShouldBe(2);
-            resultBatches[2].Length.ShouldBe(1);
+            resultBatches[0].Count.ShouldBe(2);
+            resultBatches[1].Count.ShouldBe(2);
+            resultBatches[2].Count.ShouldBe(1);
 
             var results = resultBatches.SelectMany(x => x).ToList();
             results.Count.ShouldBe(5);
@@ -122,7 +132,7 @@
             fail.outcome.ShouldBe("Failed");
             fail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
             fail.errorMessage.ShouldBe("'Fail' failed!");
-            fail.stackTrace
+            fail.stackTrace!
                 .CleanStackTraceLineNumbers()
                 .Lines()
                 .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
@@ -131,10 +141,10 @@
             failByAssertion.testCaseTitle.ShouldBe(TestClass + ".FailByAssertion");
             failByAssertion.outcome.ShouldBe("Failed");
             failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-            failByAssertion.errorMessage.Lines().ShouldBe(
+            failByAssertion.errorMessage!.Lines().ShouldBe(
                 "Expected: 2",
                 "Actual:   1");
-            failByAssertion.stackTrace
+            failByAssertion.stackTrace!
                 .CleanStackTraceLineNumbers()
                 .Lines()
                 .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
@@ -146,11 +156,11 @@
             pass.errorMessage.ShouldBe(null);
             pass.stackTrace.ShouldBe(null);
 
-            var lastRequest = requests.Last();
+            var lastRequest = (Request<AzureListener.CompleteRun>)requests.Last();
             lastRequest.Method.ShouldBe(new HttpMethod("PATCH"));
             lastRequest.Uri.ShouldBe($"{runUrl}?api-version=5.0");
 
-            var updateRun = Deserialize<AzureListener.UpdateRun>(lastRequest.Content);
+            var updateRun = lastRequest.Content;
             updateRun.state.ShouldBe("Completed");
         }
     }

--- a/src/Fixie.Tests/Internal/Listeners/ReportListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ReportListenerTests.cs
@@ -12,7 +12,7 @@
     {
         public void ShouldProduceValidXmlDocument()
         {
-            XDocument actual = null;
+            XDocument? actual = null;
             var listener = new ReportListener(report => actual = report);
 
             using (var console = new RedirectedConsole())
@@ -28,6 +28,9 @@
                         "Console.Out: Pass",
                         "Console.Error: Pass");
             }
+
+            if (actual == null)
+                throw new Exception("Expected non-null XML report.");
 
             CleanBrittleValues(actual.ToString(SaveOptions.DisableFormatting)).ShouldBe(ExpectedReport);
         }

--- a/src/Fixie.Tests/Internal/MaybeTests.cs
+++ b/src/Fixie.Tests/Internal/MaybeTests.cs
@@ -1,0 +1,36 @@
+﻿namespace Fixie.Tests.Internal
+{
+    using System;
+    using Assertions;
+    using static Fixie.Internal.Maybe;
+
+    public class MaybeTests
+    {
+        public void ShouldProvideTryPatternShorthandForFuncWithZeroParameters()
+        {
+            Func<string?> returnNull = () => null;
+            Func<string?> returnNotNull = () => "";
+
+            var hasValue = Try(returnNull, out var value);
+            hasValue.ShouldBe(false);
+            value.ShouldBe(null);
+
+            hasValue = Try(returnNotNull, out value);
+            hasValue.ShouldBe(true);
+            value.ShouldBe("");
+        }
+
+        public void ShouldProvideTryPatternShorthandForFuncWithOneParameter()
+        {
+            Func<string?, string?> returnThis = argument => argument;
+
+            var hasValue = Try(returnThis, null, out var value);
+            hasValue.ShouldBe(false);
+            value.ShouldBe(null);
+
+            hasValue = Try(returnThis, "Value", out value);
+            hasValue.ShouldBe(true);
+            value.ShouldBe("Value");
+        }
+    }
+}

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -121,7 +121,9 @@
                 "Exception thrown while attempting to run a custom method-discovery predicate. " +
                 "Check the inner exception for more details.");
 
-            exception.InnerException.Message.ShouldBe("Unsafe method-discovery predicate threw!");
+            exception.InnerException
+                .ShouldBe<Exception>()
+                .Message.ShouldBe("Unsafe method-discovery predicate threw!");
         }
 
         static IEnumerable<string> DiscoveredTestMethods<TTestClass>(Discovery discovery)

--- a/src/Fixie.Tests/Internal/ParameterDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ParameterDiscovererTests.cs
@@ -63,7 +63,7 @@
                 });
         }
 
-        IEnumerable<object[]> DiscoveredParameters(Discovery discovery)
+        IEnumerable<object?[]> DiscoveredParameters(Discovery discovery)
         {
             return new ParameterDiscoverer(discovery).GetParameters(method);
         }

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -193,7 +193,7 @@
             }
         }
 
-        static void WhereAmI([CallerMemberName] string member = null)
+        static void WhereAmI([CallerMemberName] string member = default!)
         {
             Console.WriteLine(member);
 

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -10,13 +10,13 @@
 
     public class LifecycleTests
     {
-        static string[] FailingMembers;
+        static string[] FailingMembers = Array.Empty<string>();
 
         readonly Discovery discovery;
 
         public LifecycleTests()
         {
-            FailingMembers = null;
+            FailingMembers = Array.Empty<string>();
             discovery = new SelfTestDiscovery();
         }
 
@@ -197,7 +197,7 @@
         {
             Console.WriteLine(member);
 
-            if (FailingMembers != null && FailingMembers.Contains(member))
+            if (FailingMembers.Contains(member))
                 throw new FailureException(member);
         }
 

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -16,7 +16,7 @@
 
         protected string TestClass { get; }
 
-        protected void Run(Listener listener, Action<Discovery> customize = null)
+        protected void Run(Listener listener, Action<Discovery>? customize = null)
         {
             var discovery = new SelfTestDiscovery();
 
@@ -34,7 +34,7 @@
                 {
                     if (@case.Method.Has<SkipAttribute>())
                     {
-                        @case.Skip(@case.Method.GetCustomAttribute<SkipAttribute>().Reason);
+                        @case.Skip(@case.Method.GetCustomAttribute<SkipAttribute>()!.Reason);
                         return;
                     }
 

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -54,7 +54,7 @@
                 WhereAmI();
             }
 
-            protected static void WhereAmI([CallerMemberName] string member = null)
+            protected static void WhereAmI([CallerMemberName] string member = default!)
             {
                 Console.Out.WriteLine("Console.Out: " + member);
                 Console.Error.WriteLine("Console.Error: " + member);

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -15,6 +15,7 @@
         }
 
         protected string TestClass { get; }
+        protected Type TestClassType => typeof(SampleTestClass);
 
         protected void Run(Listener listener, Action<Discovery>? customize = null)
         {

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -6,13 +6,6 @@
 
     public class ReflectionExtensionsTests
     {
-        public void CanDetermineTheTypeNameOfAnyObject()
-        {
-            5.TypeName().ShouldBe("System.Int32");
-            "".TypeName().ShouldBe("System.String");
-            ((string) null).TypeName().ShouldBe(null);
-        }
-
         public void CanDetectVoidReturnType()
         {
             Method("ReturnsVoid").IsVoid().ShouldBe(true);

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -39,7 +39,7 @@
             var disposeable = new Disposable();
             var disposeButNotDisposable = new DisposeButNotDisposable();
             var notDisposable = new NotDisposable();
-            object nullObject = null;
+            object? nullObject = null;
 
             disposeable.Invoked.ShouldBe(false);
             disposeButNotDisposable.Invoked.ShouldBe(false);

--- a/src/Fixie.Tests/ShouldBeUnreachableException.cs
+++ b/src/Fixie.Tests/ShouldBeUnreachableException.cs
@@ -5,7 +5,7 @@
 
     public class ShouldBeUnreachableException : Exception
     {
-        public ShouldBeUnreachableException([CallerMemberName] string member = null)
+        public ShouldBeUnreachableException([CallerMemberName] string member = default!)
             : base($"'{member}' reached a line of code thought to be unreachable.") { }
     }
 }

--- a/src/Fixie.Tests/SkipAttribute.cs
+++ b/src/Fixie.Tests/SkipAttribute.cs
@@ -14,6 +14,6 @@
             Reason = reason;
         }
 
-        public string Reason { get; }
+        public string? Reason { get; }
     }
 }

--- a/src/Fixie.Tests/TestAdapter/DiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/DiscoveryRecorderTests.cs
@@ -4,11 +4,13 @@
     using System.IO;
     using System.Linq;
     using Assertions;
+    using Fixie.Internal;
     using Fixie.Internal.Listeners;
     using Fixie.TestAdapter;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+    using static Utility;
 
     public class DiscoveryRecorderTests : MessagingTests
     {
@@ -21,15 +23,9 @@
 
             var discoveryRecorder = new DiscoveryRecorder(log, discoverySink, assemblyPath);
 
-            discoveryRecorder.Record(new PipeMessage.TestDiscovered
-            {
-                Test = new PipeMessage.Test
-                {
-                    Class = TestClass,
-                    Method = "Fail",
-                    Name = TestClass + ".Fail"
-                }
-            });
+            discoveryRecorder.Record(
+                new PipeMessage.TestDiscovered(
+                    new MethodDiscovered(TestClassType.GetInstanceMethod("Fail"))));
 
             log.Messages.ShouldBeEmpty();
 
@@ -46,15 +42,9 @@
 
             var discoveryRecorder = new DiscoveryRecorder(log, discoverySink, invalidAssemblyPath);
 
-            discoveryRecorder.Record(new PipeMessage.TestDiscovered
-            {
-                Test = new PipeMessage.Test
-                {
-                    Class = TestClass,
-                    Method = "Fail",
-                    Name = TestClass + ".Fail"
-                }
-            });
+            discoveryRecorder.Record(
+                new PipeMessage.TestDiscovered(
+                    new MethodDiscovered(TestClassType.GetInstanceMethod("Fail"))));
 
             log.Messages.Single().Contains(nameof(FileNotFoundException)).ShouldBe(true);
 

--- a/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.Tests.TestAdapter
 {
+    using System;
     using Fixie.TestAdapter;
     using Assertions;
     using static Utility;
@@ -79,11 +80,10 @@
         {
             var sourceLocationProvider = new SourceLocationProvider(TestAssemblyPath);
 
-            var success = sourceLocationProvider.TryGetSourceLocation(className, methodName, out var location);
+            if (!sourceLocationProvider.TryGetSourceLocation(className, methodName, out var location))
+                throw new Exception($"Expected to find a SourceLocation for method {className}.{methodName}.");
 
-            success.ShouldBe(true);
             location.CodeFilePath.EndsWith("SourceLocationSamples.cs").ShouldBe(true);
-
             location.LineNumber.ShouldBe(expectedLine);
         }
     }

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -17,7 +17,7 @@
             var instanceMethod = type.GetMethod(methodName, InstanceMethods);
 
             if (instanceMethod == null)
-                throw new Exception($"Could not find instance method '{methodName}' on type '{type.FullName}'");
+                throw new Exception($"Could not find instance method '{methodName}' on type '{type.FullName}'.");
 
             return instanceMethod;
         }

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -14,7 +14,12 @@
 
         public static MethodInfo GetInstanceMethod(this Type type, string methodName)
         {
-            return type.GetMethod(methodName, InstanceMethods);
+            var instanceMethod = type.GetMethod(methodName, InstanceMethods);
+
+            if (instanceMethod == null)
+                throw new Exception($"Could not find instance method '{methodName}' on type '{type.FullName}'");
+
+            return instanceMethod;
         }
 
         public static IReadOnlyList<MethodInfo> GetInstanceMethods(this Type type)

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -11,13 +11,13 @@
         public static string FullName<T>()
             => typeof(T).FullName;
 
-        public static string At<T>(string method, [CallerFilePath] string path = null)
+        public static string At<T>(string method, [CallerFilePath] string path = default!)
             => $"   at {FullName<T>().Replace("+", ".")}.{method} in {path}:line #";
 
         public static string[] For<TSampleTestClass>(params string[] entries)
             => entries.Select(x => FullName<TSampleTestClass>() + x).ToArray();
 
-        public static string PathToThisFile([CallerFilePath] string path = null)
+        public static string PathToThisFile([CallerFilePath] string path = default!)
             => path;
 
         public static IEnumerable<string> Run<TSampleTestClass>(Discovery discovery, Execution execution)

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -9,7 +9,10 @@
     public static class Utility
     {
         public static string FullName<T>()
-            => typeof(T).FullName;
+        {
+            return typeof(T).FullName ??
+                   throw new Exception($"Expected type {typeof(T).Name} to have a non-null FullName.");
+        }
 
         public static string At<T>(string method, [CallerFilePath] string path = default!)
             => $"   at {FullName<T>().Replace("+", ".")}.{method} in {path}:line #";

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -123,7 +123,7 @@
         /// For async Task methods, returns null after awaiting the Task.
         /// For async Task<![CDATA[<T>]]> methods, returns the Result T after awaiting the Task.
         /// </returns>
-        public object Execute(object instance)
+        public object? Execute(object instance)
         {
             try
             {

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -61,7 +61,7 @@
         /// <summary>
         /// Indicate the test case was skipped for the given reason.
         /// </summary>
-        public void Skip(string reason)
+        public void Skip(string? reason)
         {
             State = CaseState.Skipped;
             Exception = null;
@@ -110,7 +110,7 @@
 
         internal TimeSpan Duration { get; set; }
         internal string Output { get; set; }
-        internal string SkipReason { get; private set; }
+        internal string? SkipReason { get; private set; }
         internal CaseState State { get; private set; }
 
         /// <summary>

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -130,7 +130,7 @@
         /// For async Task methods, returns null after awaiting the Task.
         /// For async Task<![CDATA[<T>]]> methods, returns the Result T after awaiting the Task.
         /// </returns>
-        public object? Execute(object instance)
+        public object? Execute(object? instance)
         {
             try
             {

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -19,7 +19,7 @@
         public Case(MethodInfo caseMethod, object?[] parameters)
         {
             Parameters = parameters;
-            Class = caseMethod.ReflectedType;
+            Class = caseMethod.ReflectedType!;
 
             Method = caseMethod.TryResolveTypeArguments(parameters);
 

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -9,14 +9,21 @@
     /// </summary>
     public class Case
     {
-        public Case(MethodInfo caseMethod, params object[] parameters)
+        static readonly object[] EmptyParameters = {};
+
+        public Case(MethodInfo caseMethod)
+            : this(caseMethod, EmptyParameters)
         {
-            Parameters = parameters != null && parameters.Length == 0 ? null : parameters;
+        }
+
+        public Case(MethodInfo caseMethod, object?[] parameters)
+        {
+            Parameters = parameters;
             Class = caseMethod.ReflectedType;
 
             Method = caseMethod.TryResolveTypeArguments(parameters);
 
-            Name = CaseNameBuilder.GetName(Class, Method, Parameters);
+            Name = CaseNameBuilder.GetName(Class, Method, parameters);
 
             Output = "";
         }
@@ -49,9 +56,9 @@
 
         /// <summary>
         /// For parameterized test cases, gets the set of parameters to be passed into the test method.
-        /// For zero-argument test methods, this property is null.
+        /// For zero-argument test methods, this property is the empty array.
         /// </summary>
-        public object[] Parameters { get; }
+        public object?[] Parameters { get; }
 
         /// <summary>
         /// Gets the exception describing this test case's failure.

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -56,7 +56,7 @@
         /// <summary>
         /// Gets the exception describing this test case's failure.
         /// </summary>
-        public Exception Exception { get; private set; }
+        public Exception? Exception { get; private set; }
 
         /// <summary>
         /// Indicate the test case was skipped for the given reason.

--- a/src/Fixie/Framework.cs
+++ b/src/Fixie/Framework.cs
@@ -10,7 +10,7 @@
         static string ProductVersion()
             => typeof(Framework)
                 .Assembly
-                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
                 .InformationalVersion;
     }
 }

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -155,7 +155,7 @@
                 yield return new ConsoleListener();
         }
 
-        static bool Try<T>(Func<T?> create, [NotNullWhen(true)] out T? listener) where T : class
+        static bool Try<T>(Func<T> create, [NotNullWhen(true)] out T listener)
         {
             listener = create();
 

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -20,7 +20,7 @@
             FatalError = -1
         }
 
-        public static int Main(string[] arguments)
+        public static int Main(Assembly assembly, string[] arguments)
         {
             try
             {
@@ -29,8 +29,6 @@
                 var options = CommandLine.Parse<Options>(runnerArguments);
 
                 options.Validate();
-
-                var assembly = Assembly.GetEntryAssembly();
 
                 var pipeName = Environment.GetEnvironmentVariable("FIXIE_NAMED_PIPE");
 

--- a/src/Fixie/Internal/AssemblyRunner.cs
+++ b/src/Fixie/Internal/AssemblyRunner.cs
@@ -2,13 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.IO.Pipes;
     using System.Linq;
     using System.Reflection;
     using Cli;
     using Listeners;
     using static System.Console;
+    using static Maybe;
 
     public class AssemblyRunner
     {
@@ -153,13 +153,6 @@
                 yield return teamCity;
             else
                 yield return new ConsoleListener();
-        }
-
-        static bool Try<T>(Func<T> create, [NotNullWhen(true)] out T listener)
-        {
-            listener = create();
-
-            return listener != null;
         }
     }
 }

--- a/src/Fixie/Internal/CaseFailed.cs
+++ b/src/Fixie/Internal/CaseFailed.cs
@@ -5,7 +5,7 @@
     public class CaseFailed : CaseCompleted
     {
         public CaseFailed(Case @case) : base(@case)
-            => Exception = @case.Exception;
+            => Exception = @case.Exception!;
 
         public Exception Exception { get; }
     }

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -32,7 +32,12 @@
             if (parameter is string s)
                 return ShortStringLiteral(s);
 
-            return Convert.ToString(parameter, CultureInfo.InvariantCulture);
+            var displayString = Convert.ToString(parameter, CultureInfo.InvariantCulture);
+
+            if (displayString == null)
+                return parameter.GetType().ToString();
+
+            return displayString;
         }
 
         static string CharacterLiteral(char ch)

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -8,20 +8,20 @@
 
     static class CaseNameBuilder
     {
-        public static string GetName(Type testClass, MethodInfo method, object[] parameters)
+        public static string GetName(Type testClass, MethodInfo method, object?[] parameters)
         {
             var name = testClass.FullName + "." + method.Name;
 
             if (method.IsGenericMethod)
                 name += $"<{string.Join(", ", method.GetGenericArguments().Select(x => x.IsGenericParameter ? x.Name : x.FullName))}>";
 
-            if (parameters != null && parameters.Length > 0)
+            if (parameters.Length > 0)
                 name += $"({string.Join(", ", parameters.Select(x => x.ToDisplayString()))})";
 
             return name;
         }
 
-        static string ToDisplayString(this object parameter)
+        static string ToDisplayString(this object? parameter)
         {
             if (parameter == null)
                 return "null";

--- a/src/Fixie/Internal/CaseSkipped.cs
+++ b/src/Fixie/Internal/CaseSkipped.cs
@@ -8,6 +8,6 @@
             Reason = @case.SkipReason;
         }
 
-        public string Reason { get; }
+        public string? Reason { get; }
     }
 }

--- a/src/Fixie/Internal/ClassRunner.cs
+++ b/src/Fixie/Internal/ClassRunner.cs
@@ -55,7 +55,7 @@
                     {
                         Start(@case);
 
-                        Exception caseLifecycleException = null;
+                        Exception? caseLifecycleFailure = null;
 
                         string consoleOutput;
                         using (var console = new RedirectedConsole())
@@ -68,7 +68,7 @@
                             }
                             catch (Exception exception)
                             {
-                                caseLifecycleException = exception;
+                                caseLifecycleFailure = exception;
                             }
 
                             caseStopwatch.Stop();
@@ -83,18 +83,17 @@
                         Console.Write(consoleOutput);
 
                         var caseHasNormalResult = @case.State == CaseState.Failed || @case.State == CaseState.Passed;
-                        var caseLifecycleFailed = caseLifecycleException != null;
 
                         if (caseHasNormalResult)
                         {
                             if (@case.State == CaseState.Failed)
                                 Fail(@case, summary);
-                            else if (!caseLifecycleFailed)
+                            else if (caseLifecycleFailure == null)
                                 Pass(@case, summary);
                         }
 
-                        if (caseLifecycleFailed)
-                            Fail(new Case(@case, caseLifecycleException), summary);
+                        if (caseLifecycleFailure != null)
+                            Fail(new Case(@case, caseLifecycleFailure), summary);
                         else if (!caseHasNormalResult)
                             Skip(@case, summary);
                     }

--- a/src/Fixie/Internal/ClassRunner.cs
+++ b/src/Fixie/Internal/ClassRunner.cs
@@ -163,7 +163,7 @@
                 {
                     while (true)
                     {
-                        object[] parameters;
+                        object?[] parameters;
 
                         try
                         {
@@ -200,7 +200,7 @@
             }
         }
 
-        IEnumerable<object[]> Parameters(MethodInfo method)
+        IEnumerable<object?[]> Parameters(MethodInfo method)
             => parameterDiscoverer.GetParameters(method);
 
         void Start(Type testClass)

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -34,7 +34,7 @@
         static Type ResolveTypeArgument(Type genericArgument, Type[] parameterTypes, object?[] parameters)
         {
             bool hasNullValue = false;
-            Type resolvedTypeOfNonNullValues = null;
+            Type? resolvedTypeOfNonNullValues = null;
 
             if (parameterTypes.Length != parameters.Length)
                 return typeof(object);

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -6,7 +6,7 @@
 
     static class GenericArgumentResolver
     {
-        public static MethodInfo TryResolveTypeArguments(this MethodInfo caseMethod, object[] parameters)
+        public static MethodInfo TryResolveTypeArguments(this MethodInfo caseMethod, object?[] parameters)
         {
             if (!caseMethod.IsGenericMethodDefinition)
                 return caseMethod;
@@ -23,7 +23,7 @@
             }
         }
 
-        static Type[] ResolveTypeArguments(MethodInfo method, object[] parameters)
+        static Type[] ResolveTypeArguments(MethodInfo method, object?[] parameters)
         {
             var genericArguments = method.GetGenericArguments();
             var parameterTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
@@ -31,7 +31,7 @@
             return genericArguments.Select(genericArgument => ResolveTypeArgument(genericArgument, parameterTypes, parameters)).ToArray();
         }
 
-        static Type ResolveTypeArgument(Type genericArgument, Type[] parameterTypes, object[] parameters)
+        static Type ResolveTypeArgument(Type genericArgument, Type[] parameterTypes, object?[] parameters)
         {
             bool hasNullValue = false;
             Type resolvedTypeOfNonNullValues = null;
@@ -43,7 +43,7 @@
             {
                 if (parameterTypes[i] == genericArgument)
                 {
-                    object parameterValue = parameters[i];
+                    object? parameterValue = parameters[i];
 
                     if (parameterValue == null)
                         hasNullValue = true;

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -115,7 +115,7 @@
             public string Outcome { get; set; }
             public string DurationMilliseconds { get; set; }
             public string StdOut { get; set; }
-            public string ErrorMessage { get; set; }
+            public string? ErrorMessage { get; set; }
             public string ErrorStackTrace { get; set; }
         }
     }

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -78,7 +78,7 @@
                 x.Outcome = "Failed";
                 x.ErrorMessage = message.Exception.Message;
                 x.ErrorStackTrace =
-                    message.Exception.TypeName() +
+                    message.Exception.GetType().FullName +
                     NewLine +
                     message.Exception.LiterateStackTrace();
             });

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -17,7 +17,7 @@
         Handler<CasePassed>,
         Handler<CaseFailed>
     {
-        public delegate void PostAction(string uri, string mediaType, string content);
+        public delegate void PostAction(string uri, TestResult testResult);
 
         readonly PostAction postAction;
         readonly string uri;
@@ -28,7 +28,11 @@
         internal static AppVeyorListener? Create()
         {
             if (GetEnvironmentVariable("APPVEYOR") == "True")
-                return new AppVeyorListener();
+            {
+                var uri = GetEnvironmentVariable("APPVEYOR_API_URL");
+                if (uri != null)
+                    return new AppVeyorListener(uri, Post);
+            }
 
             return null;
         }
@@ -39,15 +43,11 @@
             Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
-        public AppVeyorListener()
-            : this(GetEnvironmentVariable("APPVEYOR_API_URL"), Post)
-        {
-        }
-
         public AppVeyorListener(string uri, PostAction postAction)
         {
             this.postAction = postAction;
             this.uri = new Uri(new Uri(uri), "api/tests").ToString();
+            runName = "Unknown";
         }
 
         public void Handle(AssemblyStarted message)
@@ -64,59 +64,54 @@
 
         public void Handle(CaseSkipped message)
         {
-            Post(message, x =>
+            Post(new TestResult(runName, message, "Skipped")
             {
-                x.Outcome = "Skipped";
-                x.ErrorMessage = message.Reason;
+                ErrorMessage = message.Reason
             });
         }
 
         public void Handle(CasePassed message)
         {
-            Post(message, x =>
-            {
-                x.Outcome = "Passed";
-            });
+            Post(new TestResult(runName, message, "Passed"));
         }
 
         public void Handle(CaseFailed message)
         {
-            Post(message, x =>
+            Post(new TestResult(runName, message, "Failed")
             {
-                x.Outcome = "Failed";
-                x.ErrorMessage = message.Exception.Message;
-                x.ErrorStackTrace =
+                ErrorMessage = message.Exception.Message,
+                ErrorStackTrace =
                     message.Exception.GetType().FullName +
                     NewLine +
-                    message.Exception.LiterateStackTrace();
+                    message.Exception.LiterateStackTrace()
             });
         }
 
-        void Post(CaseCompleted message, Action<TestResult> customize)
+        void Post(TestResult testResult)
         {
-            var testResult = new TestResult
-            {
-                TestFramework = "Fixie",
-                FileName = runName,
-                TestName = message.Name,
-                DurationMilliseconds = message.Duration.TotalMilliseconds.ToString("0"),
-                StdOut = message.Output
-            };
-
-            customize(testResult);
-
-            postAction(uri, "application/json", Serialize(testResult));
+            postAction(uri, testResult);
         }
 
-        static void Post(string uri, string mediaType, string content)
+        static void Post(string uri, TestResult testResult)
         {
-            Client.PostAsync(uri, new StringContent(content, Encoding.UTF8, mediaType))
+            var content = Serialize(testResult);
+            Client.PostAsync(uri, new StringContent(content, Encoding.UTF8, "application/json"))
                 .ContinueWith(x => x.Result.EnsureSuccessStatusCode())
                 .Wait();
         }
 
         public class TestResult
         {
+            public TestResult(string runName, CaseCompleted message, string outcome)
+            {
+                TestFramework = "Fixie";
+                FileName = runName;
+                TestName = message.Name;
+                Outcome = outcome;
+                DurationMilliseconds = message.Duration.TotalMilliseconds.ToString("0");
+                StdOut = message.Output;
+            }
+
             public string TestFramework { get; set; }
             public string FileName { get; set; }
             public string TestName { get; set; }
@@ -124,7 +119,7 @@
             public string DurationMilliseconds { get; set; }
             public string StdOut { get; set; }
             public string? ErrorMessage { get; set; }
-            public string ErrorStackTrace { get; set; }
+            public string? ErrorStackTrace { get; set; }
         }
     }
 }

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -253,7 +253,7 @@
             public string testCaseTitle { get; set; }
             public double durationInMs { get; set; }
             public string outcome { get; set; }
-            public string errorMessage { get; set; }
+            public string? errorMessage { get; set; }
             public string stackTrace { get; set; }
         }
     }

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -35,7 +35,7 @@
         readonly ApiAction send;
         readonly HttpClient client;
 
-        string runUrl;
+        string? runUrl;
 
         readonly int batchSize;
         readonly List<Result> batch;
@@ -299,7 +299,7 @@
 
         public class TestRun
         {
-            public string url { get; set; }
+            public string? url { get; set; }
         }
 
         public class Result

--- a/src/Fixie/Internal/Listeners/AzureListener.cs
+++ b/src/Fixie/Internal/Listeners/AzureListener.cs
@@ -122,7 +122,7 @@
                 x.outcome = "Failed";
                 x.errorMessage = message.Exception.Message;
                 x.stackTrace =
-                    message.Exception.TypeName() +
+                    message.Exception.GetType().FullName +
                     NewLine +
                     message.Exception.LiterateStackTrace();
             });

--- a/src/Fixie/Internal/Listeners/ConsoleListener.cs
+++ b/src/Fixie/Internal/Listeners/ConsoleListener.cs
@@ -30,7 +30,7 @@
             Console.WriteLine();
             Console.WriteLine(message.Exception.Message);
             Console.WriteLine();
-            Console.WriteLine(message.Exception.TypeName());
+            Console.WriteLine(message.Exception.GetType().FullName);
             Console.WriteLine(message.Exception.LiterateStackTrace());
             Console.WriteLine();
         }

--- a/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
+++ b/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
@@ -26,7 +26,7 @@
                     walk = walk.InnerException;
                     console.WriteLine();
                     console.WriteLine();
-                    console.WriteLine($"------- Inner Exception: {walk.TypeName()} -------");
+                    console.WriteLine($"------- Inner Exception: {walk.GetType().FullName} -------");
                     console.WriteLine(walk.Message);
                     console.Write(walk.StackTrace);
                 }

--- a/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
+++ b/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
@@ -9,8 +9,8 @@
 
     static class ExceptionExtensions
     {
-        static readonly MethodInfo CaseExecuteMethod = typeof(Case).GetMethod("Execute");
-        static readonly MethodInfo ExceptionRethrowMethod = typeof(ExceptionDispatchInfo).GetMethod("Throw", new Type[] { });
+        static readonly MethodInfo CaseExecuteMethod = typeof(Case).GetMethod("Execute")!;
+        static readonly MethodInfo ExceptionRethrowMethod = typeof(ExceptionDispatchInfo).GetMethod("Throw", new Type[] { })!;
 
         public static string LiterateStackTrace(this Exception exception)
         {
@@ -35,7 +35,7 @@
             }
         }
 
-        public static string StackTraceOmittingInternalRethrow(Exception exception)
+        public static string? StackTraceOmittingInternalRethrow(Exception exception)
         {
             // If the stack trace ends with a well-known internal segment caused by
             // ExceptionDispatchInfo.Throw(), attempt to omit that section.
@@ -75,7 +75,7 @@
 
             var lastFrame = frames.Last();
 
-            if (lastFrame.GetMethod() != CaseExecuteMethod)
+            if (lastFrame == null || lastFrame.GetMethod() != CaseExecuteMethod)
                 return exception.StackTrace;
 
             if (TryCountFramesToRemove(frames, out var numberOfTrailingStackFramesToRemove))
@@ -120,13 +120,15 @@
             return exception.StackTrace;
         }
 
-        static bool TryCountFramesToRemove(StackFrame[] frames, out int numberOfTrailingStackFramesToRemove)
+        static bool TryCountFramesToRemove(StackFrame?[] frames, out int numberOfTrailingStackFramesToRemove)
         {
             numberOfTrailingStackFramesToRemove = 0;
 
             for (int i = frames.Length - 1; i >= 0; i--)
             {
-                if (frames[i].GetMethod() == ExceptionRethrowMethod)
+                var frame = frames[i];
+
+                if (frame != null && frame.GetMethod() == ExceptionRethrowMethod)
                     return true;
 
                 numberOfTrailingStackFramesToRemove++;

--- a/src/Fixie/Internal/Listeners/PipeListener.cs
+++ b/src/Fixie/Internal/Listeners/PipeListener.cs
@@ -1,6 +1,5 @@
 ﻿namespace Fixie.Internal.Listeners
 {
-    using System;
     using System.IO.Pipes;
     using Internal;
 
@@ -18,83 +17,10 @@
             this.pipe = pipe;
         }
 
-        public void Handle(MethodDiscovered message)
-        {
-            var test = new Test(message.Method);
-
-            Write(new PipeMessage.TestDiscovered
-            {
-                Test = new PipeMessage.Test
-                {
-                    Class = test.Class,
-                    Method = test.Method,
-                    Name = test.Name
-                }
-            });
-        }
-
-        public void Handle(CaseStarted message)
-        {
-            var test = new Test(message.Method);
-
-            Write(new PipeMessage.CaseStarted
-            {
-                Test = new PipeMessage.Test
-                {
-                    Class = test.Class,
-                    Method = test.Method,
-                    Name = test.Name
-                },
-
-                Name = message.Name,
-            });
-        }
-
-        public void Handle(CaseSkipped message)
-        {
-            Write<PipeMessage.CaseSkipped>(message, x =>
-            {
-                x.Reason = message.Reason;
-            });
-        }
-
-        public void Handle(CasePassed message)
-        {
-            Write<PipeMessage.CasePassed>(message);
-        }
-
-        public void Handle(CaseFailed message)
-        {
-            Write<PipeMessage.CaseFailed>(message, x =>
-            {
-                x.Exception = new PipeMessage.Exception(message.Exception);
-            });
-        }
-
-        void Write<TTestResult>(CaseCompleted message, Action<TTestResult> customize = null)
-            where TTestResult : PipeMessage.CaseCompleted, new()
-        {
-            var test = new Test(message.Method);
-
-            var result = new TTestResult
-            {
-                Test = new PipeMessage.Test
-                {
-                    Class = test.Class,
-                    Method = test.Method,
-                    Name = test.Name
-                },
-
-                Name = message.Name,
-                Duration = message.Duration,
-                Output = message.Output
-            };
-
-            customize?.Invoke(result);
-
-            Write(result);
-        }
-
-        void Write<T>(T message) => pipe.Send(message);
+        public void Handle(MethodDiscovered message) => pipe.Send(new PipeMessage.TestDiscovered(message));
+        public void Handle(CaseStarted message) => pipe.Send(new PipeMessage.CaseStarted(message));
+        public void Handle(CaseSkipped message) => pipe.Send(new PipeMessage.CaseSkipped(message));
+        public void Handle(CasePassed message) => pipe.Send(new PipeMessage.CasePassed(message));
+        public void Handle(CaseFailed message) => pipe.Send(new PipeMessage.CaseFailed(message));
     }
 }

--- a/src/Fixie/Internal/Listeners/PipeMessage.cs
+++ b/src/Fixie/Internal/Listeners/PipeMessage.cs
@@ -59,7 +59,7 @@
 
             public Exception(System.Exception exception)
             {
-                Type = exception.TypeName();
+                Type = exception.GetType().FullName;
                 Message = exception.Message;
                 StackTrace = exception.LiterateStackTrace();
             }

--- a/src/Fixie/Internal/Listeners/PipeMessage.cs
+++ b/src/Fixie/Internal/Listeners/PipeMessage.cs
@@ -2,71 +2,152 @@
 {
     using System;
 
+    // Because we only deserialize message instances that had been constructed
+    // and serialized in a null-safe fashion, deserialization is trusted. Whenever
+    // a default constructor is needed only to satisfy the deserializer, it is
+    // declared both private and empty, with corresponding default! per property.
+
     public static class PipeMessage
     {
         public class Test
         {
-            public string Class { get; set; }
-            public string Method { get; set; }
-            public string Name { get; set; }
+            public Test(Fixie.Test test)
+            {
+                Class = test.Class;
+                Method = test.Method;
+                Name = test.Name;
+            }
+
+            Test() { /* Trust Deserialization */ }
+
+            public string Class { get; set; } = default!;
+            public string Method { get; set; } = default!;
+            public string Name { get; set; } = default!;
         }
 
         public class DiscoverTests { }
 
         public class ExecuteTests
         {
+            public ExecuteTests()
+                : this(Array.Empty<Test>()) { }
+
+            public ExecuteTests(Test[] filter)
+            {
+                Filter = filter;
+            }
+
             public Test[] Filter { get; set; }
         }
 
         public class TestDiscovered
         {
-            public Test Test { get; set; }
+            public TestDiscovered(MethodDiscovered message)
+                => Test = new Test(new Fixie.Test(message.Method));
+
+            TestDiscovered() { /* Trust Deserialization */ }
+
+            public Test Test { get; set; } = default!;
         }
 
         public class CaseStarted
         {
-            public Test Test { get; set; }
-            public string Name { get; set; }
+            public CaseStarted(Internal.CaseStarted message)
+            {
+                Test = new Test(new Fixie.Test(message.Method));
+                Name = message.Name;
+            }
+
+            CaseStarted() { /* Trust Deserialization */ }
+
+            public Test Test { get; set; } = default!;
+            public string Name { get; set; } = default!;
         }
 
         public abstract class CaseCompleted
         {
-            public Test Test { get; set; }
-            public string Name { get; set; }
+            protected CaseCompleted(Internal.CaseCompleted message)
+            {
+                var test = new Fixie.Test(message.Method);
+
+                Test = new Test(test);
+                Name = message.Name;
+                Duration = message.Duration;
+                Output = message.Output;
+            }
+
+            protected CaseCompleted() { /* Trust Deserialization */ }
+
+            public Test Test { get; set; } = default!;
+            public string Name { get; set; } = default!;
             public TimeSpan Duration { get; set; }
-            public string Output { get; set; }
+            public string Output { get; set; } = default!;
         }
 
         public class CaseSkipped : CaseCompleted
         {
+            public CaseSkipped(Internal.CaseSkipped message)
+                : base(message)
+            {
+                Reason = message.Reason;
+            }
+
+            CaseSkipped() { /* Trust Deserialization */ }
+
             public string? Reason { get; set; }
         }
 
         public class CasePassed : CaseCompleted
         {
+            public CasePassed(Internal.CasePassed message)
+                :base(message) { }
+
+            CasePassed() { /* Trust Deserialization */ }
         }
 
         public class CaseFailed : CaseCompleted
         {
-            public Exception Exception { get; set; }
+            public CaseFailed(Internal.CaseFailed message)
+                : base(message)
+            {
+                Exception = new Exception(message.Exception);
+            }
+
+            public CaseFailed(CaseStarted caseStarted, Exception exception)
+            {
+                Test = caseStarted.Test;
+                Name = caseStarted.Name;
+                Output = "";
+                Duration = TimeSpan.Zero;
+                Exception = exception;
+            }
+
+            CaseFailed() { /* Trust Deserialization */ }
+
+            public Exception Exception { get; set; } = default!;
         }
 
         public class Exception
         {
-            public Exception()
-            {
-            }
-
             public Exception(System.Exception exception)
             {
-                Type = exception.GetType().FullName;
+                Type = exception.GetType().FullName!;
                 Message = exception.Message;
                 StackTrace = exception.LiterateStackTrace();
             }
 
-            public string Type { get; set; }
-            public string Message { get; set; }
-            public string StackTrace { get; set; }
+            public Exception(string type, string message, string stackTrace)
+            {
+                Type = type;
+                Message = message;
+                StackTrace = stackTrace;
+            }
+
+            Exception() { /* Trust Deserialization */ }
+
+            public string Type { get; set; } = default!;
+            public string Message { get; set; } = default!;
+            public string StackTrace { get; set; } = default!;
         }
 
         public class Completed { }

--- a/src/Fixie/Internal/Listeners/PipeMessage.cs
+++ b/src/Fixie/Internal/Listeners/PipeMessage.cs
@@ -39,7 +39,7 @@
 
         public class CaseSkipped : CaseCompleted
         {
-            public string Reason { get; set; }
+            public string? Reason { get; set; }
         }
 
         public class CasePassed : CaseCompleted

--- a/src/Fixie/Internal/Listeners/PipeStreamExtensions.cs
+++ b/src/Fixie/Internal/Listeners/PipeStreamExtensions.cs
@@ -26,6 +26,10 @@
         public static void Send<TMessage>(this PipeStream pipe, TMessage message)
         {
             var messageType = typeof(TMessage).FullName;
+
+            if (messageType == null)
+                throw new Exception($"Expected type {typeof(TMessage).Name} to have a non-null FullName.");
+
             SendMessageBytes(pipe, Encoding.UTF8.GetBytes(messageType));
 
             SendMessageBytes(pipe, SerializeToBytes(message));

--- a/src/Fixie/Internal/Listeners/ReportListener.cs
+++ b/src/Fixie/Internal/Listeners/ReportListener.cs
@@ -58,7 +58,7 @@
                     new XAttribute("result", "Fail"),
                     new XAttribute("time", Seconds(message.Duration)),
                     new XElement("failure",
-                        new XAttribute("exception-type", message.Exception.TypeName()),
+                        new XAttribute("exception-type", message.Exception.GetType().FullName),
                         new XElement("message", new XCData(message.Exception.Message)),
                         new XElement("stack-trace", new XCData(message.Exception.LiterateStackTrace())))));
         }

--- a/src/Fixie/Internal/Listeners/ReportListener.cs
+++ b/src/Fixie/Internal/Listeners/ReportListener.cs
@@ -21,14 +21,14 @@
         internal static ReportListener? Create(Options options)
         {
             if (options.Report != null)
-                return new ReportListener(SaveReport(options));
+                return new ReportListener(SaveReport(options.Report));
 
             return null;
         }
 
-        static Action<XDocument> SaveReport(Options options)
+        static Action<XDocument> SaveReport(string absoluteOrRelativePath)
         {
-            return report => Save(report, FullPath(options.Report));
+            return report => Save(report, FullPath(absoluteOrRelativePath));
         }
 
         static string FullPath(string absoluteOrRelativePath)

--- a/src/Fixie/Internal/Listeners/ReportListener.cs
+++ b/src/Fixie/Internal/Listeners/ReportListener.cs
@@ -15,8 +15,8 @@
     {
         readonly Action<XDocument> save;
 
-        List<XElement> currentClass = new List<XElement>();
-        List<XElement> classes = new List<XElement>();
+        readonly List<XElement> currentClass = new List<XElement>();
+        readonly List<XElement> classes = new List<XElement>();
 
         internal static ReportListener? Create(Options options)
         {
@@ -93,7 +93,7 @@
                     new XAttribute("skipped", message.Skipped),
                     currentClass));
 
-            currentClass = new List<XElement>();
+            currentClass.Clear();
         }
 
         public void Handle(AssemblyCompleted message)
@@ -115,7 +115,7 @@
                         new XAttribute("test-framework", Fixie.Framework.Version),
                         classes))));
 
-            classes = null;
+            classes.Clear();
         }
 
         static string Framework => Environment.Version.ToString();

--- a/src/Fixie/Internal/Listeners/TeamCityListener.cs
+++ b/src/Fixie/Internal/Listeners/TeamCityListener.cs
@@ -36,7 +36,7 @@
         public void Handle(CaseFailed message)
         {
             var details =
-                message.Exception.TypeName() +
+                message.Exception.GetType().FullName +
                 NewLine +
                 message.Exception.LiterateStackTrace();
 

--- a/src/Fixie/Internal/Listeners/TeamCityListener.cs
+++ b/src/Fixie/Internal/Listeners/TeamCityListener.cs
@@ -61,7 +61,7 @@
             Message("testFinished name='{0}' duration='{1}'", message.Name, DurationInMilliseconds(message.Duration));
         }
 
-        static void Message(string format, params string[] args)
+        static void Message(string format, params string?[] args)
         {
             var encodedArgs = args.Select(Encode).Cast<object>().ToArray();
             Console.WriteLine("##teamcity[" + format + "]", encodedArgs);
@@ -73,7 +73,7 @@
                 Message("testStdOut name='{0}' out='{1}'", message.Name, message.Output);
         }
 
-        static string Encode(string value)
+        static string Encode(string? value)
         {
             if (value == null)
                 return "";

--- a/src/Fixie/Internal/Maybe.cs
+++ b/src/Fixie/Internal/Maybe.cs
@@ -1,0 +1,22 @@
+﻿namespace Fixie.Internal
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+
+    static class Maybe
+    {
+        public static bool Try<T>(Func<T> create, [NotNullWhen(true)] out T output)
+        {
+            output = create();
+
+            return output != null;
+        }
+
+        public static bool Try<TInput, TOutput>(Func<TInput, TOutput> create, TInput input, [NotNullWhen(true)] out TOutput output)
+        {
+            output = create(input);
+
+            return output != null;
+        }
+    }
+}

--- a/src/Fixie/Internal/Options.cs
+++ b/src/Fixie/Internal/Options.cs
@@ -5,12 +5,12 @@
 
     class Options
     {
-        public Options(string report)
+        public Options(string? report)
         {
             Report = report;
         }
 
-        public string Report { get; }
+        public string? Report { get; }
 
         public void Validate()
         {

--- a/src/Fixie/Internal/ParameterDiscoverer.cs
+++ b/src/Fixie/Internal/ParameterDiscoverer.cs
@@ -11,7 +11,7 @@
         public ParameterDiscoverer(Discovery discovery)
             => parameterSources = discovery.Config.ParameterSources;
 
-        public IEnumerable<object[]> GetParameters(MethodInfo method)
+        public IEnumerable<object?[]> GetParameters(MethodInfo method)
             => parameterSources.SelectMany(source => source.GetParameters(method));
     }
 }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -49,7 +49,7 @@
             return Run(types, method => request[method.ReflectedType!.FullName!].Contains(method.Name));
         }
 
-        ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, Func<MethodInfo, bool> methodCondition = null)
+        ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, Func<MethodInfo, bool>? methodCondition = null)
         {
             new BehaviorDiscoverer(assembly, customArguments)
                 .GetBehaviors(out var discovery, out var execution);

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -46,7 +46,7 @@
                 request[test.Class].Add(test.Method);
             }
 
-            return Run(types, method => request[method.ReflectedType.FullName].Contains(method.Name));
+            return Run(types, method => request[method.ReflectedType!.FullName!].Contains(method.Name));
         }
 
         ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, Func<MethodInfo, bool> methodCondition = null)

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -20,7 +20,7 @@
         /// For async Task methods, returns null after awaiting the Task.
         /// For async Task<![CDATA[<T>]]> methods, returns the Result T after awaiting the Task.
         /// </returns>
-        public static object? Execute(this MethodInfo method, object instance, params object[] parameters)
+        public static object? Execute(this MethodInfo method, object instance, object?[] parameters)
         {
             if (method.IsVoid() && method.HasAsyncKeyword())
                 throw new NotSupportedException(
@@ -34,7 +34,7 @@
 
             try
             {
-                result = method.Invoke(instance, parameters != null && parameters.Length == 0 ? null : parameters);
+                result = method.Invoke(instance, parameters.Length == 0 ? null : parameters);
             }
             catch (TargetInvocationException exception)
             {

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Fixie
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
@@ -9,7 +10,7 @@
 
     public static class MethodInfoExtensions
     {
-        static MethodInfo startAsTask;
+        static MethodInfo? startAsTask;
 
         /// <summary>
         /// Execute the given method against the given instance of its class.
@@ -38,7 +39,7 @@
             }
             catch (TargetInvocationException exception)
             {
-                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
                 throw; //Unreachable.
             }
 
@@ -55,7 +56,7 @@
 
             if (method.ReturnType.IsGenericType)
             {
-                var property = task.GetType().GetProperty("Result", BindingFlags.Instance | BindingFlags.Public);
+                var property = task.GetType().GetProperty("Result", BindingFlags.Instance | BindingFlags.Public)!;
 
                 return property.GetValue(task, null);
             }
@@ -68,7 +69,7 @@
             return method.Has<AsyncStateMachineAttribute>();
         }
 
-        static bool ConvertibleToTask(object result, out Task task)
+        static bool ConvertibleToTask(object result, [NotNullWhen(true)] out Task? task)
         {
             if (result is Task t)
             {
@@ -101,7 +102,7 @@
                 if (startAsTask == null)
                     startAsTask = resultType
                         .Assembly
-                        .GetType("Microsoft.FSharp.Control.FSharpAsync")
+                        .GetType("Microsoft.FSharp.Control.FSharpAsync")!
                         .GetRuntimeMethods()
                         .Single(x => x.Name == "StartAsTask");
             }
@@ -112,7 +113,7 @@
 
             var genericStartAsTask = startAsTask.MakeGenericMethod(resultType.GetGenericArguments());
 
-            return (Task) genericStartAsTask.Invoke(null, new[] { result, null, null });
+            return (Task) genericStartAsTask.Invoke(null, new[] { result, null, null })!;
         }
     }
 }

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -20,7 +20,7 @@
         /// For async Task methods, returns null after awaiting the Task.
         /// For async Task<![CDATA[<T>]]> methods, returns the Result T after awaiting the Task.
         /// </returns>
-        public static object Execute(this MethodInfo method, object instance, params object[] parameters)
+        public static object? Execute(this MethodInfo method, object instance, params object[] parameters)
         {
             if (method.IsVoid() && method.HasAsyncKeyword())
                 throw new NotSupportedException(
@@ -30,7 +30,7 @@
             if (method.ContainsGenericParameters)
                 throw new Exception("Could not resolve type parameters for generic method.");
 
-            object result;
+            object? result;
 
             try
             {

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -20,7 +20,7 @@
         /// For async Task methods, returns null after awaiting the Task.
         /// For async Task<![CDATA[<T>]]> methods, returns the Result T after awaiting the Task.
         /// </returns>
-        public static object? Execute(this MethodInfo method, object instance, object?[] parameters)
+        public static object? Execute(this MethodInfo method, object? instance, object?[] parameters)
         {
             if (method.IsVoid() && method.HasAsyncKeyword())
                 throw new NotSupportedException(

--- a/src/Fixie/ParameterSource.cs
+++ b/src/Fixie/ParameterSource.cs
@@ -15,6 +15,6 @@
     /// </summary>
     public interface ParameterSource
     {
-        IEnumerable<object[]> GetParameters(MethodInfo method);
+        IEnumerable<object?[]> GetParameters(MethodInfo method);
     }
 }

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -26,7 +26,7 @@
             return method.GetCustomAttributes<TAttribute>(true).Any();
         }
 
-        public static void Dispose(this object o)
+        public static void Dispose(this object? o)
         {
             (o as IDisposable)?.Dispose();
         }

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -6,11 +6,6 @@
 
     public static class ReflectionExtensions
     {
-        public static string TypeName(this object o)
-        {
-            return o?.GetType().FullName;
-        }
-
         public static bool IsVoid(this MethodInfo method)
         {
             return method.ReturnType == typeof(void);

--- a/src/Fixie/Test.cs
+++ b/src/Fixie/Test.cs
@@ -10,7 +10,7 @@ namespace Fixie
 
         public Test(MethodInfo method)
         {
-            Class = method.ReflectedType.FullName;
+            Class = method.ReflectedType!.FullName!;
             Method = method.Name;
             Name = Class + "." + Method;
         }

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -37,7 +37,7 @@
         /// Constructs an instance of the test class type, using its default constructor.
         /// If the class is static, no action is taken and null is returned.
         /// </summary>
-        public object Construct()
+        public object? Construct()
         {
             if (isStatic)
                 return null;

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -13,7 +13,7 @@
         readonly bool isStatic;
         internal TestClass(Type type, Action<Action<Case>> runCases) : this(type, runCases, null) { }
 
-        internal TestClass(Type type, Action<Action<Case>> runCases, MethodInfo targetMethod)
+        internal TestClass(Type type, Action<Action<Case>> runCases, MethodInfo? targetMethod)
         {
             this.runCases = runCases;
             Type = type;
@@ -31,7 +31,7 @@
         /// test runner as the sole method to be executed.
         /// Null under normal test execution.
         /// </summary>
-        public MethodInfo TargetMethod { get; }
+        public MethodInfo? TargetMethod { get; }
 
         /// <summary>
         /// Constructs an instance of the test class type, using its default constructor.
@@ -48,7 +48,7 @@
             }
             catch (TargetInvocationException exception)
             {
-                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
                 throw; //Unreachable.
             }
         }


### PR DESCRIPTION
Here we enable Nullable Reference Types, address all resulting warnings, and then begin to treat all future warnings as errors.

Guiding principles:
* Use the null forgiveness operator `!` sparingly. It usually indicates a bad design or overconfident assumption. Most usages of it come down to our calls to .NET methods where nulls can be returned to us, but only for edge cases that simply do not apply in our calls.
* Use the null hint `?` for items meaningfully intended to be null, otherwise use it sparingly. When historically-nullable values could easily be made never-null, we apply that improvement.
* When a value has to be treated as apparently-nullable, but we have *extreme* confidence that the value will be properly set to a non-null value either by the compiler or reflection by the time we actually access it, mark these special cases with `default!`. Literally this is the same to the compiler as the phrase `null!`, but we will read it as "This is trusted to have a non-null value defaulted for us through atypical means." Primary examples are [Caller...] parameters set for us by the compiler, and highly-trusted deserializations of objects *we* serialized with non-null values.)