### PR TITLE
Cross-Platform Build Script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,11 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest] # ubuntu-latest, macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: pwsh ./build.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest] # macos-latest
+        os: [windows-latest] # ubuntu-latest, macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.201
     - run: pwsh ./build.ps1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest] # ubuntu-latest, macos-latest
+        os: [windows-latest, ubuntu-latest] # macos-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.201
     - run: pwsh ./build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,6 @@
+version: '{build}'
+skip_tags: true
+image: Visual Studio 2019
+build_script:
+- pwsh: ./build
+test: off

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,6 @@ pool:
   vmImage: windows-latest
 
 steps:
-- script: build
+- pwsh: ./build
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/build-helpers.ps1
+++ b/build-helpers.ps1
@@ -16,7 +16,7 @@ function generate($path, $content) {
 }
 
 function mit-license($copyright) {
-    generate "$PSScriptRoot\LICENSE.md" @"
+    generate "$PSScriptRoot/LICENSE.md" @"
 MIT License
 
 $copyright

--- a/build-helpers.ps1
+++ b/build-helpers.ps1
@@ -16,7 +16,7 @@ function generate($path, $content) {
 }
 
 function mit-license($copyright) {
-    generate "LICENSE.md" @"
+    generate "$PSScriptRoot\LICENSE.md" @"
 MIT License
 
 $copyright

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-pwsh -NoProfile -ExecutionPolicy Bypass -Command "& '.\build.ps1' %*;"

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-powershell -NoProfile -ExecutionPolicy Bypass -Command "& '.\build.ps1' %*;"
+pwsh -NoProfile -ExecutionPolicy Bypass -Command "& '.\build.ps1' %*;"

--- a/build.ps1
+++ b/build.ps1
@@ -13,7 +13,7 @@ $versionSuffix = if ($prerelease) { "beta-{0:D4}" -f $buildNumber } else { "" }
 function Build {
     mit-license $copyright
 
-    generate "src\Directory.build.props" @"
+    generate "$PSScriptRoot\src\Directory.build.props" @"
 <Project>
     <PropertyGroup>
         <Product>Fixie</Product>

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,6 @@
 ﻿param([int]$buildNumber)
 
-. .\build-helpers
+. $PSScriptRoot\build-helpers
 
 $versionPrefix = "3.0.0"
 $prerelease = $true

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,6 @@
 ﻿param([int]$buildNumber)
 
-. $PSScriptRoot\build-helpers
+. $PSScriptRoot/build-helpers
 
 $versionPrefix = "3.0.0"
 $prerelease = $true
@@ -13,7 +13,7 @@ $versionSuffix = if ($prerelease) { "beta-{0:D4}" -f $buildNumber } else { "" }
 function Build {
     mit-license $copyright
 
-    generate "$PSScriptRoot\src\Directory.build.props" @"
+    generate "$PSScriptRoot/src/Directory.build.props" @"
 <Project>
     <PropertyGroup>
         <Product>Fixie</Product>
@@ -39,15 +39,15 @@ function Build {
 }
 
 function Test {
-    $fixie = resolve-path .\src\Fixie.Console\bin\$configuration\netcoreapp2.0\dotnet-fixie.dll
+    $fixie = resolve-path ./src/Fixie.Console/bin/$configuration/netcoreapp2.0/dotnet-fixie.dll
 
     exec { dotnet $fixie --configuration $configuration --no-build } src/Fixie.Tests
 }
 
 function Pack {
     remove-folder packages
-    exec { dotnet pack -c $configuration --no-restore --no-build --nologo } src\Fixie
-    exec { dotnet pack -c $configuration --no-restore --no-build --nologo } src\Fixie.Console
+    exec { dotnet pack -c $configuration --no-restore --no-build --nologo } src/Fixie
+    exec { dotnet pack -c $configuration --no-restore --no-build --nologo } src/Fixie.Console
 }
 
 main {


### PR DESCRIPTION
Before this PR, the build script assumed it would only be executed on Windows, and used a *.cmd shim to invoke that script via Powershell 5, invoked with the `powershell` command.

Now, we have a script that is intended to be executed with the cross-platform Powershell 7, invoked with the `pwsh` command. The script changes favor unix-style/path/separators, and make no assumptions about the current working directory, based on experimentation running the script under various CI systems and operating systems.

The build script *runs* on Windows, Ubuntu, and macOS systems, but currently only *passes* on Windows:

1. There are two normal test failures on macOS, to be addressed in a separate PR.
2. Ubuntu VM runs on GitHub Actions seem to lack prerequisites for using C# 8 features, so that is simply on hold.

We now have explicit CI configuration files for AppVeyor, Azure DevOps, and GitHub Actions. The AppVeyor and Azure DevOps builds are merely for verifying test-reporting integrations with those systems. The GitHub Actions build is our primary CI system moving forward: while AppVeyor and Azure DevOps will focus merely on compiling and collecting test results to their own reporting screens, the GitHub Actions build will eventually grow to target multiple operating systems and to produce the official versioned NuGet package artifacts.