### PR TITLE
Replace TargetMethod with SelectedTests

### DIFF
--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -60,7 +60,7 @@
 
                     RunTests(log, frameworkHandle, assemblyPath, runner =>
                     {
-                        runner.Run(assemblyGroup.Select(x => x.FullyQualifiedName).ToList());
+                        runner.Run(assemblyGroup.Select(x => x.FullyQualifiedName).ToHashSet());
                     });
                 }
             }

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -60,7 +60,7 @@
 
                     RunTests(log, frameworkHandle, assemblyPath, runner =>
                     {
-                        runner.Run(assemblyGroup.Select(x => new Test(x.FullyQualifiedName)).ToList());
+                        runner.Run(assemblyGroup.Select(x => x.FullyQualifiedName).ToList());
                     });
                 }
             }

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
     using System.Reflection;
@@ -60,7 +61,7 @@
 
                     RunTests(log, frameworkHandle, assemblyPath, runner =>
                     {
-                        runner.Run(assemblyGroup.Select(x => x.FullyQualifiedName).ToHashSet());
+                        runner.Run(assemblyGroup.Select(x => x.FullyQualifiedName).ToImmutableHashSet());
                     });
                 }
             }

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -1,5 +1,6 @@
 namespace Fixie.Tests.Internal
 {
+    using System.Collections.Immutable;
     using Assertions;
     using Fixie.Internal;
     using static Utility;
@@ -42,7 +43,7 @@ namespace Fixie.Tests.Internal
             var discovery = new SelfTestDiscovery();
             var execution = new CreateInstancePerCase();
 
-            new Runner(GetType().Assembly, listener).Run(candidateTypes, discovery, execution);
+            new Runner(GetType().Assembly, listener).Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
 
             listener.Entries.ShouldBe(
                 Self + "+PassTestClass.PassA passed",

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -1,6 +1,7 @@
 ﻿namespace Fixie.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
@@ -16,10 +17,8 @@
             {
                 test.Run(@case =>
                 {
-                    var methodWasExplicitlyRequested = testClass.TargetMethod != null;
-
-                    if (methodWasExplicitlyRequested && @case.Exception is AssertException exception)
-                        if (!exception.HasCompactRepresentations)
+                    if (@case.Exception is AssertException exception && !exception.HasCompactRepresentations)
+                        if (testClass.TestAssembly.SelectedTests?.Count == 1)
                             LaunchDiffTool(exception);
                 });
             }

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -18,7 +18,7 @@
                 test.Run(@case =>
                 {
                     if (@case.Exception is AssertException exception && !exception.HasCompactRepresentations)
-                        if (testClass.TestAssembly.SelectedTests?.Count == 1)
+                        if (testClass.TestAssembly.SelectedTests.Count == 1)
                             LaunchDiffTool(exception);
                 });
             }

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
@@ -57,7 +58,7 @@
             if (candidateTypes.Length == 0)
                 throw new InvalidOperationException("At least one type must be specified.");
 
-            new Runner(candidateTypes[0].Assembly, listener).Run(candidateTypes, discovery, execution);
+            new Runner(candidateTypes[0].Assembly, listener).Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
         }
 
         public static IEnumerable<object?[]> UsingInputAttributes(MethodInfo method)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -41,7 +41,7 @@
 
         public ExecutionSummary Run(HashSet<string> selectedTests)
         {
-            return Run(assembly.GetTypes(), method => selectedTests.Contains(new Test(method).Name));
+            return Run(assembly.GetTypes(), selectedTests);
         }
 
         public ExecutionSummary Run(TestPattern testPattern)
@@ -72,14 +72,14 @@
             return Run(matchingTests);
         }
 
-        ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, Func<MethodInfo, bool>? selected = null)
+        ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, HashSet<string>? selectedTests = null)
         {
             new BehaviorDiscoverer(assembly, customArguments)
                 .GetBehaviors(out var discovery, out var execution);
 
             try
             {
-                return Run(candidateTypes, discovery, execution, selected);
+                return Run(candidateTypes, discovery, execution, selectedTests);
             }
             finally
             {
@@ -101,14 +101,14 @@
                 bus.Publish(new TestDiscovered(new Test(testMethod)));
         }
 
-        internal ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, Discovery discovery, Execution execution, Func<MethodInfo, bool>? selected = null)
+        internal ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, Discovery discovery, Execution execution, HashSet<string>? selectedTests = null)
         {
             var recorder = new ExecutionRecorder(bus);
             var classDiscoverer = new ClassDiscoverer(discovery);
             var classes = classDiscoverer.TestClasses(candidateTypes);
             var methodDiscoverer = new MethodDiscoverer(discovery);
 
-            var testAssembly = new TestAssembly(assembly, recorder, classes, methodDiscoverer, selected, execution);
+            var testAssembly = new TestAssembly(assembly, recorder, classes, methodDiscoverer, selectedTests, execution);
             recorder.Start(testAssembly);
             testAssembly.Run();
             return recorder.Complete(testAssembly);

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -43,6 +43,10 @@
         {
             var request = new Dictionary<string, HashSet<string>>();
             var types = new List<Type>();
+            
+            var selectedTestNames = new HashSet<string>();
+            foreach (var test in selectedTests)
+                selectedTestNames.Add(test.Name);
 
             foreach (var test in selectedTests)
             {
@@ -59,7 +63,7 @@
                 request[test.Class].Add(test.Method);
             }
 
-            return Run(types, method => request[method.ReflectedType!.FullName!].Contains(method.Name));
+            return Run(types, method => selectedTestNames.Contains(new Test(method).Name));
         }
 
         public ExecutionSummary Run(TestPattern testPattern)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -39,12 +39,12 @@
             return Run(assembly.GetTypes());
         }
 
-        public ExecutionSummary Run(IReadOnlyList<Test> tests)
+        public ExecutionSummary Run(IReadOnlyList<Test> selectedTests)
         {
             var request = new Dictionary<string, HashSet<string>>();
             var types = new List<Type>();
 
-            foreach (var test in tests)
+            foreach (var test in selectedTests)
             {
                 if (!request.ContainsKey(test.Class))
                 {

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -39,18 +39,18 @@
             return Run(assembly.GetTypes());
         }
 
-        public ExecutionSummary Run(IReadOnlyList<Test> selectedTests)
+        public ExecutionSummary Run(IReadOnlyList<string> selectedTests)
         {
             var selectedTestNames = new HashSet<string>();
-            foreach (var test in selectedTests)
-                selectedTestNames.Add(test.Name);
+            foreach (var selectedTest in selectedTests)
+                selectedTestNames.Add(selectedTest);
 
             return Run(assembly.GetTypes(), method => selectedTestNames.Contains(new Test(method).Name));
         }
 
         public ExecutionSummary Run(TestPattern testPattern)
         {
-            var matchingTests = new List<Test>();
+            var matchingTests = new List<string>();
             var discovery = new BehaviorDiscoverer(assembly, customArguments).GetDiscovery();
 
             try
@@ -65,7 +65,7 @@
                     var test = new Test(testMethod);
 
                     if (testPattern.Matches(test))
-                        matchingTests.Add(test);
+                        matchingTests.Add(test.Name);
                 }
             }
             finally

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -41,29 +41,11 @@
 
         public ExecutionSummary Run(IReadOnlyList<Test> selectedTests)
         {
-            var request = new Dictionary<string, HashSet<string>>();
-            var types = new List<Type>();
-            
             var selectedTestNames = new HashSet<string>();
             foreach (var test in selectedTests)
                 selectedTestNames.Add(test.Name);
 
-            foreach (var test in selectedTests)
-            {
-                if (!request.ContainsKey(test.Class))
-                {
-                    request.Add(test.Class, new HashSet<string>());
-
-                    var type = assembly.GetType(test.Class);
-
-                    if (type != null)
-                        types.Add(type);
-                }
-
-                request[test.Class].Add(test.Method);
-            }
-
-            return Run(types, method => selectedTestNames.Contains(new Test(method).Name));
+            return Run(assembly.GetTypes(), method => selectedTestNames.Contains(new Test(method).Name));
         }
 
         public ExecutionSummary Run(TestPattern testPattern)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -39,18 +39,14 @@
             return Run(assembly.GetTypes());
         }
 
-        public ExecutionSummary Run(IReadOnlyList<string> selectedTests)
+        public ExecutionSummary Run(HashSet<string> selectedTests)
         {
-            var selectedTestNames = new HashSet<string>();
-            foreach (var selectedTest in selectedTests)
-                selectedTestNames.Add(selectedTest);
-
-            return Run(assembly.GetTypes(), method => selectedTestNames.Contains(new Test(method).Name));
+            return Run(assembly.GetTypes(), method => selectedTests.Contains(new Test(method).Name));
         }
 
         public ExecutionSummary Run(TestPattern testPattern)
         {
-            var matchingTests = new List<string>();
+            var matchingTests = new HashSet<string>();
             var discovery = new BehaviorDiscoverer(assembly, customArguments).GetDiscovery();
 
             try

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -108,7 +108,7 @@
             var classes = classDiscoverer.TestClasses(candidateTypes);
             var methodDiscoverer = new MethodDiscoverer(discovery);
 
-            var testAssembly = new TestAssembly(assembly, recorder, classes, methodDiscoverer, selectedTests, execution);
+            var testAssembly = new TestAssembly(assembly, selectedTests, recorder, classes, methodDiscoverer, execution);
             recorder.Start(testAssembly);
             testAssembly.Run();
             return recorder.Complete(testAssembly);

--- a/src/Fixie/TestAssembly.cs
+++ b/src/Fixie/TestAssembly.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
     using System.Reflection;
     using Internal;
@@ -13,7 +14,7 @@
         readonly MethodDiscoverer methodDiscoverer;
         readonly Execution execution;
 
-        internal TestAssembly(Assembly assembly, HashSet<string>? selectedTests, ExecutionRecorder recorder,
+        internal TestAssembly(Assembly assembly, ImmutableHashSet<string> selectedTests, ExecutionRecorder recorder,
             IReadOnlyList<Type> classes,
             MethodDiscoverer methodDiscoverer, Execution execution)
         {
@@ -30,9 +31,9 @@
 
         /// <summary>
         /// Gets the set of explicitly selected test names to be executed.
-        /// Null under normal test execution when all tests are being executed.
+        /// Empty under normal test execution when all tests are being executed.
         /// </summary>
-        public HashSet<string>? SelectedTests { get; }
+        public ImmutableHashSet<string> SelectedTests { get; }
 
         internal void Run()
         {
@@ -40,7 +41,7 @@
             {
                 IEnumerable<MethodInfo> methods = methodDiscoverer.TestMethods(@class);
 
-                if (SelectedTests != null)
+                if (!SelectedTests.IsEmpty)
                     methods = methods.Where(method => SelectedTests.Contains(new Test(method).Name));
 
                 var testMethods = methods

--- a/src/Fixie/TestAssembly.cs
+++ b/src/Fixie/TestAssembly.cs
@@ -11,17 +11,17 @@
         readonly ExecutionRecorder recorder;
         readonly IReadOnlyList<Type> classes;
         readonly MethodDiscoverer methodDiscoverer;
-        readonly Func<MethodInfo, bool>? selected;
+        readonly HashSet<string>? selectedTests;
         readonly Execution execution;
 
         internal TestAssembly(Assembly assembly, ExecutionRecorder recorder, IReadOnlyList<Type> classes,
-            MethodDiscoverer methodDiscoverer, Func<MethodInfo, bool>? selected, Execution execution)
+            MethodDiscoverer methodDiscoverer, HashSet<string>? selectedTests, Execution execution)
         {
             Assembly = assembly;
             this.recorder = recorder;
             this.classes = classes;
             this.methodDiscoverer = methodDiscoverer;
-            this.selected = selected;
+            this.selectedTests = selectedTests;
             this.execution = execution;
         }
 
@@ -33,8 +33,8 @@
             {
                 IEnumerable<MethodInfo> methods = methodDiscoverer.TestMethods(@class);
 
-                if (selected != null)
-                    methods = methods.Where(selected);
+                if (selectedTests != null)
+                    methods = methods.Where(method => selectedTests.Contains(new Test(method).Name));
 
                 var testMethods = methods
                     .Select(method => new TestMethod(recorder, method))

--- a/src/Fixie/TestAssembly.cs
+++ b/src/Fixie/TestAssembly.cs
@@ -49,11 +49,7 @@
 
                 if (testMethods.Any())
                 {
-                    var targetMethod = classes.Count == 1 && testMethods.Count == 1
-                        ? testMethods.Single()
-                        : null;
-
-                    var testClass = new TestClass(this, @class, testMethods, targetMethod?.Method);
+                    var testClass = new TestClass(this, @class, testMethods);
 
                     Exception? classLifecycleFailure = null;
 

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -6,12 +6,18 @@
 
     public class TestClass
     {
-        internal TestClass(Type type, IReadOnlyList<TestMethod> tests, MethodInfo? targetMethod)
+        internal TestClass(TestAssembly testAssembly, Type type, IReadOnlyList<TestMethod> tests, MethodInfo? targetMethod)
         {
+            TestAssembly = testAssembly;
             Type = type;
             Tests = tests;
             TargetMethod = targetMethod;
         }
+
+        /// <summary>
+        /// The test assembly under execution.
+        /// </summary>
+        public TestAssembly TestAssembly { get; }
 
         /// <summary>
         /// The test class under execution.

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -6,12 +6,11 @@
 
     public class TestClass
     {
-        internal TestClass(TestAssembly testAssembly, Type type, IReadOnlyList<TestMethod> tests, MethodInfo? targetMethod)
+        internal TestClass(TestAssembly testAssembly, Type type, IReadOnlyList<TestMethod> tests)
         {
             TestAssembly = testAssembly;
             Type = type;
             Tests = tests;
-            TargetMethod = targetMethod;
         }
 
         /// <summary>
@@ -28,13 +27,6 @@
         /// The test methods under execution.
         /// </summary>
         public IReadOnlyList<TestMethod> Tests { get; }
-
-        /// <summary>
-        /// Gets the target MethodInfo identified by the
-        /// test runner as the sole method to be executed.
-        /// Null under normal test execution.
-        /// </summary>
-        public MethodInfo? TargetMethod { get; }
 
         /// <summary>
         /// Construct an instance of the test class using


### PR DESCRIPTION
Replaces the deprecated `TargetMethod` concept with a more general purpose `SelectedTests` concept.

Historically, when a single test method was selected by a test runner like Test Explorer, the often-null `TargetMethod` property would be set to the MethodInfo of that selected test method. This originated with Fixie v1 TestDriven.NET support as a direct influence from TestDriven.NET's integration API.

This PR replaces the concept with a generalized `SelectedTests` property, an ummutable set of selected test names. Tests can be selected in various runners such as Test Explorer and at the command line with the `--tests` pattern matching filter.