### PR TITLE
Improve Generic Type Argument Resolution

### DIFF
--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -107,6 +107,13 @@ namespace Fixie.Tests.Assertions
                 itemExpectations[i](actualItems[i]);
         }
 
+        public static void ShouldBeGenericTypeParameter(this Type actual, string expectedName)
+        {
+            actual.IsGenericParameter.ShouldBe(true);
+            actual.FullName.ShouldBe(null);
+            actual.Name.ShouldBe(expectedName);
+        }
+
         static string Json<T>(T @object)
         {
             return JsonSerializer.Serialize(@object, JsonSerializerOptions);

--- a/src/Fixie.Tests/CaseTests.cs
+++ b/src/Fixie.Tests/CaseTests.cs
@@ -120,7 +120,7 @@
                 .Name.ShouldBe("Fixie.Tests.CaseTests.Generic<System.Boolean, System.String>(123, True, \"a\", \"b\")");
 
             Case("Generic", 123, true, 1, null)
-                .Name.ShouldBe("Fixie.Tests.CaseTests.Generic<System.Boolean, System.Object>(123, True, 1, null)");
+                .Name.ShouldBe("Fixie.Tests.CaseTests.Generic<System.Boolean, System.Int32>(123, True, 1, null)");
 
             Case("Generic", 123, 1.23m, "a", null)
                 .Name.ShouldBe("Fixie.Tests.CaseTests.Generic<System.Decimal, System.String>(123, 1.23, \"a\", null)");
@@ -180,7 +180,7 @@
             method.Name.ShouldBe("Generic");
             method.GetParameters()
                 .Select(x => x.ParameterType)
-                .ShouldBe(typeof(int), typeof(bool), typeof(object), typeof(object));
+                .ShouldBe(typeof(int), typeof(bool), typeof(int), typeof(int));
 
             method = Case("Generic", 123, 1.23m, "a", null).Method;
             method.Name.ShouldBe("Generic");

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -128,7 +128,7 @@
                         ".ConstrainedGeneric<T> failed: Exception thrown while attempting to yield input parameters for method: ConstrainedGeneric",
                         ".UnconstrainedGeneric<System.Int32>(0) passed",
                         ".UnconstrainedGeneric<System.Int32>(1) passed",
-                        ".UnconstrainedGeneric<System.Object> failed: Exception thrown while attempting to yield input parameters for method: UnconstrainedGeneric"));
+                        ".UnconstrainedGeneric<T> failed: Exception thrown while attempting to yield input parameters for method: UnconstrainedGeneric"));
         }
 
         public void ShouldResolveGenericTypeParameters()
@@ -143,25 +143,25 @@
 
                         ".ConstrainedGenericMethodWithNoInputsProvided<T> failed: This test case has declared parameters, but no parameter values have been provided to it.",
 
-                        ".GenericMethodWithIncorrectParameterCountProvided<System.Object>(123, 123) failed: Parameter count mismatch.",
+                        ".GenericMethodWithIncorrectParameterCountProvided<System.Int32>(123, 123) failed: Parameter count mismatch.",
 
-                        ".GenericMethodWithNoInputsProvided<System.Object> failed: This test case has declared parameters, but no parameter values have been provided to it.",
+                        ".GenericMethodWithNoInputsProvided<T> failed: This test case has declared parameters, but no parameter values have been provided to it.",
 
-                        ".MultipleGenericArgumentsMultipleParameters<System.Int32, System.Object>(123, null, 456, System.Int32, System.Object) passed",
+                        ".MultipleGenericArgumentsMultipleParameters<T1, T2>(123, null, 456, System.Int32, System.Object) failed: Could not resolve type parameters for generic method.",
                         ".MultipleGenericArgumentsMultipleParameters<System.Int32, System.String>(123, \"stringArg1\", 456, System.Int32, System.String) passed",
-                        ".MultipleGenericArgumentsMultipleParameters<System.String, System.Object>(\"stringArg\", null, null, System.String, System.Object) passed",
-                        ".MultipleGenericArgumentsMultipleParameters<System.String, System.Object>(\"stringArg1\", null, \"stringArg2\", System.String, System.Object) passed",
+                        ".MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg\", null, null, System.String, System.Object) failed: Could not resolve type parameters for generic method.",
+                        ".MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg1\", null, \"stringArg2\", System.String, System.Object) failed: Could not resolve type parameters for generic method.",
                         ".MultipleGenericArgumentsMultipleParameters<System.String, System.String>(null, \"stringArg1\", \"stringArg2\", System.String, System.String) passed",
 
                         ".SingleGenericArgument<System.Int32>(123, System.Int32) passed",
-                        ".SingleGenericArgument<System.Object>(null, System.Object) passed",
+                        ".SingleGenericArgument<T>(null, System.Object) failed: Could not resolve type parameters for generic method.",
                         ".SingleGenericArgument<System.String>(\"stringArg\", System.String) passed",
 
                         ".SingleGenericArgumentMultipleParameters<System.Int32>(123, 456, System.Int32) passed",
                         ".SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", 123, System.Object) failed: Object of type 'System.Int32' cannot be converted to type 'System.String'.",
                         ".SingleGenericArgumentMultipleParameters<System.Int32>(123, \"stringArg\", System.Object) failed: Object of type 'System.String' cannot be converted to type 'System.Int32'.",
                         ".SingleGenericArgumentMultipleParameters<System.Int32>(123, null, System.Int32) passed", //MethodInfo.Invoke converts nulls to default(T) for value types.
-                        ".SingleGenericArgumentMultipleParameters<System.Object>(null, null, System.Object) passed",
+                        ".SingleGenericArgumentMultipleParameters<T>(null, null, System.Object) failed: Could not resolve type parameters for generic method.",
                         ".SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", null, System.String) passed",
                         ".SingleGenericArgumentMultipleParameters<System.String>(\"stringArg1\", \"stringArg2\", System.String) passed",
                         ".SingleGenericArgumentMultipleParameters<System.String>(null, \"stringArg\", System.String) passed"));
@@ -180,10 +180,8 @@
                         ".GenericFuncParameter<System.Int32>(5, System.Func`2[System.Int32,System.Int32], 10) passed",
                         ".GenericFuncParameter<System.String>(5, System.Func`2[System.Int32,System.String], \"5\") passed",
 
-                        //This runtime failure would ideally be better detected at generic type parameter resolution time.
                         ".GenericFuncParameter<System.String>(5, System.Func`2[System.Int32,System.String], '5') failed: " +
-                        "Object of type 'System.Char' cannot be converted to type " +
-                        "'System.String'."));
+                        "Object of type 'System.Char' cannot be converted to type 'System.String'."));
         }
 
         class InputAttributeParameterSource : ParameterSource

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -158,9 +158,9 @@
                         ".SingleGenericArgument<System.String>(\"stringArg\", System.String) passed",
 
                         ".SingleGenericArgumentMultipleParameters<System.Int32>(123, 456, System.Int32) passed",
-                        ".SingleGenericArgumentMultipleParameters<System.Object>(\"stringArg\", 123, System.Object) passed",
-                        ".SingleGenericArgumentMultipleParameters<System.Object>(123, \"stringArg\", System.Object) passed",
-                        ".SingleGenericArgumentMultipleParameters<System.Object>(123, null, System.Object) passed",
+                        ".SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", 123, System.Object) failed: Object of type 'System.Int32' cannot be converted to type 'System.String'.",
+                        ".SingleGenericArgumentMultipleParameters<System.Int32>(123, \"stringArg\", System.Object) failed: Object of type 'System.String' cannot be converted to type 'System.Int32'.",
+                        ".SingleGenericArgumentMultipleParameters<System.Int32>(123, null, System.Int32) passed", //MethodInfo.Invoke converts nulls to default(T) for value types.
                         ".SingleGenericArgumentMultipleParameters<System.Object>(null, null, System.Object) passed",
                         ".SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", null, System.String) passed",
                         ".SingleGenericArgumentMultipleParameters<System.String>(\"stringArg1\", \"stringArg2\", System.String) passed",
@@ -174,27 +174,16 @@
             Run<ComplexGenericTestClass>(discovery, execution)
                 .ShouldBe(
                     For<ComplexGenericTestClass>(
-                        //Runtime failure for the CompoundGenericParameter test is undesirable.
-                        //This assertion merely reveals the current behavior.
-                        ".CompoundGenericParameter<System.Object, System.Object>([1, A], \"System.Int32\", \"System.String\") failed: " +
-                        "Object of type 'System.Collections.Generic.KeyValuePair`2[System.Int32,System.String]' cannot be converted to type " +
-                        "'System.Collections.Generic.KeyValuePair`2[System.Object,System.Object]'.",
+                        ".CompoundGenericParameter<System.Int32, System.String>([1, A], \"System.Int32\", \"System.String\") passed",
+                        ".CompoundGenericParameter<System.String, System.Int32>([B, 2], \"System.String\", \"System.Int32\") passed",
 
-                        //Runtime failure for the CompoundGenericParameter test is undesirable.
-                        //This assertion merely reveals the current behavior.
-                        ".CompoundGenericParameter<System.Object, System.Object>([B, 2], \"System.String\", \"System.Int32\") failed: " +
-                        "Object of type 'System.Collections.Generic.KeyValuePair`2[System.String,System.Int32]' cannot be converted to type " +
-                        "'System.Collections.Generic.KeyValuePair`2[System.Object,System.Object]'.",
-
-                        //Despite the above limitation, resolution for the GenericFuncParameter test works because
-                        //enough information is picked up from the final parameter.
                         ".GenericFuncParameter<System.Int32>(5, System.Func`2[System.Int32,System.Int32], 10) passed",
                         ".GenericFuncParameter<System.String>(5, System.Func`2[System.Int32,System.String], \"5\") passed",
 
                         //This runtime failure would ideally be better detected at generic type parameter resolution time.
-                        ".GenericFuncParameter<System.Char>(5, System.Func`2[System.Int32,System.String], '5') failed: " +
-                        "Object of type 'System.Func`2[System.Int32,System.String]' cannot be converted to type " +
-                        "'System.Func`2[System.Int32,System.Char]'."));
+                        ".GenericFuncParameter<System.String>(5, System.Func`2[System.Int32,System.String], '5') failed: " +
+                        "Object of type 'System.Char' cannot be converted to type " +
+                        "'System.String'."));
         }
 
         class InputAttributeParameterSource : ParameterSource
@@ -328,7 +317,7 @@
             [Input(123, 456, typeof(int))]
             [Input("stringArg", 123, typeof(object))]
             [Input(123, "stringArg", typeof(object))]
-            [Input(123, null, typeof(object))]
+            [Input(123, null, typeof(int))]
             [Input(null, null, typeof(object))]
             [Input("stringArg", null, typeof(string))]
             [Input("stringArg1", "stringArg2", typeof(string))]

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -21,18 +21,18 @@
                 .ShouldBe(Empty);
         }
 
-        public void ShouldResolveToObjectWhenGenericTypeHasNoMatchingParameters()
+        public void ShouldNotResolveWhenGenericTypeHasNoMatchingParameters()
         {
             Resolve("NoMatchingParameters", 0, "")
-                .ShouldBe(typeof(object));
+                .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
         }
 
-        public void ShouldResolveToObjectWhenGenericTypeHasOneNullMatchingParameter()
+        public void ShouldNotResolveWhenGenericTypeHasOneNullMatchingParameter()
         {
-            Resolve("OneMatchingParameter", new object?[] { null })
-                .ShouldBe(typeof(object));
+            Resolve("OneMatchingParameter", new object?[] {null})
+                .ShouldSatisfy(t => t.ShouldBeGenericTypeParameter("T"));
         }
-
+        
         public void ShouldResolveToConcreteTypeOfValueWhenGenericTypeHasOneNonNullMatchingParameter()
         {
             Resolve("OneMatchingParameter", 1.2m)
@@ -60,10 +60,10 @@
                 .ShouldBe(typeof(string));
         }
 
-        public void ShouldResolveToObjectWhenGenericTypeHasMultipleMatchingParametersButAllAreNull()
+        public void ShouldNotResolveWhenGenericTypeHasMultipleMatchingParametersButAllAreNull()
         {
             Resolve("MultipleMatchingParameter", null, null, null)
-                .ShouldBe(typeof(object));
+                .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
         }
 
         public void ShouldTreatNullsAsTypeCompatibleWithReferenceTypes()
@@ -90,37 +90,95 @@
                 .ShouldBe(typeof(decimal));
         }
 
-        public void ShouldResolveAllGenericArguments()
+        public void ShouldResolveGenericArgumentsIfAndOnlyIfTheyCanAllBeResolved()
         {
-            Resolve("MultipleGenericArguments", null, 1.2m, "string", 0)
-                .ShouldBe(typeof(object), typeof(object), typeof(decimal));
+            Resolve("MultipleUnsatisfiableGenericArguments", null, 1.2m, "string", 0)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleGenericArguments", false, 1.2m, "string", 0)
-                .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
+            Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, "string", 0)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleGenericArguments", false, 1.2m, "string a", "string b")
-                .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
+            Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, "string a", "string b")
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleGenericArguments", false, 1.2m, 2.3m, 3.4m)
-                .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
+            Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, 2.3m, 3.4m)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleGenericArguments", false, "string a", "string b", "string c")
-                .ShouldBe(typeof(object), typeof(bool), typeof(string));
+            Resolve("MultipleUnsatisfiableGenericArguments", false, "string a", "string b", "string c")
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleGenericArguments", false, null, null, null)
-                .ShouldBe(typeof(object), typeof(bool), typeof(object));
+            Resolve("MultipleUnsatisfiableGenericArguments", false, null, null, null)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
             
-            Resolve("MultipleGenericArguments", false, "string a", "string b", null)
-                .ShouldBe(typeof(object), typeof(bool), typeof(string));
+            Resolve("MultipleUnsatisfiableGenericArguments", false, "string a", "string b", null)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleGenericArguments", false, 1.2m, 2.3m, null)
-                .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
+            Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, 2.3m, null)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+
+            Resolve("MultipleSatisfiableGenericArguments", null, 1.2m, "string", 0)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+
+            Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string", 0)
+                .ShouldBe(typeof(bool), typeof(decimal));
+
+            Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string a", "string b")
+                .ShouldBe(typeof(bool), typeof(decimal));
+
+            Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, 2.3m, 3.4m)
+                .ShouldBe(typeof(bool), typeof(decimal));
+
+            Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", "string c")
+                .ShouldBe(typeof(bool), typeof(string));
+
+            Resolve("MultipleSatisfiableGenericArguments", false, null, null, null)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+            
+            Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", null)
+                .ShouldBe(typeof(bool), typeof(string));
+
+            Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, 2.3m, null)
+                .ShouldBe(typeof(bool), typeof(decimal));
         }
 
-        public void ShouldResolveToObjectWhenInputParameterCountDoesNotMatchDeclaredParameterCount()
+        public void ShouldNotResolveWhenInputParameterCountIsLessThanDeclaredParameterCount()
         {
-            Resolve("MultipleGenericArguments", 1).ShouldBe(typeof(object), typeof(object), typeof(object));
-            Resolve("MultipleGenericArguments", 1, true, false, true, false).ShouldBe(typeof(object), typeof(object), typeof(object));
+            Resolve("MultipleMatchingParameter", 1, 2)
+                .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
+        }
+
+        public void ShouldAttemptReasonableResolutionByIgnoringExcessParametersWhenInputParameterCountIsGreaterThanDeclaredParameterCount()
+        {
+            Resolve("MultipleMatchingParameter", 1, 2, 3, 4)
+                .ShouldBe(typeof(int));
         }
 
         public void ShouldResolveGenericArgumentsWhenGenericConstraintsAreSatisfied()
@@ -174,7 +232,10 @@
             public void NoMatchingParameters<T>(int i, string s) { }
             public void OneMatchingParameter<T>(T match) { }
             public void MultipleMatchingParameter<T>(T firstMatch, T secondMatch, T thirdMatch) { }
-            public void MultipleGenericArguments<TNoMatch, TOneMatch, TMultipleMatch>(
+            public void MultipleUnsatisfiableGenericArguments<TNoMatch, TOneMatch, TMultipleMatch>(
+                TOneMatch oneMatch,
+                TMultipleMatch firstMultiMatch, TMultipleMatch secondMultiMatch, TMultipleMatch thirdMultiMatch) { }
+            public void MultipleSatisfiableGenericArguments<TOneMatch, TMultipleMatch>(
                 TOneMatch oneMatch,
                 TMultipleMatch firstMultiMatch, TMultipleMatch secondMultiMatch, TMultipleMatch thirdMultiMatch) { }
             void ConstrainedGeneric<T>(T t) where T : struct { }

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -42,13 +42,13 @@
                 .ShouldBe(typeof(string));
         }
 
-        public void ShouldResolveToObjectWhenGenericTypeHasMultipleMatchingParametersOfInconsistentConcreteTypes()
+        public void ShouldResolveToFirstConcreteTypeWhenGenericTypeHasMultipleMatchingParametersOfInconsistentConcreteTypes()
         {
             Resolve("MultipleMatchingParameter", 1.2m, "string", 0)
-                .ShouldBe(typeof(object));
+                .ShouldBe(typeof(decimal));
             
             Resolve("MultipleMatchingParameter", 1.2m, "string a", "string b")
-                .ShouldBe(typeof(object));
+                .ShouldBe(typeof(decimal));
         }
 
         public void ShouldResolveToConcreteTypeOfValuesWhenGenericTypeHasMultipleMatchingParametersOfTheExactSameConcreteType()
@@ -78,28 +78,28 @@
                 .ShouldBe(typeof(string));
         }
 
-        public void ShouldTreatNullAsTypeIncompatibleWithValueTypes()
+        public void ShouldIgnoreNullAsTypeIncompatibleWithValueTypes()
         {
             Resolve("MultipleMatchingParameter", null, 2.3m, 3.4m)
-                .ShouldBe(typeof(object));
+                .ShouldBe(typeof(decimal));
 
             Resolve("MultipleMatchingParameter", 1.2m, null, 3.4m)
-                .ShouldBe(typeof(object));
+                .ShouldBe(typeof(decimal));
 
             Resolve("MultipleMatchingParameter", 1.2m, 2.3m, null)
-                .ShouldBe(typeof(object));
+                .ShouldBe(typeof(decimal));
         }
 
         public void ShouldResolveAllGenericArguments()
         {
             Resolve("MultipleGenericArguments", null, 1.2m, "string", 0)
-                .ShouldBe(typeof(object), typeof(object), typeof(object));
+                .ShouldBe(typeof(object), typeof(object), typeof(decimal));
 
             Resolve("MultipleGenericArguments", false, 1.2m, "string", 0)
-                .ShouldBe(typeof(object), typeof(bool), typeof(object));
+                .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
 
             Resolve("MultipleGenericArguments", false, 1.2m, "string a", "string b")
-                .ShouldBe(typeof(object), typeof(bool), typeof(object));
+                .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
 
             Resolve("MultipleGenericArguments", false, 1.2m, 2.3m, 3.4m)
                 .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
@@ -114,7 +114,7 @@
                 .ShouldBe(typeof(object), typeof(bool), typeof(string));
 
             Resolve("MultipleGenericArguments", false, 1.2m, 2.3m, null)
-                .ShouldBe(typeof(object), typeof(bool), typeof(object));
+                .ShouldBe(typeof(object), typeof(bool), typeof(decimal));
         }
 
         public void ShouldResolveToObjectWhenInputParameterCountDoesNotMatchDeclaredParameterCount()
@@ -134,15 +134,11 @@
 
         public void ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
         {
-            //Resorting to 'object' here is not ideal. A perfect match is preferable.
-            //This assertion merely reveals the current behavior.
             Resolve("CompoundGenericParameter", new KeyValuePair<int, string>(1, "A"))
-                .ShouldBe(typeof(object), typeof(object));
+                .ShouldBe(typeof(int), typeof(string));
 
-            //Resorting to 'object' here is not ideal. A perfect match is preferable.
-            //This assertion merely reveals the current behavior.
             Resolve("CompoundGenericParameter", new KeyValuePair<string, int>("A", 1))
-                .ShouldBe(typeof(object), typeof(object));
+                .ShouldBe(typeof(string), typeof(int));
 
             Resolve("GenericFuncParameter", 5, new Func<int, int>(i => i * 2), 10)
                 .ShouldBe(typeof(int));
@@ -150,10 +146,10 @@
             Resolve("GenericFuncParameter", 5, new Func<int, string>(i => i.ToString()), "5")
                 .ShouldBe(typeof(string));
 
-            //We select char as our T, though the Func would fail to cast at runtime,
+            //We select string as our T, though the char argument would fail to cast at runtime,
             //causing this test to fail.
             Resolve("GenericFuncParameter", 5, new Func<int, string>(i => i.ToString()), '5')
-                .ShouldBe(typeof(char));
+                .ShouldBe(typeof(string));
         }
 
         public void ShouldLeaveGenericTypeParameterWhenGenericTypeParametersCannotBeResolved()

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -1,6 +1,7 @@
-﻿namespace Fixie.Internal
+namespace Fixie.Internal
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
 
@@ -35,33 +36,75 @@
                 return allAmbiguous;
             }
 
-            return genericArguments.Select(genericArgument => ResolveTypeArgument(genericArgument, parameterTypes, arguments)).ToArray();
-        }
-
-        static Type ResolveTypeArgument(Type genericArgument, Type[] parameterTypes, object?[] arguments)
-        {
-            bool hasNullValue = false;
-            Type? resolvedTypeOfNonNullValues = null;
+            var genericToSpecific = new Dictionary<Type, Type>();
 
             for (int i = 0; i < parameterTypes.Length; i++)
-            {
-                if (parameterTypes[i] == genericArgument)
-                {
-                    object? argument = arguments[i];
+        {
+                var argument = arguments[i];
+                var parameterType = parameterTypes[i];
 
-                    if (argument == null)
-                        hasNullValue = true;
-                    else if (resolvedTypeOfNonNullValues == null)
-                        resolvedTypeOfNonNullValues = argument.GetType();
-                    else if (resolvedTypeOfNonNullValues != argument.GetType())
-                        return typeof(object);
-                }
+                if (argument == null)
+                    continue;
+
+                TraverseTypes(genericToSpecific, parameterType, argument.GetType());
             }
 
-            if (resolvedTypeOfNonNullValues == null)
-                return typeof(object);
+            return genericArguments
+                .Select(genericArgument =>
+                    genericToSpecific.TryGetValue(genericArgument, out var specificType)
+                        ? specificType
+                        : typeof(object)).ToArray();
+        }
 
-            return hasNullValue && resolvedTypeOfNonNullValues.IsValueType ? typeof(object) : resolvedTypeOfNonNullValues;
+        static void TraverseTypes(Dictionary<Type, Type> genericToSpecific, Type parameterType, Type argumentType)
+            {
+            if (parameterType.IsGenericParameter)
+                {
+                // A type mapping has been detected:
+                //   Parameter: T, Argument: Dictionary<int, string>
+
+                var genericTypeParameterHasAlreadyBeenFixed = genericToSpecific.ContainsKey(parameterType);
+
+                // The first mapping wins. Subsequent ambiguity will be detected by MethodInfo.Invoke(...).
+                if (genericTypeParameterHasAlreadyBeenFixed)
+                    return;
+
+                genericToSpecific[parameterType] = argumentType;
+                return;
+            }
+
+            // Non-generics provide no new type mappings:
+            //   Parameter: int, Argument: bool
+            //   Parameter: List<int>, Argument: bool
+            //   Parameter: int, Argument: List<bool>
+            if (!parameterType.IsGenericType || !argumentType.IsGenericType)
+                return;
+
+            // A perfect match provides no new type mappings:
+            //   Parameter: Dictionary<int, bool>, Argument: Dictionary<int, bool>
+            //   Parameter: Dictionary<T, bool>, Argument: Dictionary<T, bool>
+            if (parameterType == argumentType)
+                return;
+
+            var parameterGenericTypeDefinition = parameterType.GetGenericTypeDefinition();
+            var argumentGenericTypeDefinition = argumentType.GetGenericTypeDefinition();
+
+            // A complete mismatch provides no new type mappings:
+            //   Parameter: Nullable<T>, Argument: Dictionary<int, bool>
+            if (parameterGenericTypeDefinition != argumentGenericTypeDefinition)
+                return;
+
+            // The generic types are compatible and may provide more type mappings:
+            //   Parameter: Dictionary<T1, List<T2>>, Argument: Dictionary<int, List<bool>>
+            var parameterTypeGenericArguments = parameterType.GetGenericArguments(); // [T1, List<T2>]
+            var argumentTypeGenericArguments = argumentType.GetGenericArguments(); // [int, List<bool>]
+
+            for (int i = 0; i < parameterTypeGenericArguments.Length; i++)
+            {
+                TraverseTypes(genericToSpecific,
+                    parameterTypeGenericArguments[i],
+                    argumentTypeGenericArguments[i]);
+            }
         }
     }
 }

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -28,6 +28,13 @@
             var genericArguments = method.GetGenericArguments();
             var parameterTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
 
+            if (parameterTypes.Length != parameters.Length)
+            {
+                var allAmbiguous = new Type[genericArguments.Length];
+                Array.Fill(allAmbiguous, typeof(object));
+                return allAmbiguous;
+            }
+
             return genericArguments.Select(genericArgument => ResolveTypeArgument(genericArgument, parameterTypes, parameters)).ToArray();
         }
 
@@ -35,9 +42,6 @@
         {
             bool hasNullValue = false;
             Type? resolvedTypeOfNonNullValues = null;
-
-            if (parameterTypes.Length != parameters.Length)
-                return typeof(object);
 
             for (int i = 0; i < parameterTypes.Length; i++)
             {

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -6,12 +6,12 @@
 
     static class GenericArgumentResolver
     {
-        public static MethodInfo TryResolveTypeArguments(this MethodInfo caseMethod, object?[] parameters)
+        public static MethodInfo TryResolveTypeArguments(this MethodInfo caseMethod, object?[] arguments)
         {
             if (!caseMethod.IsGenericMethodDefinition)
                 return caseMethod;
 
-            var typeArguments = ResolveTypeArguments(caseMethod, parameters);
+            var typeArguments = ResolveTypeArguments(caseMethod, arguments);
 
             try
             {
@@ -23,22 +23,22 @@
             }
         }
 
-        static Type[] ResolveTypeArguments(MethodInfo method, object?[] parameters)
+        static Type[] ResolveTypeArguments(MethodInfo method, object?[] arguments)
         {
             var genericArguments = method.GetGenericArguments();
             var parameterTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
 
-            if (parameterTypes.Length != parameters.Length)
+            if (parameterTypes.Length != arguments.Length)
             {
                 var allAmbiguous = new Type[genericArguments.Length];
                 Array.Fill(allAmbiguous, typeof(object));
                 return allAmbiguous;
             }
 
-            return genericArguments.Select(genericArgument => ResolveTypeArgument(genericArgument, parameterTypes, parameters)).ToArray();
+            return genericArguments.Select(genericArgument => ResolveTypeArgument(genericArgument, parameterTypes, arguments)).ToArray();
         }
 
-        static Type ResolveTypeArgument(Type genericArgument, Type[] parameterTypes, object?[] parameters)
+        static Type ResolveTypeArgument(Type genericArgument, Type[] parameterTypes, object?[] arguments)
         {
             bool hasNullValue = false;
             Type? resolvedTypeOfNonNullValues = null;
@@ -47,13 +47,13 @@
             {
                 if (parameterTypes[i] == genericArgument)
                 {
-                    object? parameterValue = parameters[i];
+                    object? argument = arguments[i];
 
-                    if (parameterValue == null)
+                    if (argument == null)
                         hasNullValue = true;
                     else if (resolvedTypeOfNonNullValues == null)
-                        resolvedTypeOfNonNullValues = parameterValue.GetType();
-                    else if (resolvedTypeOfNonNullValues != parameterValue.GetType())
+                        resolvedTypeOfNonNullValues = argument.GetType();
+                    else if (resolvedTypeOfNonNullValues != argument.GetType())
                         return typeof(object);
                 }
             }


### PR DESCRIPTION
Fixie has always supported parameterized test methods, including generic test methods. To make sense of such a generic method invocation, Fixie has to figure out what concrete types replace the generic type argumets in each invocation, comparable to the type checking that would normally happen by the compiler at runtime.

For instance, given a generic test method and some presumed attribute-based `ParameterSource`:

```cs
[Input(1, "A")]
[Input("B", 'C')]
public void GenericTest<T1, T2>(T1 x, T2 y) { ... }
```

Fixie has to nail down the meaning of `T1` and `T2` once for each of the two sets of inputs. In the first invocation of the test, `T1` is `int` and `T2` is `string`. In the second `T1` is `string` and `T2` is `char`.

In Fixie v1 and v2, though, the attempts to nail down each type parameter were naive. There were plenty of realistic scenarios where we'd fail to determine a useful concrete type for each generic placeholder. We would smooth over those cases by assuming `object` as the concrete type, which allowed for the test to be invoked, and likely fail with a relatively useful error message about type mismatches. This is less than satisfying, mostly because it goes against idiomatic C#: rarely would you ever explicitly place `object` in the type parameters of a method call yourself: `SomeGenericMethod<object>(...)`.

Additionally, we would fail to inspect "deeply" when the declared parameters *contained* the generic placeholders: `public void GenericTest<T1>(List<T1> items) { ... }` would resolve `T1` to `object`, even if the parameter value at runtime was known to be something more specific such as a `List<string>`. Again, the result goes against idiomatic C#: the compiler would have no trouble recognizing `T1` as `string` when calling `GenericTest(new List<string>())`.

This PR reimplements the type resolution process from scratch. It considers the recursive nature of comparing types like `Dictionary<T1, List<T2>>` against `Dictionary<string, List<int>>` to resolve type parameters, and it deliberately leaves the type parameters entirely unresolved when *any* of them remain ambiguous, so that we can ultimately allow `MethodInfo.Invoke(...)` to provide the most useful ambiguity error message to the user.

