### PR TITLE
Remove Ordering from Discovery Phase

### DIFF
--- a/src/Fixie.Tests/Cases/BasicCaseTests.cs
+++ b/src/Fixie.Tests/Cases/BasicCaseTests.cs
@@ -58,9 +58,9 @@
         {
             public void FailA() { throw new FailureException(); }
 
-            public void PassA() { }
-
             public void FailB() { throw new FailureException(); }
+
+            public void PassA() { }
 
             public void PassB() { }
 

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -94,36 +94,24 @@ namespace Fixie.Tests.Cases
 
         class SampleTestClass
         {
-            public void Throw() { throw new FailureException(); }
-
-            public void Pass() { }
-
-            public bool BoolThrow() { throw new FailureException(); }
-
-            public bool BoolTrue() => true;
-
             public bool BoolFalse() => false;
-
+            public bool BoolThrow() { throw new FailureException(); }
+            public bool BoolTrue() => true;
+            public void Pass() { }
             public string String() => "ABC";
-
             public string? StringNull() => null;
+            public void Throw() { throw new FailureException(); }
         }
 
         class SampleAsyncTestClass
         {
-            public async Task Throw() { ThrowException(); await Awaitable(true); }
-            
-            public async Task Pass() => await Awaitable(true);
-
-            public async Task<bool> BoolThrow() { ThrowException(); return await Awaitable(true); }
-            
-            public async Task<bool> BoolTrue() => await Awaitable(true);
-
             public async Task<bool> BoolFalse() => await Awaitable(false);
-
+            public async Task<bool> BoolThrow() { ThrowException(); return await Awaitable(true); }
+            public async Task<bool> BoolTrue() => await Awaitable(true);
+            public async Task Pass() => await Awaitable(true);
             public async Task<string> String()=> await Awaitable("ABC");
-
             public async Task<string?> StringNull() => await Awaitable<string?>(null);
+            public async Task Throw() { ThrowException(); await Awaitable(true); }
 
             static Task<T> Awaitable<T>(T value)
                 => Task.Run(() => value);

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -274,8 +274,6 @@
 
         class ParameterizedTestClass
         {
-            public void ZeroArgs() { }
-
             public void IntArg(int i)
             {
                 if (i != 0)
@@ -290,40 +288,22 @@
                 if (a + b != expectedSum)
                     throw new Exception($"Expected sum of {expectedSum} but was {a + b}.");
             }
+
+            public void ZeroArgs() { }
         }
 
         class GenericTestClass
         {
-            [Input(123, null, 456, typeof(int), typeof(object))]
-            [Input(123, "stringArg1", 456, typeof(int), typeof(string))]
-            [Input("stringArg", null, null, typeof(string), typeof(object))]
-            [Input("stringArg1", null, "stringArg2", typeof(string), typeof(object))]
-            [Input(null, "stringArg1", "stringArg2", typeof(string), typeof(string))]
-            public void MultipleGenericArgumentsMultipleParameters<T1, T2>(T1 genericArgument1A, T2 genericArgument2, T1 genericArgument1B, Type expectedT1, Type expectedT2)
+            [Input(1)]
+            [Input("Oops")]
+            public void ConstrainedGeneric<T>(T input) where T : struct
             {
-                typeof(T1).ShouldBe(expectedT1);
-                typeof(T2).ShouldBe(expectedT2);
+                typeof(T).IsValueType.ShouldBe(true);
             }
 
-            [Input(123, 456, typeof(int))]
-            [Input("stringArg", 123, typeof(object))]
-            [Input(123, "stringArg", typeof(object))]
-            [Input(123, null, typeof(int))]
-            [Input(null, null, typeof(object))]
-            [Input("stringArg", null, typeof(string))]
-            [Input("stringArg1", "stringArg2", typeof(string))]
-            [Input(null, "stringArg", typeof(string))]
-            public void SingleGenericArgumentMultipleParameters<T>(T genericArgument1, T genericArgument2, Type expectedT)
+            public void ConstrainedGenericMethodWithNoInputsProvided<T>(T input) where T : struct
             {
-                typeof(T).ShouldBe(expectedT);
-            }
-
-            [Input(123, typeof(int))]
-            [Input(null, typeof(object))]
-            [Input("stringArg", typeof(string))]
-            public void SingleGenericArgument<T>(T genericArgument, Type expectedT)
-            {
-                typeof(T).ShouldBe(expectedT);
+                throw new ShouldBeUnreachableException();
             }
 
             [Input(123, 123)]
@@ -337,16 +317,36 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            [Input(1)]
-            [Input("Oops")]
-            public void ConstrainedGeneric<T>(T input) where T : struct
+            [Input(123, null, 456, typeof(int), typeof(object))]
+            [Input(123, "stringArg1", 456, typeof(int), typeof(string))]
+            [Input("stringArg", null, null, typeof(string), typeof(object))]
+            [Input("stringArg1", null, "stringArg2", typeof(string), typeof(object))]
+            [Input(null, "stringArg1", "stringArg2", typeof(string), typeof(string))]
+            public void MultipleGenericArgumentsMultipleParameters<T1, T2>(T1 genericArgument1A, T2 genericArgument2, T1 genericArgument1B, Type expectedT1, Type expectedT2)
             {
-                typeof(T).IsValueType.ShouldBe(true);
+                typeof(T1).ShouldBe(expectedT1);
+                typeof(T2).ShouldBe(expectedT2);
             }
 
-            public void ConstrainedGenericMethodWithNoInputsProvided<T>(T input) where T : struct
+            [Input(123, typeof(int))]
+            [Input(null, typeof(object))]
+            [Input("stringArg", typeof(string))]
+            public void SingleGenericArgument<T>(T genericArgument, Type expectedT)
             {
-                throw new ShouldBeUnreachableException();
+                typeof(T).ShouldBe(expectedT);
+            }
+
+            [Input(123, 456, typeof(int))]
+            [Input("stringArg", 123, typeof(object))]
+            [Input(123, "stringArg", typeof(object))]
+            [Input(123, null, typeof(int))]
+            [Input(null, null, typeof(object))]
+            [Input("stringArg", null, typeof(string))]
+            [Input("stringArg1", "stringArg2", typeof(string))]
+            [Input(null, "stringArg", typeof(string))]
+            public void SingleGenericArgumentMultipleParameters<T>(T genericArgument1, T genericArgument2, Type expectedT)
+            {
+                typeof(T).ShouldBe(expectedT);
             }
 
             static string Format(object? obj)
@@ -373,13 +373,13 @@
 
         class ConstrainedGenericTestClass
         {
-            public void UnconstrainedGeneric<T>(T input)
-            {
-            }
-
             public void ConstrainedGeneric<T>(T input) where T : struct
             {
                 typeof(T).IsValueType.ShouldBe(true);
+            }
+
+            public void UnconstrainedGeneric<T>(T input)
+            {
             }
         }
     }

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
     using System.Threading.Tasks;
     using Assertions;
     using Fixie.Internal;
@@ -125,25 +124,6 @@
             exception.InnerException
                 .ShouldBe<Exception>()
                 .Message.ShouldBe("Unsafe method discovery predicate threw!");
-        }
-
-        public void ShouldFailWithClearExplanationWhenOrderingThrows()
-        {
-            var customDiscovery = new SampleDiscovery();
-
-            customDiscovery
-                .Methods
-                .OrderBy((Func<MethodInfo, string>)(x => throw new Exception("Unsafe method ordering rule threw!")));
-
-            Action attemptFaultyDiscovery = () => DiscoveredTestMethods<Sample>(customDiscovery);
-
-            var exception = attemptFaultyDiscovery.ShouldThrow<Exception>(
-                "Exception thrown while attempting to run a custom method ordering rule. " +
-                "Check the inner exception for more details.");
-
-            exception.InnerException
-                .ShouldBe<Exception>()
-                .Message.ShouldBe("Unsafe method ordering rule threw!");
         }
 
         static IEnumerable<string> DiscoveredTestMethods<TTestClass>(Discovery discovery)

--- a/src/Fixie.Tests/Internal/TestAssemblyTests.cs
+++ b/src/Fixie.Tests/Internal/TestAssemblyTests.cs
@@ -74,8 +74,8 @@ namespace Fixie.Tests.Internal
             listener.Entries.ShouldBe(
                 Self + "+PassTestClass.PassB passed",
                 Self + "+PassTestClass.PassA passed",
-                Self + "+PassFailTestClass.Fail failed: 'Fail' failed!",
                 Self + "+PassFailTestClass.Pass passed",
+                Self + "+PassFailTestClass.Fail failed: 'Fail' failed!",
                 Self + "+SkipTestClass.SkipB skipped",
                 Self + "+SkipTestClass.SkipA skipped");
         }
@@ -104,8 +104,8 @@ namespace Fixie.Tests.Internal
 
         class PassFailTestClass
         {
-            public void Pass() { }
             public void Fail() { throw new FailureException(); }
+            public void Pass() { }
         }
 
         class SkipTestClass

--- a/src/Fixie.Tests/Internal/TestAssemblyTests.cs
+++ b/src/Fixie.Tests/Internal/TestAssemblyTests.cs
@@ -1,6 +1,5 @@
 namespace Fixie.Tests.Internal
 {
-    using System;
     using Assertions;
     using Fixie.Internal;
     using static Utility;
@@ -52,32 +51,6 @@ namespace Fixie.Tests.Internal
                 Self + "+PassFailTestClass.Pass passed",
                 Self + "+SkipTestClass.SkipA skipped",
                 Self + "+SkipTestClass.SkipB skipped");
-        }
-
-        public void ShouldAllowRandomShufflingOfCaseExecutionOrder()
-        {
-            var listener = new StubListener();
-
-            var candidateTypes = new[]
-            {
-                typeof(SampleIrrelevantClass), typeof(PassTestClass), typeof(int),
-                typeof(PassFailTestClass), typeof(SkipTestClass)
-            };
-            var discovery = new SelfTestDiscovery();
-            var execution = new CreateInstancePerCase();
-
-            discovery.Methods
-                .Shuffle(new Random(1));
-
-            new TestAssembly(GetType().Assembly, listener).Run(candidateTypes, discovery, execution);
-
-            listener.Entries.ShouldBe(
-                Self + "+PassTestClass.PassB passed",
-                Self + "+PassTestClass.PassA passed",
-                Self + "+PassFailTestClass.Pass passed",
-                Self + "+PassFailTestClass.Fail failed: 'Fail' failed!",
-                Self + "+SkipTestClass.SkipB skipped",
-                Self + "+SkipTestClass.SkipA skipped");
         }
 
         class CreateInstancePerCase : Execution

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -80,17 +80,17 @@ namespace Fixie.Tests
 
         class SampleTestClass
         {
+            public void Fail()
+            {
+                WhereAmI();
+                throw new FailureException();
+            }
+
             [Input(1)]
             [Input(2)]
             public void Pass(int i)
             {
                 WhereAmI(i);
-            }
-
-            public void Fail()
-            {
-                WhereAmI();
-                throw new FailureException();
             }
 
             public void Skip()
@@ -123,15 +123,15 @@ namespace Fixie.Tests
 
         static class StaticTestClass
         {
-            public static void Pass()
-            {
-                WhereAmI();
-            }
-
             public static void Fail()
             {
                 WhereAmI();
                 throw new FailureException();
+            }
+
+            public static void Pass()
+            {
+                WhereAmI();
             }
 
             public static void Skip()

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -57,7 +57,7 @@
         {
             public void Execute(TestClass testClass)
             {
-                foreach (var test in testClass.Tests)
+                foreach (var test in testClass.Tests.OrderByName())
                 {
                     if (test.Method.Has<SkipAttribute>(out var skip))
                     {

--- a/src/Fixie.Tests/SelfTestDiscovery.cs
+++ b/src/Fixie.Tests/SelfTestDiscovery.cs
@@ -1,9 +1,5 @@
 ﻿namespace Fixie.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public class SelfTestDiscovery : Discovery
     {
         public SelfTestDiscovery()
@@ -12,11 +8,5 @@
                 .Where(x => x.IsNestedPrivate || x.IsNestedFamily)
                 .Where(x => x.Name.EndsWith("TestClass"));
         }
-    }
-
-    public static class SelfTestExtensions
-    {
-        public static IEnumerable<TestMethod> OrderByName(this IEnumerable<TestMethod> tests)
-            => tests.OrderBy(x => x.Method.Name, StringComparer.Ordinal);
     }
 }

--- a/src/Fixie.Tests/SelfTestDiscovery.cs
+++ b/src/Fixie.Tests/SelfTestDiscovery.cs
@@ -11,9 +11,6 @@
             Classes
                 .Where(x => x.IsNestedPrivate || x.IsNestedFamily)
                 .Where(x => x.Name.EndsWith("TestClass"));
-
-            Methods
-                .OrderBy(x => x.Name, StringComparer.Ordinal);
         }
     }
 

--- a/src/Fixie.Tests/SelfTestDiscovery.cs
+++ b/src/Fixie.Tests/SelfTestDiscovery.cs
@@ -1,6 +1,8 @@
 ﻿namespace Fixie.Tests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     public class SelfTestDiscovery : Discovery
     {
@@ -13,5 +15,11 @@
             Methods
                 .OrderBy(x => x.Name, StringComparer.Ordinal);
         }
+    }
+
+    public static class SelfTestExtensions
+    {
+        public static IEnumerable<TestMethod> OrderByName(this IEnumerable<TestMethod> tests)
+            => tests.OrderBy(x => x.Method.Name, StringComparer.Ordinal);
     }
 }

--- a/src/Fixie.Tests/ShuffleExtensionsTests.cs
+++ b/src/Fixie.Tests/ShuffleExtensionsTests.cs
@@ -1,0 +1,47 @@
+namespace Fixie.Tests
+{
+    using System;
+    using Assertions;
+    using static Utility;
+
+    public class ShuffleExtensionsTests
+    {
+        const int Seed = 17;
+
+        public void ShouldEnableRandomShufflingOfTestExecutionOrder()
+        {
+            var listener = new StubListener();
+            var discovery = new SelfTestDiscovery();
+            var execution = new ShuffleExecution();
+
+            Run(listener, discovery, execution, typeof(SampleTestClass));
+
+            listener.Entries
+                .ShouldBe(
+                    For<SampleTestClass>(
+                        ".PassC passed",
+                        ".PassA passed",
+                        ".PassB passed",
+                        ".PassE passed",
+                        ".PassD passed"));
+        }
+
+        class ShuffleExecution : Execution
+        {
+            public void Execute(TestClass testClass)
+            {
+                foreach (var test in testClass.Tests.Shuffle(new Random(Seed)))
+                    test.Run();
+            }
+        }
+
+        class SampleTestClass
+        {
+            public void PassA() { }
+            public void PassB() { }
+            public void PassC() { }
+            public void PassD() { }
+            public void PassE() { }
+        }
+    }
+}

--- a/src/Fixie.Tests/TestAdapter/DiscoveryListenerTests.cs
+++ b/src/Fixie.Tests/TestAdapter/DiscoveryListenerTests.cs
@@ -29,9 +29,9 @@
             discoverySink.TestCases.ShouldSatisfy(
                 x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Fail", assemblyPath),
                 x => x.ShouldBeDiscoveryTimeTest(TestClass + ".FailByAssertion", assemblyPath),
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", assemblyPath),
-                x => x.ShouldBeDiscoveryTimeTest(TestClass + ".SkipWithReason", assemblyPath),
                 x => x.ShouldBeDiscoveryTimeTest(TestClass + ".SkipWithoutReason", assemblyPath),
+                x => x.ShouldBeDiscoveryTimeTest(TestClass + ".SkipWithReason", assemblyPath),
+                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", assemblyPath),
                 x => x.ShouldBeDiscoveryTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath));
         }
 
@@ -62,9 +62,9 @@
             discoverySink.TestCases.ShouldSatisfy(
                 x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Fail", invalidAssemblyPath),
                 x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".FailByAssertion", invalidAssemblyPath),
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", invalidAssemblyPath),
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".SkipWithReason", invalidAssemblyPath),
                 x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".SkipWithoutReason", invalidAssemblyPath),
+                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".SkipWithReason", invalidAssemblyPath),
+                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", invalidAssemblyPath),
                 x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(GenericTestClass + ".ShouldBeString", invalidAssemblyPath));
         }
 

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -34,17 +34,17 @@ namespace Fixie.Tests
                 WhereAmI();
             }
 
+            public void Fail()
+            {
+                WhereAmI();
+                throw new FailureException();
+            }
+
             [Input(1)]
             [Input(2)]
             public void Pass(int i)
             {
                 WhereAmI(i);
-            }
-
-            public void Fail()
-            {
-                WhereAmI();
-                throw new FailureException();
             }
 
             public void Skip()
@@ -102,15 +102,15 @@ namespace Fixie.Tests
 
         static class StaticTestClass
         {
-            public static void Pass()
-            {
-                WhereAmI();
-            }
-
             public static void Fail()
             {
                 WhereAmI();
                 throw new FailureException();
+            }
+
+            public static void Pass()
+            {
+                WhereAmI();
             }
 
             public static void Skip()

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -12,6 +12,9 @@
     {
         const BindingFlags InstanceMethods = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 
+        public static IEnumerable<TestMethod> OrderByName(this IEnumerable<TestMethod> tests)
+            => tests.OrderBy(x => x.Method.Name, StringComparer.Ordinal);
+
         public static MethodInfo GetInstanceMethod(this Type type, string methodName)
         {
             var instanceMethod = type.GetMethod(methodName, InstanceMethods);

--- a/src/Fixie/Internal/Configuration.cs
+++ b/src/Fixie/Internal/Configuration.cs
@@ -12,8 +12,6 @@
 
         public Configuration()
         {
-            OrderMethods = methods => methods;
-
             usingDefaultTestClassCondition = true;
             testClassConditions = new List<Func<Type, bool>>
             {
@@ -21,8 +19,6 @@
             };
             testMethodConditions = new List<Func<MethodInfo, bool>>();
         }
-
-        public Func<IReadOnlyList<MethodInfo>, IReadOnlyList<MethodInfo>> OrderMethods { get; set; }
 
         public void AddTestClassCondition(Func<Type, bool> testClassCondition)
         {

--- a/src/Fixie/Internal/Expressions/MethodExpression.cs
+++ b/src/Fixie/Internal/Expressions/MethodExpression.cs
@@ -1,8 +1,6 @@
 ﻿namespace Fixie.Internal.Expressions
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
 
     public class MethodExpression
@@ -23,81 +21,6 @@
         {
             config.AddTestMethodCondition(condition);
             return this;
-        }
-
-        /// <summary>
-        /// Randomizes the order of execution of a test class's contained test methods, using the
-        /// given pseudo-random number generator.
-        /// </summary>
-        public MethodExpression Shuffle(Random random)
-        {
-            config.OrderMethods = methods =>
-            {
-                var array = methods.ToArray();
-
-                Shuffle(array, random);
-
-                return array;
-            };
-            return this;
-        }
-
-        /// <summary>
-        /// Randomizes the order of execution of a test class's contained test methods.
-        /// </summary>
-        public MethodExpression Shuffle()
-        {
-            return Shuffle(new Random());
-        }
-
-        /// <summary>
-        /// Defines the order of execution of a test class's contained test methods.
-        /// </summary>
-        public MethodExpression OrderBy<TKey>(Func<MethodInfo, TKey> keySelector)
-        {
-            config.OrderMethods = methods => methods.OrderBy(keySelector).ToList();
-            return this;
-        }
-
-        /// <summary>
-        /// Defines the order of execution of a test class's contained test methods.
-        /// </summary>
-        public MethodExpression OrderBy<TKey>(Func<MethodInfo, TKey> keySelector, IComparer<TKey> comparer)
-        {
-            config.OrderMethods = methods => methods.OrderBy(keySelector, comparer).ToList();
-            return this;
-        }
-
-        /// <summary>
-        /// Defines the order of execution of a test class's contained test methods.
-        /// </summary>
-        public MethodExpression OrderByDescending<TKey>(Func<MethodInfo, TKey> keySelector)
-        {
-            config.OrderMethods = methods => methods.OrderByDescending(keySelector).ToList();
-            return this;
-        }
-
-        /// <summary>
-        /// Defines the order of execution of a test class's contained test methods.
-        /// </summary>
-        public MethodExpression OrderByDescending<TKey>(Func<MethodInfo, TKey> keySelector, IComparer<TKey> comparer)
-        {
-            config.OrderMethods = methods => methods.OrderByDescending(keySelector, comparer).ToList();
-            return this;
-        }
-
-        //Fisher-Yates Shuffle
-        //  C# implementation from http://stackoverflow.com/a/110570
-        static void Shuffle<T>(T[] array, Random random)
-        {
-            int n = array.Length;
-            while (n > 1)
-            {
-                int k = random.Next(n--);
-                T temp = array[n];
-                array[n] = array[k];
-                array[k] = temp;
-            }
         }
     }
 }

--- a/src/Fixie/Internal/MethodDiscoverer.cs
+++ b/src/Fixie/Internal/MethodDiscoverer.cs
@@ -2,38 +2,19 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Reflection;
 
     class MethodDiscoverer
     {
         readonly IReadOnlyList<Func<MethodInfo, bool>> testMethodConditions;
-        readonly Func<IReadOnlyList<MethodInfo>, IReadOnlyList<MethodInfo>> orderMethods;
         
         public MethodDiscoverer(Discovery discovery)
         {
             testMethodConditions = discovery.Config.TestMethodConditions;
-            orderMethods = discovery.Config.OrderMethods;
         }
 
         public IReadOnlyList<MethodInfo> TestMethods(Type testClass)
-        {
-            var matchingMethods = MatchingMethods(testClass);
-
-            try
-            {
-                return orderMethods(matchingMethods);
-            }
-            catch (Exception exception)
-            {
-                throw new Exception(
-                    "Exception thrown while attempting to run a custom method ordering rule. " +
-                    "Check the inner exception for more details.", exception);
-            }
-        }
-
-        IReadOnlyList<MethodInfo> MatchingMethods(Type testClass)
         {
             try
             {

--- a/src/Fixie/ShuffleExtensions.cs
+++ b/src/Fixie/ShuffleExtensions.cs
@@ -1,0 +1,41 @@
+﻿namespace Fixie
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class ShuffleExtensions
+    {
+        /// <summary>
+        /// Randomizes the order of the given tests.
+        /// </summary>
+        public static IReadOnlyList<TestMethod> Shuffle(this IEnumerable<TestMethod> tests)
+        {
+            return tests.Shuffle(new Random());
+        }
+
+        /// <summary>
+        /// Randomizes the order of the given tests, using the given pseudo-random number generator.
+        /// </summary>
+        public static IReadOnlyList<TestMethod> Shuffle(this IEnumerable<TestMethod> tests, Random random)
+        {
+            var array = tests.ToArray();
+
+            FisherYatesShuffle(array, random);
+
+            return array;
+        }
+
+        static void FisherYatesShuffle<T>(T[] array, Random random)
+        {
+            int n = array.Length;
+            while (n > 1)
+            {
+                int k = random.Next(n--);
+                T temp = array[n];
+                array[n] = array[k];
+                array[k] = temp;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Because #235 enables flexible and idiomatic test ordering as an Execution phase concern rather than a Discovery concern, declarative ordering rules on Discovery are deprecated and removed.

Before:
```cs
public class CustomDiscovery : Discovery
{
    public CustomDiscovery()
    {
        Methods
            .OrderBy(x => x.Name);
    }
}

public class CustomExecution : Execution
{
    public void Execute(TestClass testClass)
    {
        foreach (var test in testClass.Tests)
            test.Run();
    }
}
```

After:
```cs
public class CustomExecution : Execution
{
    public void Execute(TestClass testClass)
    {
        foreach (var test in testClass.Tests.OrderBy(x => x.Name))
            test.Run();
    }
}
```

The "Shuffle" test order randomizer is still available, now as an extension method on `IEnumerable<TestMethod>`:

```cs
public class CustomExecution : Execution
{
    public void Execute(TestClass testClass)
    {
        foreach (var test in testClass.Tests.Shuffle())
            test.Run();
    }
}
```