### PR TITLE
Test Result Post-Processing

### DIFF
--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -140,8 +140,6 @@ namespace Fixie.Tests.Cases
                 {
                     test.Run(@case =>
                     {
-                        @case.Execute();
-
                         var result = @case.Result;
 
                         Console.WriteLine(@case.Method.Name + " " + (result ?? "null"));

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -543,7 +543,7 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldSkipTestAndCaseLifecyclesWhenAllTestsAreSkipped()
+        public void ShouldSkipTestLifecyclesWhenAllTestsAreSkipped()
         {
             var output = Run<AllSkippedTestClass, InstrumentedExecution>();
 

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -218,11 +218,7 @@ namespace Fixie.Tests
                         try
                         {
                             CaseSetUp();
-                            test.Run(parameters, @case =>
-                            {
-                                @case.Execute();
-                                CaseInspection();
-                            });
+                            test.Run(parameters, @case => CaseInspection());
                             CaseTearDown();
                         }
                         catch (Exception exception)
@@ -275,22 +271,6 @@ namespace Fixie.Tests
             }
         }
 
-        class ShortCircuitCaseExection : Execution
-        {
-            public void Execute(TestClass testClass)
-            {
-                testClass.RunTests(test =>
-                {
-                    test.Run(@case =>
-                    {
-                        //Case lifecycle chooses not to invoke @case.Execute(instance).
-                        //Since the test cases never run, they are all considered
-                        //'skipped'.
-                    });
-                });
-            }
-        }
-
         class RetryExecution : Execution
         {
             const int MaxAttempts = 3;
@@ -313,8 +293,6 @@ namespace Fixie.Tests
                 {
                     test.Run(parameters, @case =>
                     {
-                        @case.Execute();
-
                         remainingAttempts--;
                         
                         if (@case.State == CaseState.Failed && remainingAttempts > 0)
@@ -630,18 +608,6 @@ namespace Fixie.Tests
         public void ShouldSkipAllTestsWhenShortCircuitingTestExecution()
         {
             var output = Run<SampleTestClass, ShortCircuitTestExection>();
-
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail skipped",
-                "SampleTestClass.Pass skipped",
-                "SampleTestClass.Skip skipped");
-
-            output.ShouldHaveLifecycle();
-        }
-
-        public void ShouldSkipAllCasesWhenShortCircuitingCaseExecution()
-        {
-            var output = Run<SampleTestClass, ShortCircuitCaseExection>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail skipped",

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -15,8 +15,6 @@
             {
                 test.Run(@case =>
                 {
-                    @case.Execute();
-
                     var methodWasExplicitlyRequested = testClass.TargetMethod != null;
 
                     if (methodWasExplicitlyRequested && @case.Exception is AssertException exception)

--- a/src/Fixie/Internal/ExecutionRecorder.cs
+++ b/src/Fixie/Internal/ExecutionRecorder.cs
@@ -59,9 +59,10 @@
             bus.Publish(message);
         }
 
-        public void Skip(TestMethod testMethod)
+        public void Skip(TestMethod testMethod, string? reason = null)
         {
             var @case = new Case(testMethod.Method, EmptyParameters);
+            @case.Skip(reason);
             Skip(@case);
         }
 
@@ -85,10 +86,10 @@
             bus.Publish(message);
         }
 
-        public void Fail(TestMethod testMethod, Exception exception)
+        public void Fail(TestMethod testMethod, Exception reason)
         {
             var @case = new Case(testMethod.Method, EmptyParameters);
-            @case.Fail(exception);
+            @case.Fail(reason);
             Fail(@case);
         }
 

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -49,7 +49,7 @@
                 {
                     testLifecycle(testMethod);
 
-                    if (!testMethod.Invoked)
+                    if (!testMethod.RecordedResult)
                         recorder.Skip(testMethod);
                 }
                 catch (Exception exception)

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -26,7 +26,7 @@
 
         internal bool Invoked { get; private set; }
 
-        void RunCore(object?[] parameters, Action<Case>? caseLifecycle = null)
+        void RunCore(object?[] parameters, object? instance, Action<Case>? caseLifecycle = null)
         {
             Invoked = true;
 
@@ -67,24 +67,24 @@
 
         public void Run(object?[] parameters, Action<Case>? caseLifecycle = null)
         {
-            RunCore(parameters, caseLifecycle);
+            RunCore(parameters, null, caseLifecycle);
         }
 
         public void Run(Action<Case>? caseLifecycle = null)
         {
-            RunCore(EmptyParameters, caseLifecycle);
+            RunCore(EmptyParameters, null, caseLifecycle);
         }
 
         public void RunCases(ParameterSource parameterSource, Action<Case>? caseLifecycle = null)
         {
             foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, caseLifecycle);
+                RunCore(parameters, null, caseLifecycle);
         }
 
         public void RunCases(ParameterSource parameterSource, object? instance)
         {
             foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, @case => @case.Execute(instance));
+                RunCore(parameters, null, @case => @case.Execute(instance));
         }
 
         IEnumerable<object?[]> GetCases(ParameterSource parameterSource)
@@ -99,7 +99,7 @@
         /// </summary>
         public void Skip(string? reason)
         {
-            RunCore(EmptyParameters, @case =>
+            RunCore(EmptyParameters, null, @case =>
             {
                 @case.Skip(reason);
             });
@@ -110,7 +110,7 @@
         /// </summary>
         public void Fail(Exception reason)
         {
-            RunCore(EmptyParameters, @case =>
+            RunCore(EmptyParameters, null, @case =>
             {
                 @case.Fail(reason);
             });

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -1,6 +1,7 @@
 ﻿namespace Fixie
 {
     using System;
+    using System.Collections.Generic;
     using System.Reflection;
     using Internal;
 
@@ -71,17 +72,21 @@
 
         public void RunCases(ParameterSource parameterSource, Action<Case>? caseLifecycle = null)
         {
-            var lazyInvocations = HasParameters
-                ? parameterSource(Method)
-                : InvokeOnceWithZeroParameters;
-
-            foreach (var parameters in lazyInvocations)
+            foreach (var parameters in GetCases(parameterSource))
                 Run(parameters, caseLifecycle);
         }
 
         public void RunCases(ParameterSource parameterSource, object? instance)
         {
-            RunCases(parameterSource, @case => @case.Execute(instance));
+            foreach (var parameters in GetCases(parameterSource))
+                Run(parameters, @case => @case.Execute(instance));
+        }
+
+        IEnumerable<object?[]> GetCases(ParameterSource parameterSource)
+        {
+            return HasParameters
+                ? parameterSource(Method)
+                : InvokeOnceWithZeroParameters;
         }
 
         /// <summary>

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -26,7 +26,7 @@
 
         internal bool Invoked { get; private set; }
 
-        public void Run(object?[] parameters, Action<Case>? caseLifecycle = null)
+        void RunCore(object?[] parameters, Action<Case>? caseLifecycle = null)
         {
             Invoked = true;
 
@@ -65,21 +65,26 @@
                 recorder.Skip(@case, output);
         }
 
+        public void Run(object?[] parameters, Action<Case>? caseLifecycle = null)
+        {
+            RunCore(parameters, caseLifecycle);
+        }
+
         public void Run(Action<Case>? caseLifecycle = null)
         {
-            Run(EmptyParameters, caseLifecycle);
+            RunCore(EmptyParameters, caseLifecycle);
         }
 
         public void RunCases(ParameterSource parameterSource, Action<Case>? caseLifecycle = null)
         {
             foreach (var parameters in GetCases(parameterSource))
-                Run(parameters, caseLifecycle);
+                RunCore(parameters, caseLifecycle);
         }
 
         public void RunCases(ParameterSource parameterSource, object? instance)
         {
             foreach (var parameters in GetCases(parameterSource))
-                Run(parameters, @case => @case.Execute(instance));
+                RunCore(parameters, @case => @case.Execute(instance));
         }
 
         IEnumerable<object?[]> GetCases(ParameterSource parameterSource)
@@ -94,7 +99,7 @@
         /// </summary>
         public void Skip(string? reason)
         {
-            Run(EmptyParameters, @case =>
+            RunCore(EmptyParameters, @case =>
             {
                 @case.Skip(reason);
             });
@@ -105,7 +110,7 @@
         /// </summary>
         public void Fail(Exception reason)
         {
-            Run(EmptyParameters, @case =>
+            RunCore(EmptyParameters, @case =>
             {
                 @case.Fail(reason);
             });

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -16,7 +16,7 @@
         {
             this.recorder = recorder;
             Method = method;
-            Invoked = false;
+            RecordedResult = false;
         }
 
         bool? hasParameters;
@@ -24,12 +24,10 @@
 
         public MethodInfo Method { get; }
 
-        internal bool Invoked { get; private set; }
+        internal bool RecordedResult { get; private set; }
 
         void RunCore(object?[] parameters, object? instance, Action<Case>? caseLifecycle = null)
         {
-            Invoked = true;
-
             var @case = new Case(Method, parameters);
 
             Exception? caseLifecycleFailure = null;
@@ -70,6 +68,7 @@
                 recorder.Fail(new Case(@case, caseLifecycleFailure));
             else if (@case.State == CaseState.Skipped)
                 recorder.Skip(@case, output);
+            RecordedResult = true;
         }
 
         public void Run(object?[] parameters, Action<Case>? caseLifecycle = null)
@@ -106,8 +105,8 @@
         /// </summary>
         public void Skip(string? reason)
         {
-            Invoked = true;
             recorder.Skip(this, reason);
+            RecordedResult = true;
         }
 
         /// <summary>
@@ -115,8 +114,8 @@
         /// </summary>
         public void Fail(Exception reason)
         {
-            Invoked = true;
             recorder.Fail(this, reason);
+            RecordedResult = true;
         }
     }
 }

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -40,9 +40,16 @@
                 try
                 {
                     if (caseLifecycle == null)
-                        @case.Execute();
+                    {
+                        if (instance != null)
+                            @case.Execute(instance);
+                        else
+                            @case.Execute();
+                    }
                     else
+                    {
                         caseLifecycle(@case);
+                    }
                 }
                 catch (Exception exception)
                 {
@@ -84,7 +91,7 @@
         public void RunCases(ParameterSource parameterSource, object? instance)
         {
             foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, null, @case => @case.Execute(instance));
+                RunCore(parameters, instance, null);
         }
 
         IEnumerable<object?[]> GetCases(ParameterSource parameterSource)

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -106,10 +106,8 @@
         /// </summary>
         public void Skip(string? reason)
         {
-            RunCore(EmptyParameters, null, @case =>
-            {
-                @case.Skip(reason);
-            });
+            Invoked = true;
+            recorder.Skip(this, reason);
         }
 
         /// <summary>
@@ -117,10 +115,8 @@
         /// </summary>
         public void Fail(Exception reason)
         {
-            RunCore(EmptyParameters, null, @case =>
-            {
-                @case.Fail(reason);
-            });
+            Invoked = true;
+            recorder.Fail(this, reason);
         }
     }
 }

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -26,7 +26,7 @@
 
         internal bool RecordedResult { get; private set; }
 
-        void RunCore(object?[] parameters, object? instance, Action<Case>? caseLifecycle = null)
+        void RunCore(object?[] parameters, object? instance, Action<Case>? inspectCase = null)
         {
             var @case = new Case(Method, parameters);
 
@@ -37,17 +37,12 @@
             {
                 try
                 {
-                    if (caseLifecycle == null)
-                    {
-                        if (instance != null)
-                            @case.Execute(instance);
-                        else
-                            @case.Execute();
-                    }
+                    if (instance != null)
+                        @case.Execute(instance);
                     else
-                    {
-                        caseLifecycle(@case);
-                    }
+                        @case.Execute();
+
+                    inspectCase?.Invoke(@case);
                 }
                 catch (Exception exception)
                 {
@@ -71,26 +66,26 @@
             RecordedResult = true;
         }
 
-        public void Run(object?[] parameters, Action<Case>? caseLifecycle = null)
+        public void Run(object?[] parameters, Action<Case>? inspectCase = null)
         {
-            RunCore(parameters, null, caseLifecycle);
+            RunCore(parameters, null, inspectCase);
         }
 
-        public void Run(Action<Case>? caseLifecycle = null)
+        public void Run(Action<Case>? inspectCase = null)
         {
-            RunCore(EmptyParameters, null, caseLifecycle);
+            RunCore(EmptyParameters, null, inspectCase);
         }
 
-        public void RunCases(ParameterSource parameterSource, Action<Case>? caseLifecycle = null)
+        public void RunCases(ParameterSource parameterSource, Action<Case>? inspectCase = null)
         {
             foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, null, caseLifecycle);
+                RunCore(parameters, null, inspectCase);
         }
 
         public void RunCases(ParameterSource parameterSource, object? instance)
         {
             foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, instance, null);
+                RunCore(parameters, instance, inspectCase: null);
         }
 
         IEnumerable<object?[]> GetCases(ParameterSource parameterSource)

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -26,7 +26,7 @@
 
         internal bool RecordedResult { get; private set; }
 
-        void RunCore(object?[] parameters, object? instance, Action<Case>? inspectCase = null)
+        void RunCore(object?[] parameters, object? instance, Action<Case>? inspectCase)
         {
             var @case = new Case(Method, parameters);
 
@@ -63,29 +63,40 @@
                 recorder.Fail(new Case(@case, caseLifecycleFailure));
             else if (@case.State == CaseState.Skipped)
                 recorder.Skip(@case, output);
+            
             RecordedResult = true;
-        }
-
-        public void Run(object?[] parameters, Action<Case>? inspectCase = null)
-        {
-            RunCore(parameters, null, inspectCase);
         }
 
         public void Run(Action<Case>? inspectCase = null)
         {
-            RunCore(EmptyParameters, null, inspectCase);
+            RunCore(EmptyParameters, instance: null, inspectCase);
+        }
+
+        public void Run(object?[] parameters, Action<Case>? inspectCase = null)
+        {
+            RunCore(parameters, instance: null, inspectCase);
         }
 
         public void RunCases(ParameterSource parameterSource, Action<Case>? inspectCase = null)
         {
             foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, null, inspectCase);
+                RunCore(parameters, instance: null, inspectCase);
         }
 
-        public void RunCases(ParameterSource parameterSource, object? instance)
+        public void Run(object? instance, Action<Case>? inspectCase = null)
+        {
+            RunCore(EmptyParameters, instance, inspectCase);
+        }
+
+        public void Run(object?[] parameters, object? instance, Action<Case>? inspectCase = null)
+        {
+            RunCore(parameters, instance, inspectCase);
+        }
+
+        public void RunCases(ParameterSource parameterSource, object? instance, Action<Case>? inspectCase = null)
         {
             foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, instance, inspectCase: null);
+                RunCore(parameters, instance, inspectCase);
         }
 
         IEnumerable<object?[]> GetCases(ParameterSource parameterSource)


### PR DESCRIPTION
Before this PR, those who customize at the deepest "test case" level had to remember to call @case.Execute() to meaningfully begin execution of the test case. Then they could proceed with evaluating the result state of the test case (to decide that it be treated as skipped, to enrich a failure message with more information, etc).

This had some flaws. It was easy to forget, needlessly verbose, and encouraged "bad behavior" such as calling @case.Execute() multiple times when the appropriate thing would be to call TestMethod.Run(...) multiple times instead. Calling @case.Execute() multiple times would pollute the meaning of tracked console output and duration measurement for the case.

This PR eliminates the need to call @case.Execute() yourself, turning the deepest customization hook from a general-purpose test case lifecycle, which is now irrleveant in light of the new TestMethod-level API, into a more focused result-post-processing hook.

Before:

```cs
public class TreatBoolReturnValuesAsAssertions : Execution
{
    public void Execute(TestClass testClass)
    {
        testClass.RunTests(test =>
        {
            test.Run(@case =>
            {
                @case.Execute(); // No longer necessary.

                if (@case.Exception == null && @case.Result is false)
                    @case.Fail("Boolean test case returned false!");
            });
        });
    }
}
```

After:

```cs
public class TreatBoolReturnValuesAsAssertions : Execution
{
    public void Execute(TestClass testClass)
    {
        testClass.RunTests(test =>
        {
            test.Run(@case =>
            {
                if (@case.Exception == null && @case.Result is false)
                    @case.Fail("Boolean test case returned false!");
            });
        });
    }
}
```