### PR TITLE
GenericArgumentResolver can resolve array types, such as when passing…

### DIFF
--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -210,6 +210,23 @@
                 .ShouldBe(typeof(string));
         }
 
+        public void ShouldResolveGenericTypeParametersAppearingWithinArrays()
+        {
+            Resolve("GenericArrayResolution", new[] {1}, "A")
+                .ShouldBe(typeof(int), typeof(string));
+
+            Resolve("GenericArrayResolution", new[] {"B"}, 2)
+                .ShouldBe(typeof(string), typeof(int));
+
+            Resolve("GenericArrayResolution", new[] {"C"}, new[] {3})
+                .ShouldBe(typeof(string), typeof(int[]));
+
+            Resolve("GenericArrayResolution", 0, 1)
+                .ShouldSatisfy(
+                    x => x.ShouldBeGenericTypeParameter("T1"),
+                    x => x.ShouldBeGenericTypeParameter("T2"));
+        }
+
         public void ShouldLeaveGenericTypeParameterWhenGenericTypeParametersCannotBeResolved()
         {
             var unresolved = Resolve("ConstrainedGeneric", "Incompatible").Single();
@@ -241,6 +258,7 @@
             void ConstrainedGeneric<T>(T t) where T : struct { }
             public void CompoundGenericParameter<TKey, TValue>(KeyValuePair<TKey, TValue> pair) { }
             public void GenericFuncParameter<TResult>(int input, Func<int, TResult> transform, TResult expectedResult) { }
+            public void GenericArrayResolution<T1, T2>(T1[] array, T2 arbitrary) { }
         }
     }
 }

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -97,6 +97,20 @@
                 return;
             }
 
+            // Array item types may provide new type mappings:
+            //   Parameter: T[], Argument: int[]
+            if (parameterType.IsArray && argumentType.IsArray)
+            {
+                var parameterElementType = parameterType.GetElementType();
+                var argumentElementType = argumentType.GetElementType();
+
+                if (parameterElementType != null && argumentElementType != null)
+                {
+                    TraverseTypes(genericToSpecific, parameterElementType, argumentElementType);
+                    return;
+                }
+            }
+
             // Non-generics provide no new type mappings:
             //   Parameter: int, Argument: bool
             //   Parameter: List<int>, Argument: bool


### PR DESCRIPTION
This augments #225 to support resolving generic test method types involving arrays such as when passing `new[ ] { 1 , 2 }` into a generic test parameter declared as `T[]`.