### PR TITLE
Shorthand for common attribute lookup patterns in custom conventions.

### DIFF
--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -33,9 +33,9 @@
             {
                 testClass.RunCases(@case =>
                 {
-                    if (@case.Method.Has<SkipAttribute>())
+                    if (@case.Method.Has<SkipAttribute>(out var skip))
                     {
-                        @case.Skip(@case.Method.GetCustomAttribute<SkipAttribute>()!.Reason);
+                        @case.Skip(skip.Reason);
                         return;
                     }
 

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -28,7 +28,7 @@
 
             Method<AttributeSample>("AttributeOnBaseDeclaration").Has<SampleMethodAttribute>().ShouldBe(true);
             Method<AttributeSample>("AttributeOnOverrideDeclaration").Has<SampleMethodAttribute>().ShouldBe(true);
-            Method<AttributeSample>("NoAttrribute").Has<SampleMethodAttribute>().ShouldBe(false);
+            Method<AttributeSample>("NoAttribute").Has<SampleMethodAttribute>().ShouldBe(false);
         }
 
         public void CanDetectAndObtainAttributeWhenOneTimeUseAttributeIsPresent()
@@ -97,7 +97,7 @@
             [SampleMethod]
             public virtual void AttributeOnBaseDeclaration() { }
             public virtual void AttributeOnOverrideDeclaration() { }
-            public virtual void NoAttrribute() { }
+            public virtual void NoAttribute() { }
         }
 
         [NonInherited]
@@ -106,7 +106,7 @@
             public override void AttributeOnBaseDeclaration() { }
             [SampleMethod]
             public override void AttributeOnOverrideDeclaration() { }
-            public override void NoAttrribute() { }
+            public override void NoAttribute() { }
         }
 
         static MethodInfo Method(string name)

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -31,6 +31,28 @@
             Method<AttributeSample>("NoAttrribute").Has<SampleMethodAttribute>().ShouldBe(false);
         }
 
+        public void CanDetectAndObtainAttributeWhenOneTimeUseAttributeIsPresent()
+        {
+            //Zero Matches
+            var hasMissingAttribute =  typeof(AttributeSample).Has<AttributeUsageAttribute>(out var missingAttribute);
+            hasMissingAttribute.ShouldBe(false);
+            missingAttribute.ShouldBe(null);
+
+            //Single Match, Inherited
+            var hasInheritedAttribute = typeof(AttributeSample).Has<InheritedAttribute>(out var inheritedAttribute);
+            hasInheritedAttribute.ShouldBe(true);
+            inheritedAttribute.ShouldBe<InheritedAttribute>();
+
+            //Single Match, Not Inherited
+            var hasNonInheritedAttribute = typeof(AttributeSample).Has<NonInheritedAttribute>(out var nonInheritedAttribute);
+            hasNonInheritedAttribute.ShouldBe(true);
+            nonInheritedAttribute.ShouldBe<NonInheritedAttribute>();
+
+            //Ambiguous Match
+            Action attemptAmbiguousAttributeLookup = () => typeof(AttributeSample).Has<AmbiguouslyMultipleAttribute>(out _);
+            attemptAmbiguousAttributeLookup.ShouldThrow<AmbiguousMatchException>("Multiple custom attributes of the same type found.");
+        }
+
         public void CanDisposeDisposables()
         {
             var disposeable = new Disposable();
@@ -59,12 +81,17 @@
         class InheritedAttribute : Attribute { }
         class NonInheritedAttribute : Attribute { }
 
+        [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+        class AmbiguouslyMultipleAttribute : Attribute { }
+
         static class StaticClass { }
         abstract class AbstractClass { }
         class ConcreteClass { }
         sealed class SealedConcreteClass { }
 
         [Inherited]
+        [AmbiguouslyMultiple]
+        [AmbiguouslyMultiple]
         abstract class AttributeSampleBase
         {
             [SampleMethod]

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -20,15 +20,12 @@
             typeof(SealedConcreteClass).IsStatic().ShouldBe(false);
         }
 
-        public void CanDetectClassAttributes()
+        public void CanDetectAttributes()
         {
             typeof(AttributeSample).Has<InheritedAttribute>().ShouldBe(true);
             typeof(AttributeSample).Has<NonInheritedAttribute>().ShouldBe(true);
             typeof(AttributeSample).Has<AttributeUsageAttribute>().ShouldBe(false);
-        }
 
-        public void CanDetectMethodAttributes()
-        {
             Method<AttributeSample>("AttributeOnBaseDeclaration").Has<SampleMethodAttribute>().ShouldBe(true);
             Method<AttributeSample>("AttributeOnOverrideDeclaration").Has<SampleMethodAttribute>().ShouldBe(true);
             Method<AttributeSample>("NoAttrribute").Has<SampleMethodAttribute>().ShouldBe(false);

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -1,8 +1,10 @@
 ﻿namespace Fixie
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
+    using static Internal.Maybe;
 
     public static class ReflectionExtensions
     {
@@ -19,6 +21,11 @@
         public static bool Has<TAttribute>(this MemberInfo member) where TAttribute : Attribute
         {
             return member.GetCustomAttributes<TAttribute>(true).Any();
+        }
+
+        public static bool Has<TAttribute>(this MemberInfo member, [NotNullWhen(true)] out TAttribute? matchingAttribute) where TAttribute : Attribute
+        {
+            return Try(() => member.GetCustomAttribute<TAttribute>(true), out matchingAttribute);
         }
 
         public static void Dispose(this object? o)

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -16,14 +16,9 @@
             return type.IsAbstract && type.IsSealed;
         }
 
-        public static bool Has<TAttribute>(this Type type) where TAttribute : Attribute
+        public static bool Has<TAttribute>(this MemberInfo member) where TAttribute : Attribute
         {
-            return type.GetCustomAttributes<TAttribute>(true).Any();
-        }
-
-        public static bool Has<TAttribute>(this MethodInfo method) where TAttribute : Attribute
-        {
-            return method.GetCustomAttributes<TAttribute>(true).Any();
+            return member.GetCustomAttributes<TAttribute>(true).Any();
         }
 
         public static void Dispose(this object? o)


### PR DESCRIPTION
1. Consolidate redundant `Has<TAttribute>()` extension methods, by recognizing their reliance on a common base type: `Type` and `MethodInfo` are both `MemberInfo`, and `MemberInfo` is the relevant `this` type in play here.

2. Add the `MemberInfo.Has<TAttribute>(out)` extension method, which provides efficient, null-safe shorthand for the common pattern of checking for the presence of a singly-applied `Attribute` and getting a reference to that `Attribute` when present. Custom conventions are likely to benefit from this shorthand. For instance, a convention that allows for a test to be skipped by applying `[Skip("Skipping until issue 234 closes.")]` can be simply expressed: "if this test case has a `SkipAttribute` then skip it for this reason".