### PR TITLE
Full Accounting of Abnormal Results

### DIFF
--- a/src/Fixie.Tests/Cases/BasicCaseTests.cs
+++ b/src/Fixie.Tests/Cases/BasicCaseTests.cs
@@ -36,6 +36,7 @@
             Run<CannotInvokeConstructorTestClass>()
                 .ShouldBe(
                     For<CannotInvokeConstructorTestClass>(
+                        ".UnreachableCase skipped",
                         ".UnreachableCase failed: No parameterless constructor defined " +
                         $"for type '{FullName<CannotInvokeConstructorTestClass>()}'."));
         }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -68,9 +68,9 @@
             Run<ParameterizedTestClass>(discovery, execution)
                 .ShouldBe(
                     For<ParameterizedTestClass>(
+                        ".ZeroArgs passed",
                         ".IntArg skipped",
-                        ".MultipleCasesFromAttributes skipped",
-                        ".ZeroArgs passed"));
+                        ".MultipleCasesFromAttributes skipped"));
         }
 
         public void ShouldFailWithClearExplanationWhenParameterCountsAreMismatched()
@@ -171,11 +171,7 @@
                         ".ConstrainedGeneric<System.Int32>(1) passed",
                         ".ConstrainedGeneric<T>(\"Oops\") failed: Could not resolve type parameters for generic method.",
 
-                        ".ConstrainedGenericMethodWithNoInputsProvided<T> skipped",
-
                         ".GenericMethodWithIncorrectParameterCountProvided<System.Int32>(123, 123) failed: Parameter count mismatch.",
-
-                        ".GenericMethodWithNoInputsProvided<T> skipped",
 
                         ".MultipleGenericArgumentsMultipleParameters<T1, T2>(123, null, 456, System.Int32, System.Object) failed: Could not resolve type parameters for generic method.",
                         ".MultipleGenericArgumentsMultipleParameters<System.Int32, System.String>(123, \"stringArg1\", 456, System.Int32, System.String) passed",
@@ -194,7 +190,10 @@
                         ".SingleGenericArgumentMultipleParameters<T>(null, null, System.Object) failed: Could not resolve type parameters for generic method.",
                         ".SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", null, System.String) passed",
                         ".SingleGenericArgumentMultipleParameters<System.String>(\"stringArg1\", \"stringArg2\", System.String) passed",
-                        ".SingleGenericArgumentMultipleParameters<System.String>(null, \"stringArg\", System.String) passed"));
+                        ".SingleGenericArgumentMultipleParameters<System.String>(null, \"stringArg\", System.String) passed",
+                        
+                        ".ConstrainedGenericMethodWithNoInputsProvided<T> skipped",
+                        ".GenericMethodWithNoInputsProvided<T> skipped"));
         }
 
         public void ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()

--- a/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
@@ -16,7 +16,7 @@
 
             Run(listener, out _);
 
-            listener.Messages.Count.ShouldBe(19);
+            listener.Messages.Count.ShouldBe(17);
             
             var assemblyStarted = (AssemblyStarted)listener.Messages[0];
             var sampleTestClassStarted = (ClassStarted)listener.Messages[1];
@@ -26,17 +26,16 @@
             var failByAssertion = (CaseFailed)listener.Messages[5];
             var passStarted = (TestStarted)listener.Messages[6];
             var pass = (CasePassed)listener.Messages[7];
-            var skipWithReasonStarted = (TestStarted)listener.Messages[8];
-            var skipWithReason = (CaseSkipped)listener.Messages[9];
-            var skipWithoutReasonStarted = (TestStarted)listener.Messages[10];
-            var skipWithoutReason = (CaseSkipped)listener.Messages[11];
-            var sampleTestClassCompleted = (ClassCompleted)listener.Messages[12];
-            var sampleGenericTestClassStarted = (ClassStarted)listener.Messages[13];
-            var shouldBeStringStarted = (TestStarted)listener.Messages[14];
-            var shouldBeStringPass = (CasePassed)listener.Messages[15];
-            var shouldBeStringFail = (CaseFailed)listener.Messages[16];
-            var sampleGenericTestClassCompleted = (ClassCompleted)listener.Messages[17];
-            var assemblyCompleted = (AssemblyCompleted)listener.Messages[18];
+            
+            var skipWithReason = (CaseSkipped)listener.Messages[8];
+            var skipWithoutReason = (CaseSkipped)listener.Messages[9];
+            var sampleTestClassCompleted = (ClassCompleted)listener.Messages[10];
+            var sampleGenericTestClassStarted = (ClassStarted)listener.Messages[11];
+            var shouldBeStringStarted = (TestStarted)listener.Messages[12];
+            var shouldBeStringPass = (CasePassed)listener.Messages[13];
+            var shouldBeStringFail = (CaseFailed)listener.Messages[14];
+            var sampleGenericTestClassCompleted = (ClassCompleted)listener.Messages[15];
+            var assemblyCompleted = (AssemblyCompleted)listener.Messages[16];
 
             assemblyStarted.Assembly.ShouldBe(assembly);
             
@@ -77,15 +76,11 @@
                 "Expected: 2",
                 "Actual:   1");
 
-            skipWithReasonStarted.Test.Name.ShouldBe(TestClass + ".SkipWithReason");
-
             skipWithReason.Test.Name.ShouldBe(TestClass + ".SkipWithReason");
             skipWithReason.Name.ShouldBe(TestClass + ".SkipWithReason");
             skipWithReason.Output.ShouldBe("");
             skipWithReason.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
             skipWithReason.Reason.ShouldBe("⚠ Skipped with reason.");
-
-            skipWithoutReasonStarted.Test.Name.ShouldBe(TestClass + ".SkipWithoutReason");
 
             skipWithoutReason.Test.Name.ShouldBe(TestClass + ".SkipWithoutReason");
             skipWithoutReason.Name.ShouldBe(TestClass + ".SkipWithoutReason");

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -357,15 +357,20 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailAllTestsWhenClassSetUpThrows()
+        public void ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenClassSetUpThrows()
         {
             FailDuring("ClassSetUp");
         
             var output = Run<SampleTestClass, InstrumentedExecution>();
         
             output.ShouldHaveResults(
+                "SampleTestClass.Fail skipped",
                 "SampleTestClass.Fail failed: 'ClassSetUp' failed!",
+                
+                "SampleTestClass.Pass skipped",
                 "SampleTestClass.Pass failed: 'ClassSetUp' failed!",
+                
+                "SampleTestClass.Skip skipped",
                 "SampleTestClass.Skip failed: 'ClassSetUp' failed!");
         
             output.ShouldHaveLifecycle("ClassSetUp");
@@ -525,10 +530,10 @@ namespace Fixie.Tests
                 "SampleTestClass.Fail failed: 'Fail' failed!",
                 "SampleTestClass.Pass(1) passed",
                 "SampleTestClass.Pass(2) passed",
-                "SampleTestClass.Skip skipped",
 
                 "SampleTestClass.Fail failed: 'ClassTearDown' failed!",
                 "SampleTestClass.Pass failed: 'ClassTearDown' failed!",
+                "SampleTestClass.Skip skipped",
                 "SampleTestClass.Skip failed: 'ClassTearDown' failed!");
 
             output.ShouldHaveLifecycle(

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -440,7 +440,7 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailCaseWithoutHidingPrimaryFailureWhenCaseInspectionThrows()
+        public void ShouldFailCaseWithoutHidingPrimaryCaseResultsWhenCaseInspectionThrows()
         {
             FailDuring("CaseInspection");
 
@@ -449,7 +449,9 @@ namespace Fixie.Tests
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
                 "SampleTestClass.Fail failed: 'CaseInspection' failed!",
+                "SampleTestClass.Pass(1) passed",
                 "SampleTestClass.Pass(1) failed: 'CaseInspection' failed!",
+                "SampleTestClass.Pass(2) passed",
                 "SampleTestClass.Pass(2) failed: 'CaseInspection' failed!",
                 "SampleTestClass.Skip skipped");
 

--- a/src/Fixie.Tests/TestAdapter/ExecutionListenerTests.cs
+++ b/src/Fixie.Tests/TestAdapter/ExecutionListenerTests.cs
@@ -31,7 +31,7 @@
 
             var messages = recorder.Messages;
 
-            messages.Count.ShouldBe(13);
+            messages.Count.ShouldBe(11);
 
             foreach (var message in messages)
             {
@@ -52,15 +52,13 @@
             var passStart = (TestCase)messages[4];
             var pass = (TestResult)messages[5];
             
-            var skipWithReasonStart = (TestCase)messages[6];
-            var skipWithReason = (TestResult)messages[7];
+            var skipWithReason = (TestResult)messages[6];
             
-            var skipWithoutReasonStart = (TestCase)messages[8];
-            var skipWithoutReason = (TestResult)messages[9];
+            var skipWithoutReason = (TestResult)messages[7];
             
-            var shouldBeStringStart = (TestCase)messages[10];
-            var shouldBeStringPass = (TestResult)messages[11];
-            var shouldBeStringFail = (TestResult)messages[12];
+            var shouldBeStringStart = (TestCase)messages[8];
+            var shouldBeStringPass = (TestResult)messages[9];
+            var shouldBeStringFail = (TestResult)messages[10];
 
             failStart.ShouldBeExecutionTimeTest(TestClass + ".Fail", assemblyPath);
 
@@ -109,8 +107,6 @@
             pass.Messages[0].Text.Lines().ShouldBe("Console.Out: Pass", "Console.Error: Pass");
             pass.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
 
-            skipWithReasonStart.ShouldBeExecutionTimeTest(TestClass + ".SkipWithReason", assemblyPath);
-
             skipWithReason.TestCase.ShouldBeExecutionTimeTest(TestClass+".SkipWithReason", assemblyPath);
             skipWithReason.TestCase.DisplayName.ShouldBe(TestClass+".SkipWithReason");
             skipWithReason.Outcome.ShouldBe(TestOutcome.Skipped);
@@ -119,8 +115,6 @@
             skipWithReason.DisplayName.ShouldBe(TestClass+".SkipWithReason");
             skipWithReason.Messages.ShouldBeEmpty();
             skipWithReason.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-
-            skipWithoutReasonStart.ShouldBeExecutionTimeTest(TestClass + ".SkipWithoutReason", assemblyPath);
 
             skipWithoutReason.TestCase.ShouldBeExecutionTimeTest(TestClass+".SkipWithoutReason", assemblyPath);
             skipWithoutReason.TestCase.DisplayName.ShouldBe(TestClass+".SkipWithoutReason");

--- a/src/Fixie/Internal/TestAssembly.cs
+++ b/src/Fixie/Internal/TestAssembly.cs
@@ -139,10 +139,11 @@
                         foreach (var testMethod in testMethods)
                             recorder.Fail(testMethod, classLifecycleFailure);
                     }
-                    else if (!testClass.Invoked)
+                    else
                     {
                         foreach (var testMethod in testMethods)
-                            recorder.Skip(testMethod);
+                            if (!testMethod.RecordedResult)
+                                recorder.Skip(testMethod);
                     }
             
                     recorder.Complete(testClass);

--- a/src/Fixie/Internal/TestAssembly.cs
+++ b/src/Fixie/Internal/TestAssembly.cs
@@ -134,18 +134,15 @@
                         classLifecycleFailure = exception;
                     }
 
-                    if (classLifecycleFailure != null)
+                    foreach (var testMethod in testMethods)
                     {
-                        foreach (var testMethod in testMethods)
+                        if (!testMethod.RecordedResult)
+                            testMethod.Skip();
+
+                        if (classLifecycleFailure != null)
                             testMethod.Fail(classLifecycleFailure);
                     }
-                    else
-                    {
-                        foreach (var testMethod in testMethods)
-                            if (!testMethod.RecordedResult)
-                                testMethod.Skip();
-                    }
-            
+
                     recorder.Complete(testClass);
                 }
             }

--- a/src/Fixie/Internal/TestAssembly.cs
+++ b/src/Fixie/Internal/TestAssembly.cs
@@ -119,7 +119,7 @@
                         ? testMethods.Single()
                         : null;
 
-                    var testClass = new TestClass(recorder, @class, testMethods, targetMethod?.Method);
+                    var testClass = new TestClass(@class, testMethods, targetMethod?.Method);
 
                     recorder.Start(testClass);
 

--- a/src/Fixie/Internal/TestAssembly.cs
+++ b/src/Fixie/Internal/TestAssembly.cs
@@ -137,13 +137,13 @@
                     if (classLifecycleFailure != null)
                     {
                         foreach (var testMethod in testMethods)
-                            recorder.Fail(testMethod, classLifecycleFailure);
+                            testMethod.Fail(classLifecycleFailure);
                     }
                     else
                     {
                         foreach (var testMethod in testMethods)
                             if (!testMethod.RecordedResult)
-                                recorder.Skip(testMethod);
+                                testMethod.Skip();
                     }
             
                     recorder.Complete(testClass);

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -43,9 +43,6 @@
                 try
                 {
                     testLifecycle(testMethod);
-
-                    if (!testMethod.RecordedResult)
-                        testMethod.Skip();
                 }
                 catch (Exception exception)
                 {

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -50,11 +50,11 @@
                     testLifecycle(testMethod);
 
                     if (!testMethod.RecordedResult)
-                        recorder.Skip(testMethod);
+                        testMethod.Skip();
                 }
                 catch (Exception exception)
                 {
-                    recorder.Fail(testMethod, exception);
+                    testMethod.Fail(exception);
                 }
             }
         }

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -3,19 +3,16 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
-    using Internal;
 
     /// <summary>
     /// The context in which a test class is running.
     /// </summary>
     public class TestClass
     {
-        readonly ExecutionRecorder recorder;
         readonly IReadOnlyList<TestMethod> testMethods;
 
-        internal TestClass(ExecutionRecorder recorder, Type type, IReadOnlyList<TestMethod> testMethods, MethodInfo? targetMethod)
+        internal TestClass(Type type, IReadOnlyList<TestMethod> testMethods, MethodInfo? targetMethod)
         {
-            this.recorder = recorder;
             this.testMethods = testMethods;
 
             Type = type;

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -38,8 +38,6 @@
         {
             foreach (var testMethod in testMethods)
             {
-                recorder.Start(testMethod);
-
                 try
                 {
                     testLifecycle(testMethod);

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -20,7 +20,6 @@
 
             Type = type;
             TargetMethod = targetMethod;
-            Invoked = false;
         }
 
         /// <summary>
@@ -35,12 +34,8 @@
         /// </summary>
         public MethodInfo? TargetMethod { get; }
 
-        internal bool Invoked { get; private set; }
-
         public void RunTests(Action<TestMethod> testLifecycle)
         {
-            Invoked = true;
-
             foreach (var testMethod in testMethods)
             {
                 recorder.Start(testMethod);

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -28,6 +28,9 @@
 
         void RunCore(object?[] parameters, object? instance, Action<Case>? inspectCase)
         {
+            if (!RecordedResult)
+                recorder.Start(this);
+
             var @case = new Case(Method, parameters);
 
             Exception? caseLifecycleFailure = null;

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -59,7 +59,7 @@
 
             if (@case.State == CaseState.Skipped)
                 recorder.Skip(@case, output);
-            if (@case.State == CaseState.Failed)
+            else if (@case.State == CaseState.Failed)
                 recorder.Fail(@case, output);
             else if (@case.State == CaseState.Passed)
                 recorder.Pass(@case, output);

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -109,7 +109,7 @@
         /// <summary>
         /// Emit a skip result for this test, with the given reason.
         /// </summary>
-        public void Skip(string? reason)
+        public void Skip(string? reason = null)
         {
             recorder.Skip(this, reason);
             RecordedResult = true;

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -54,15 +54,15 @@
 
             Console.Write(output);
 
+            if (@case.State == CaseState.Skipped)
+                recorder.Skip(@case, output);
             if (@case.State == CaseState.Failed)
                 recorder.Fail(@case, output);
-            else if (@case.State == CaseState.Passed && caseLifecycleFailure == null)
+            else if (@case.State == CaseState.Passed)
                 recorder.Pass(@case, output);
 
             if (caseLifecycleFailure != null)
                 recorder.Fail(new Case(@case, caseLifecycleFailure));
-            else if (@case.State == CaseState.Skipped)
-                recorder.Skip(@case, output);
             
             RecordedResult = true;
         }


### PR DESCRIPTION
This PR satisfies the goal of providing a "full accounting" of test results even in abnormal situations.

Under normal circumstances, all tests run and all tests have a single unambiguous Pass or Fail result based on whether or not the test method throws. The story is more interesting when a convention chooses to recharacterize such a result as a Skip (a "Programmatic Skip Result"), when a convention chooses never to run a test in the first place (an "Automatic Skip Result"), or when any level of a customization throws unexpectedly (a "Lifecycle Fail Result").

In prior versions, Fixie would attempt to deliberately simplify results. A Pass or a Programmatic Skip would be suppressed if the custom lifecycle eventually threw an exception, for instance, allowing the failure to supercede the original result. There were two downsides to this simplification of reported results:

First, it hid meaningful information. A suppressed Pass or Skip result, for instance, might have important metadata in it such as the duration, captured console output, or the Skip reason string. It's conceivable that such information would be useful to diagnose some subsequent lifecycle failure. Even the sequence of Pass/Fail/Skip states is itself information. It may be useful to know that a test experienced a deliberate programmatic Skip with a known `reason` and *then* threw an unanticipated exception during test "tear down" steps.

Second, it made the implementation needlessly complex, resulting in a few areas where it wasn't 100% clear that we were meeting intended guarantees.

This PR simplifies the implementation and provides a more useful "full accounting":

1. As always, we emit at least one result for every test in the run, even when a user's customizations throw exceptions. It would be a serious violation to fail to emit any result for a test, as the user would have an apparently-green build with no idea something wasn't really running as intended.
2. For any test that is actually invoked, we emit every programmatic result encountered. A test might be run 3 times due to parameterization, for instance: we'd guarantee a distinct programmatic Pass, Fail, or Skip result for each invocation.
3. For any test that is never actually invoked, we emit an automatic Skip result.
4. For any exception thrown by a user's custom lifecycle, we emit the exception as at least one Fail result, regardless of any other Pass, Fail, or Skip results already emitted. Such a failure can be applied to multiple tests when it is unclear which test might be affected: a class-level tear down that throws, for instance, will have the Exception on a Fail result for *all* the tests in that test class, to be absolutely sure it is reported.