### PR TITLE
Idiomatic Test Class Lifecycles

### DIFF
--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -138,22 +138,15 @@ namespace Fixie.Tests.Cases
             {
                 foreach (var test in testClass.Tests)
                 {
-                    try
+                    test.Run(@case =>
                     {
-                        test.Run(@case =>
-                        {
-                            var result = @case.Result;
+                        var result = @case.Result;
 
-                            Console.WriteLine(@case.Method.Name + " " + (result ?? "null"));
+                        Console.WriteLine(@case.Method.Name + " " + (result ?? "null"));
 
-                            if (@case.Exception == null && result is bool success && !success)
-                                @case.Fail("Boolean test case returned false!");
-                        });
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
+                        if (@case.Exception == null && result is bool success && !success)
+                            @case.Fail("Boolean test case returned false!");
+                    });
                 }
             }
         }

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -136,18 +136,25 @@ namespace Fixie.Tests.Cases
         {
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    test.Run(@case =>
+                    try
                     {
-                        var result = @case.Result;
+                        test.Run(@case =>
+                        {
+                            var result = @case.Result;
 
-                        Console.WriteLine(@case.Method.Name + " " + (result ?? "null"));
+                            Console.WriteLine(@case.Method.Name + " " + (result ?? "null"));
 
-                        if (@case.Exception == null && result is bool success && !success)
-                            @case.Fail("Boolean test case returned false!");
-                    });
-                });
+                            if (@case.Exception == null && result is bool success && !success)
+                                @case.Fail("Boolean test case returned false!");
+                        });
+                    }
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
             }
         }
     }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -24,16 +24,7 @@
             public void Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                {
-                    try
-                    {
-                        test.RunCases(parameterSource);
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
-                }
+                    test.RunCases(parameterSource);
             }
         }
 

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -34,21 +34,14 @@
             {
                 foreach (var test in testClass.Tests)
                 {
-                    try
+                    if (test.HasParameters)
                     {
-                        if (test.HasParameters)
-                        {
-                            foreach (var parameters in InputAttributeParameterSource(test.Method))
-                                test.Run(parameters);
-                        }
-                        else
-                        {
-                            test.Run();
-                        }
+                        foreach (var parameters in InputAttributeParameterSource(test.Method))
+                            test.Run(parameters);
                     }
-                    catch (Exception exception)
+                    else
                     {
-                        test.Fail(exception);
+                        test.Run();
                     }
                 }
             }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -23,10 +23,17 @@
 
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    test.RunCases(parameterSource);
-                });
+                    try
+                    {
+                        test.RunCases(parameterSource);
+                    }
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
             }
         }
 
@@ -34,18 +41,25 @@
         {
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    if (test.HasParameters)
+                    try
                     {
-                        foreach (var parameters in InputAttributeParameterSource(test.Method))
-                            test.Run(parameters);
+                        if (test.HasParameters)
+                        {
+                            foreach (var parameters in InputAttributeParameterSource(test.Method))
+                                test.Run(parameters);
+                        }
+                        else
+                        {
+                            test.Run();
+                        }
                     }
-                    else
+                    catch (Exception exception)
                     {
-                        test.Run();
+                        test.Fail(exception);
                     }
-                });
+                }
             }
         }
 

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Fixie.Tests.Internal
 {
-    using System;
     using System.Collections.Generic;
     using Assertions;
     using Fixie.Internal;
@@ -73,19 +72,8 @@
             public void Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                {
-                    try
-                    {
-                        if (test.Method.Name.Contains("Skip"))
-                            continue;
-
+                    if (!test.Method.Name.Contains("Skip"))
                         test.Run();
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
-                }
             }
         }
     }

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.Tests.Internal
 {
+    using System;
     using System.Collections.Generic;
     using Assertions;
     using Fixie.Internal;
@@ -71,13 +72,20 @@
         {
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    if (test.Method.Name.Contains("Skip"))
-                        return;
+                    try
+                    {
+                        if (test.Method.Name.Contains("Skip"))
+                            continue;
 
-                    test.Run();
-                });
+                        test.Run();
+                    }
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
             }
         }
     }

--- a/src/Fixie.Tests/Internal/TestAssemblyTests.cs
+++ b/src/Fixie.Tests/Internal/TestAssemblyTests.cs
@@ -85,17 +85,8 @@ namespace Fixie.Tests.Internal
             public void Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                {
-                    try
-                    {
-                        if (!test.Method.Name.Contains("Skip"))
-                            test.Run();
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
-                }
+                    if (!test.Method.Name.Contains("Skip"))
+                        test.Run();
             }
         }
 

--- a/src/Fixie.Tests/Internal/TestAssemblyTests.cs
+++ b/src/Fixie.Tests/Internal/TestAssemblyTests.cs
@@ -84,11 +84,18 @@ namespace Fixie.Tests.Internal
         {
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    if (!test.Method.Name.Contains("Skip"))
-                        test.Run();
-                });
+                    try
+                    {
+                        if (!test.Method.Name.Contains("Skip"))
+                            test.Run();
+                    }
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
             }
         }
 

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -186,39 +186,46 @@ namespace Fixie.Tests
             {
                 ClassSetUp();
 
-                foreach (var test in testClass.Tests.Where(t => !t.Method.Name.Contains("Skip")))
-                {
-                    try
-                    {
-                        TestSetUp();
-
-                        var cases = test.HasParameters
-                            ? parameterSource(test.Method)
-                            : InvokeOnceWithZeroParameters;
-
-                        foreach (var parameters in cases)
-                        {
-                            try
-                            {
-                                CaseSetUp();
-                                test.Run(parameters, @case => CaseInspection());
-                                CaseTearDown();
-                            }
-                            catch (Exception exception)
-                            {
-                                test.Fail(exception);
-                            }
-                        }
-
-                        TestTearDown();
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
-                }
+                foreach (var test in testClass.Tests)
+                    if (!test.Method.Name.Contains("Skip"))
+                        TestLifecycle(test);
 
                 ClassTearDown();
+            }
+
+            void TestLifecycle(TestMethod test)
+            {
+                try
+                {
+                    TestSetUp();
+
+                    var cases = test.HasParameters
+                        ? parameterSource(test.Method)
+                        : InvokeOnceWithZeroParameters;
+
+                    foreach (var parameters in cases)
+                        CaseLifecycle(test, parameters);
+
+                    TestTearDown();
+                }
+                catch (Exception exception)
+                {
+                    test.Fail(exception);
+                }
+            }
+
+            static void CaseLifecycle(TestMethod test, object?[] parameters)
+            {
+                try
+                {
+                    CaseSetUp();
+                    test.Run(parameters, @case => CaseInspection());
+                    CaseTearDown();
+                }
+                catch (Exception exception)
+                {
+                    test.Fail(exception);
+                }
             }
 
             static readonly object[] EmptyParameters = {};

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -252,12 +252,19 @@ namespace Fixie.Tests
         {
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    //Test lifecycle chooses not to invoke test.Run(...).
-                    //Since the tests never run, they are all considered
-                    //'skipped'.
-                });
+                    try
+                    {
+                        //Test lifecycle chooses not to invoke test.Run(...).
+                        //Since the tests never run, they are all considered
+                        //'skipped'.
+                    }
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
             }
         }
 
@@ -267,12 +274,19 @@ namespace Fixie.Tests
 
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    if (!test.Method.Name.Contains("Skip"))
-                        foreach (var parameters in Cases(test))
-                            RunWithRetries(test, parameters);
-                });
+                    try
+                    {
+                        if (!test.Method.Name.Contains("Skip"))
+                            foreach (var parameters in Cases(test))
+                                RunWithRetries(test, parameters);
+                    }
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
             }
 
             static void RunWithRetries(TestMethod test, object?[] parameters)

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -254,16 +254,9 @@ namespace Fixie.Tests
             {
                 foreach (var test in testClass.Tests)
                 {
-                    try
-                    {
-                        //Test lifecycle chooses not to invoke test.Run(...).
-                        //Since the tests never run, they are all considered
-                        //'skipped'.
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
+                    //Test lifecycle chooses not to invoke test.Run(...).
+                    //Since the tests never run, they are all considered
+                    //'skipped'.
                 }
             }
         }
@@ -275,18 +268,9 @@ namespace Fixie.Tests
             public void Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                {
-                    try
-                    {
-                        if (!test.Method.Name.Contains("Skip"))
-                            foreach (var parameters in Cases(test))
-                                RunWithRetries(test, parameters);
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
-                }
+                    if (!test.Method.Name.Contains("Skip"))
+                        foreach (var parameters in Cases(test))
+                            RunWithRetries(test, parameters);
             }
 
             static void RunWithRetries(TestMethod test, object?[] parameters)

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -185,32 +185,42 @@ namespace Fixie.Tests
             public void Execute(TestClass testClass)
             {
                 ClassSetUp();
-                testClass.RunTests(test =>
+
+                foreach (var test in testClass.Tests)
                 {
-                    if (test.Method.Name.Contains("Skip"))
-                        return;
-
-                    TestSetUp();
-
-                    var cases = test.HasParameters
-                        ? parameterSource(test.Method)
-                        : InvokeOnceWithZeroParameters;
-                    
-                    foreach (var parameters in cases)
+                    try
                     {
-                        try
+                        if (!test.Method.Name.Contains("Skip"))
                         {
-                            CaseSetUp();
-                            test.Run(parameters, @case => CaseInspection());
-                            CaseTearDown();
-                        }
-                        catch (Exception exception)
-                        {
-                            test.Fail(exception);
+                            TestSetUp();
+
+                            var cases = test.HasParameters
+                                ? parameterSource(test.Method)
+                                : InvokeOnceWithZeroParameters;
+
+                            foreach (var parameters in cases)
+                            {
+                                try
+                                {
+                                    CaseSetUp();
+                                    test.Run(parameters, @case => CaseInspection());
+                                    CaseTearDown();
+                                }
+                                catch (Exception exception)
+                                {
+                                    test.Fail(exception);
+                                }
+                            }
+
+                            TestTearDown();
                         }
                     }
-                    TestTearDown();
-                });
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
+
                 ClassTearDown();
             }
 

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -186,34 +186,31 @@ namespace Fixie.Tests
             {
                 ClassSetUp();
 
-                foreach (var test in testClass.Tests)
+                foreach (var test in testClass.Tests.Where(t => !t.Method.Name.Contains("Skip")))
                 {
                     try
                     {
-                        if (!test.Method.Name.Contains("Skip"))
+                        TestSetUp();
+
+                        var cases = test.HasParameters
+                            ? parameterSource(test.Method)
+                            : InvokeOnceWithZeroParameters;
+
+                        foreach (var parameters in cases)
                         {
-                            TestSetUp();
-
-                            var cases = test.HasParameters
-                                ? parameterSource(test.Method)
-                                : InvokeOnceWithZeroParameters;
-
-                            foreach (var parameters in cases)
+                            try
                             {
-                                try
-                                {
-                                    CaseSetUp();
-                                    test.Run(parameters, @case => CaseInspection());
-                                    CaseTearDown();
-                                }
-                                catch (Exception exception)
-                                {
-                                    test.Fail(exception);
-                                }
+                                CaseSetUp();
+                                test.Run(parameters, @case => CaseInspection());
+                                CaseTearDown();
                             }
-
-                            TestTearDown();
+                            catch (Exception exception)
+                            {
+                                test.Fail(exception);
+                            }
                         }
+
+                        TestTearDown();
                     }
                     catch (Exception exception)
                     {

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -238,26 +238,13 @@ namespace Fixie.Tests
                 .GetCustomAttributes<InputAttribute>(true)
                 .Select(input => input.Parameters);
 
-        class ShortCircuitClassExecution : Execution
+        class ShortCircuitTestExecution : Execution
         {
             public void Execute(TestClass testClass)
             {
-                //Class lifecycle chooses not to invoke testClass.RunTests(...).
+                //Class lifecycle chooses not to invoke test.Run(...).
                 //Since the tests never run, they are all considered
                 //'skipped'.
-            }
-        }
-
-        class ShortCircuitTestExection : Execution
-        {
-            public void Execute(TestClass testClass)
-            {
-                foreach (var test in testClass.Tests)
-                {
-                    //Test lifecycle chooses not to invoke test.Run(...).
-                    //Since the tests never run, they are all considered
-                    //'skipped'.
-                }
             }
         }
 
@@ -585,21 +572,9 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("Fail", "Fail", "Fail", "Pass(1)", "Pass(1)", "Pass(2)");
         }
 
-        public void ShouldSkipAllTestsWhenShortCircuitingClassExecution()
-        {
-            var output = Run<SampleTestClass, ShortCircuitClassExecution>();
-
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail skipped",
-                "SampleTestClass.Pass skipped",
-                "SampleTestClass.Skip skipped");
-
-            output.ShouldHaveLifecycle();
-        }
-
         public void ShouldSkipAllTestsWhenShortCircuitingTestExecution()
         {
-            var output = Run<SampleTestClass, ShortCircuitTestExection>();
+            var output = Run<SampleTestClass, ShortCircuitTestExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail skipped",

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -59,21 +59,13 @@
             {
                 foreach (var test in testClass.Tests)
                 {
-                    try
+                    if (test.Method.Has<SkipAttribute>(out var skip))
                     {
-                        if (test.Method.Has<SkipAttribute>(out var skip))
-                        {
-                            test.Skip(skip.Reason);
-                        }
-                        else
-                        {
-                            test.RunCases(UsingInputAttibutes);
-                        }
+                        test.Skip(skip.Reason);
+                        continue;
                     }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
+
+                    test.RunCases(UsingInputAttibutes);
                 }
             }
 

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -57,16 +57,24 @@
         {
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    if (test.Method.Has<SkipAttribute>(out var skip))
+                    try
                     {
-                        test.Skip(skip.Reason);
-                        return;
+                        if (test.Method.Has<SkipAttribute>(out var skip))
+                        {
+                            test.Skip(skip.Reason);
+                        }
+                        else
+                        {
+                            test.RunCases(UsingInputAttibutes);
+                        }
                     }
-
-                    test.RunCases(UsingInputAttibutes);
-                });
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
             }
 
             static IEnumerable<object?[]> UsingInputAttibutes(MethodInfo method)

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.Tests
 {
+    using System;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
@@ -11,17 +12,24 @@
     {
         public void Execute(TestClass testClass)
         {
-            testClass.RunTests(test =>
+            foreach (var test in testClass.Tests)
             {
-                test.Run(@case =>
+                try
                 {
-                    var methodWasExplicitlyRequested = testClass.TargetMethod != null;
+                    test.Run(@case =>
+                    {
+                        var methodWasExplicitlyRequested = testClass.TargetMethod != null;
 
-                    if (methodWasExplicitlyRequested && @case.Exception is AssertException exception)
-                        if (!exception.HasCompactRepresentations)
-                            LaunchDiffTool(exception);
-                });
-            });
+                        if (methodWasExplicitlyRequested && @case.Exception is AssertException exception)
+                            if (!exception.HasCompactRepresentations)
+                                LaunchDiffTool(exception);
+                    });
+                }
+                catch (Exception exception1)
+                {
+                    test.Fail(exception1);
+                }
+            }
         }
 
         static void LaunchDiffTool(AssertException exception)

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -14,21 +14,14 @@
         {
             foreach (var test in testClass.Tests)
             {
-                try
+                test.Run(@case =>
                 {
-                    test.Run(@case =>
-                    {
-                        var methodWasExplicitlyRequested = testClass.TargetMethod != null;
+                    var methodWasExplicitlyRequested = testClass.TargetMethod != null;
 
-                        if (methodWasExplicitlyRequested && @case.Exception is AssertException exception)
-                            if (!exception.HasCompactRepresentations)
-                                LaunchDiffTool(exception);
-                    });
-                }
-                catch (Exception exception1)
-                {
-                    test.Fail(exception1);
-                }
+                    if (methodWasExplicitlyRequested && @case.Exception is AssertException exception)
+                        if (!exception.HasCompactRepresentations)
+                            LaunchDiffTool(exception);
+                });
             }
         }
 

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -134,17 +134,8 @@ namespace Fixie.Tests
             public void Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                {
-                    try
-                    {
-                        if (!ShouldSkip(test))
-                            test.RunCases(UsingInputAttibutes);
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
-                }
+                    if (!ShouldSkip(test))
+                        test.RunCases(UsingInputAttibutes);
             }
         }
 
@@ -156,17 +147,8 @@ namespace Fixie.Tests
                 var instance = type.IsStatic() ? null : Activator.CreateInstance(type);
 
                 foreach (var test in testClass.Tests)
-                {
-                    try
-                    {
-                        if (!ShouldSkip(test))
-                            test.RunCases(UsingInputAttibutes, instance);
-                    }
-                    catch (Exception exception)
-                    {
-                        test.Fail(exception);
-                    }
-                }
+                    if (!ShouldSkip(test))
+                        test.RunCases(UsingInputAttibutes, instance);
 
                 instance.Dispose();
             }

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -133,11 +133,18 @@ namespace Fixie.Tests
         {
             public void Execute(TestClass testClass)
             {
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    if (!ShouldSkip(test))
-                        test.RunCases(UsingInputAttibutes);
-                });
+                    try
+                    {
+                        if (!ShouldSkip(test))
+                            test.RunCases(UsingInputAttibutes);
+                    }
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
             }
         }
 
@@ -148,11 +155,18 @@ namespace Fixie.Tests
                 var type = testClass.Type;
                 var instance = type.IsStatic() ? null : Activator.CreateInstance(type);
 
-                testClass.RunTests(test =>
+                foreach (var test in testClass.Tests)
                 {
-                    if (!ShouldSkip(test))
-                        test.RunCases(UsingInputAttibutes, instance);
-                });
+                    try
+                    {
+                        if (!ShouldSkip(test))
+                            test.RunCases(UsingInputAttibutes, instance);
+                    }
+                    catch (Exception exception)
+                    {
+                        test.Fail(exception);
+                    }
+                }
 
                 instance.Dispose();
             }

--- a/src/Fixie/Internal/DefaultExecution.cs
+++ b/src/Fixie/Internal/DefaultExecution.cs
@@ -1,8 +1,22 @@
 ﻿namespace Fixie.Internal
 {
+    using System;
+
     class DefaultExecution : Execution
     {
         public void Execute(TestClass testClass)
-            => testClass.RunTests(test => test.Run());
+        {
+            foreach (var test in testClass.Tests)
+            {
+                try
+                {
+                    test.Run();
+                }
+                catch (Exception exception)
+                {
+                    test.Fail(exception);
+                }
+            }
+        }
     }
 }

--- a/src/Fixie/Internal/DefaultExecution.cs
+++ b/src/Fixie/Internal/DefaultExecution.cs
@@ -1,22 +1,11 @@
 ﻿namespace Fixie.Internal
 {
-    using System;
-
     class DefaultExecution : Execution
     {
         public void Execute(TestClass testClass)
         {
             foreach (var test in testClass.Tests)
-            {
-                try
-                {
-                    test.Run();
-                }
-                catch (Exception exception)
-                {
-                    test.Fail(exception);
-                }
-            }
+                test.Run();
         }
     }
 }

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -32,20 +32,5 @@
         /// Null under normal test execution.
         /// </summary>
         public MethodInfo? TargetMethod { get; }
-
-        public void RunTests(Action<TestMethod> testLifecycle)
-        {
-            foreach (var test in Tests)
-            {
-                try
-                {
-                    testLifecycle(test);
-                }
-                catch (Exception exception)
-                {
-                    test.Fail(exception);
-                }
-            }
-        }
     }
 }

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -9,20 +9,22 @@
     /// </summary>
     public class TestClass
     {
-        readonly IReadOnlyList<TestMethod> testMethods;
-
-        internal TestClass(Type type, IReadOnlyList<TestMethod> testMethods, MethodInfo? targetMethod)
+        internal TestClass(Type type, IReadOnlyList<TestMethod> tests, MethodInfo? targetMethod)
         {
-            this.testMethods = testMethods;
-
             Type = type;
+            Tests = tests;
             TargetMethod = targetMethod;
         }
 
         /// <summary>
-        /// The test class to execute.
+        /// The test class under execution.
         /// </summary>
         public Type Type { get; }
+
+        /// <summary>
+        /// The test methods under execution.
+        /// </summary>
+        public IReadOnlyList<TestMethod> Tests { get; }
 
         /// <summary>
         /// Gets the target MethodInfo identified by the
@@ -33,15 +35,15 @@
 
         public void RunTests(Action<TestMethod> testLifecycle)
         {
-            foreach (var testMethod in testMethods)
+            foreach (var test in Tests)
             {
                 try
                 {
-                    testLifecycle(testMethod);
+                    testLifecycle(test);
                 }
                 catch (Exception exception)
                 {
-                    testMethod.Fail(exception);
+                    test.Fail(exception);
                 }
             }
         }

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -82,8 +82,15 @@
 
         public void RunCases(ParameterSource parameterSource, Action<Case>? inspectCase = null)
         {
-            foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, instance: null, inspectCase);
+            try
+            {
+                foreach (var parameters in GetCases(parameterSource))
+                    RunCore(parameters, instance: null, inspectCase);
+            }
+            catch (Exception exception)
+            {
+                Fail(exception);
+            }
         }
 
         public void Run(object? instance, Action<Case>? inspectCase = null)
@@ -98,8 +105,15 @@
 
         public void RunCases(ParameterSource parameterSource, object? instance, Action<Case>? inspectCase = null)
         {
-            foreach (var parameters in GetCases(parameterSource))
-                RunCore(parameters, instance, inspectCase);
+            try
+            {
+                foreach (var parameters in GetCases(parameterSource))
+                    RunCore(parameters, instance, inspectCase);
+            }
+            catch (Exception exception)
+            {
+                Fail(exception);
+            }
         }
 
         IEnumerable<object?[]> GetCases(ParameterSource parameterSource)


### PR DESCRIPTION
Before this PR, convention authors had to deal with an awkward method, `TestClass.RunTests(Action<TestMethod> testLifecycle)`, in order to run any tests:

```cs
public class TestingConvention : Execution
{
    public void Execute(TestClass testClass)
    {
        testClass.RunTests(test =>
        {
            if (test.Method.Has<SkipAttribute>(out var skip))
            {
                test.Skip(skip.Reason);
                return;
            }

            test.Run();
        }); 
    }
}
```

Recent improvements to the underlying model have allowed us to phase this out in favor of plain old fashioned idiomatic C#. This makes it much easier to write, reason about, and step through a convention under the debugger:

```cs
public class TestingConvention : Execution
{
    public void Execute(TestClass testClass)
    {
        foreach (var test in testClass.Tests)
        {
            if (test.Method.Has<SkipAttribute>(out var skip))
                test.Skip(skip.Reason);
            else
                test.Run();
        });
    }
}
```

By exposing the read-only collection of tests, this also makes the Discovery phase "Test Ordering" concept redundant. That will be phased out in a separate PR.