### PR TITLE
Enable successful builds on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest] # ubuntu-latest, macos-latest
+        os: [windows-latest, macos-latest] # ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: pwsh ./build.ps1

--- a/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.Tests.Internal.Listeners
 {
+    using System;
     using System.Linq;
     using System.Text.RegularExpressions;
     using Assertions;
@@ -9,6 +10,8 @@
     {
         public void ShouldReportResultsToTheConsoleInTeamCityFormat()
         {
+            var eol = Environment.NewLine == "\r\n" ? "|r|n" : "|n";
+
             var listener = new TeamCityListener();
 
             Run(listener, out var console);
@@ -21,32 +24,31 @@
 
                     "Console.Out: Fail",
                     "Console.Error: Fail",
-                    "##teamcity[testStarted name='" + TestClass + ".Fail']",
-                    "##teamcity[testStdOut name='" + TestClass + ".Fail' out='Console.Out: Fail|r|nConsole.Error: Fail|r|n']",
-                    "##teamcity[testFailed name='" + TestClass + ".Fail' message='|'Fail|' failed!' details='Fixie.Tests.FailureException|r|n" + At("Fail()") + "']",
-                    "##teamcity[testFinished name='" + TestClass + ".Fail' duration='#']",
+                    $"##teamcity[testStarted name='{TestClass}.Fail']",
+                    $"##teamcity[testStdOut name='{TestClass}.Fail' out='Console.Out: Fail{eol}Console.Error: Fail{eol}']",
+                    $"##teamcity[testFailed name='{TestClass}.Fail' message='|'Fail|' failed!' details='Fixie.Tests.FailureException{eol}{At("Fail()")}']",
+                    $"##teamcity[testFinished name='{TestClass}.Fail' duration='#']",
 
                     "Console.Out: FailByAssertion",
                     "Console.Error: FailByAssertion",
-                    "##teamcity[testStarted name='" + TestClass + ".FailByAssertion']",
-                    "##teamcity[testStdOut name='" + TestClass + ".FailByAssertion' out='Console.Out: FailByAssertion|r|nConsole.Error: FailByAssertion|r|n']",
-                    "##teamcity[testFailed name='" + TestClass + ".FailByAssertion' message='Expected: 2|r|nActual:   1' details='Fixie.Tests.Assertions.AssertException|r|n" + At("FailByAssertion()") + "']",
-                    "##teamcity[testFinished name='" + TestClass + ".FailByAssertion' duration='#']",
+                    $"##teamcity[testStarted name='{TestClass}.FailByAssertion']",
+                    $"##teamcity[testStdOut name='{TestClass}.FailByAssertion' out='Console.Out: FailByAssertion{eol}Console.Error: FailByAssertion{eol}']",
+                    $"##teamcity[testFailed name='{TestClass}.FailByAssertion' message='Expected: 2{eol}Actual:   1' details='Fixie.Tests.Assertions.AssertException{eol}{At("FailByAssertion()")}']",
+                    $"##teamcity[testFinished name='{TestClass}.FailByAssertion' duration='#']",
 
                     "Console.Out: Pass",
                     "Console.Error: Pass",
-                    "##teamcity[testStarted name='" + TestClass + ".Pass']",
-                    "##teamcity[testStdOut name='" + TestClass + ".Pass' out='Console.Out: Pass|r|nConsole.Error: Pass|r|n']",
-                    "##teamcity[testFinished name='" + TestClass + ".Pass' duration='#']",
-
-                    "##teamcity[testStarted name='" + TestClass + ".SkipWithReason']",
-                    "##teamcity[testIgnored name='" + TestClass + ".SkipWithReason' message='|0x26a0 Skipped with reason.']",
-                    "##teamcity[testFinished name='" + TestClass + ".SkipWithReason' duration='#']",
-
-
-                    "##teamcity[testStarted name='" + TestClass + ".SkipWithoutReason']",
-                    "##teamcity[testIgnored name='" + TestClass + ".SkipWithoutReason' message='']",
-                    "##teamcity[testFinished name='" + TestClass + ".SkipWithoutReason' duration='#']",
+                    $"##teamcity[testStarted name='{TestClass}.Pass']",
+                    $"##teamcity[testStdOut name='{TestClass}.Pass' out='Console.Out: Pass{eol}Console.Error: Pass{eol}']",
+                    $"##teamcity[testFinished name='{TestClass}.Pass' duration='#']",
+                    
+                    $"##teamcity[testStarted name='{TestClass}.SkipWithReason']",
+                    $"##teamcity[testIgnored name='{TestClass}.SkipWithReason' message='|0x26a0 Skipped with reason.']",
+                    $"##teamcity[testFinished name='{TestClass}.SkipWithReason' duration='#']",
+                    
+                    $"##teamcity[testStarted name='{TestClass}.SkipWithoutReason']",
+                    $"##teamcity[testIgnored name='{TestClass}.SkipWithoutReason' message='']",
+                    $"##teamcity[testFinished name='{TestClass}.SkipWithoutReason' duration='#']",
 
                     "##teamcity[testSuiteFinished name='Fixie.Tests']");
         }

--- a/src/Fixie.Tests/Internal/OptionsTests.cs
+++ b/src/Fixie.Tests/Internal/OptionsTests.cs
@@ -15,9 +15,9 @@
             Action validReport = new Options(report: "Report.xml").Validate;
             validReport();
 
-            Action invalidReport = new Options(report: "\t").Validate;
+            Action invalidReport = new Options(report: "\0").Validate;
             invalidReport.ShouldThrow<CommandLineException>(
-                "Specified report name is invalid: \t");
+                "Specified report name is invalid: \0");
         }
     }
 }


### PR DESCRIPTION
Getting the build script to succeed on macOS came down to improving the expectations within two tests:

1. When command line argument parsing validates the `--report` command line argument, it correctly relies on the OS-aware `Path.GetInvalidPathChars()` method. However, the *test* of that validation used the tab character `\t` as an example of an invalid character. It turns out that tab is invalid only on Windows. After inspecting the implementation of `Path.GetInvalidPathChars()` for each OS, the null character `\0` is a better choice for the assertion as it is considered invalid everywhere.

2. The support for reporting to TeamCity correctly encodes special characters according to TeamCity's "Service Message" documentation. Although that reporting already *works* on macOS, the *test* of that feature asserted representative messages that assumed Windows-style line endings. The test's assertion is now OS-aware.