### PR TITLE
Async Turtles All The Way Down

### DIFF
--- a/build/Fixie.Program.cs
+++ b/build/Fixie.Program.cs
@@ -5,6 +5,6 @@
     class Program
     {
         [STAThread]
-        static int Main(string[] customArguments) => EntryPoint.Main(typeof(Program).Assembly, customArguments);
+        static int Main(string[] customArguments) => EntryPoint.Main(typeof(Program).Assembly, customArguments).GetAwaiter().GetResult();
     }
 }

--- a/build/Fixie.Program.cs
+++ b/build/Fixie.Program.cs
@@ -1,10 +1,12 @@
 ﻿namespace Fixie.Internal
 {
     using System;
+    using System.Threading.Tasks;
 
     class Program
     {
         [STAThread]
-        static int Main(string[] customArguments) => EntryPoint.Main(typeof(Program).Assembly, customArguments).GetAwaiter().GetResult();
+        static async Task<int> Main(string[] customArguments)
+            => await EntryPoint.Main(typeof(Program).Assembly, customArguments);
     }
 }

--- a/build/Fixie.Program.fs
+++ b/build/Fixie.Program.fs
@@ -5,4 +5,4 @@ open System.Reflection
 
 [<STAThread; EntryPoint>]
 let main customArguments =
-    EntryPoint.Main(Assembly.GetExecutingAssembly(), customArguments)
+    EntryPoint.Main(Assembly.GetExecutingAssembly(), customArguments).GetAwaiter().GetResult();

--- a/src/Fixie.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.TestAdapter/VsTestDiscoverer.cs
@@ -47,7 +47,7 @@
             var listener = new DiscoveryListener(log, discoverySink, assemblyPath);
             var runner = new Runner(assembly, listener);
 
-            runner.Discover();
+            runner.DiscoverAsync().GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -34,7 +34,7 @@
                 foreach (var assemblyPath in sources)
                     RunTests(log, frameworkHandle, assemblyPath, runner =>
                     {
-                        runner.Run().GetAwaiter().GetResult();
+                        runner.RunAsync().GetAwaiter().GetResult();
                     });
             }
             catch (Exception exception)
@@ -67,7 +67,7 @@
                         var selectedTests =
                             assemblyGroup.Select(x => x.FullyQualifiedName).ToImmutableHashSet();
                         
-                        runner.Run(selectedTests).GetAwaiter().GetResult();
+                        runner.RunAsync(selectedTests).GetAwaiter().GetResult();
                     });
                 }
             }

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -32,7 +32,10 @@
                 HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
 
                 foreach (var assemblyPath in sources)
-                    RunTests(log, frameworkHandle, assemblyPath, runner => runner.Run());
+                    RunTests(log, frameworkHandle, assemblyPath, runner =>
+                    {
+                        runner.Run().GetAwaiter().GetResult();
+                    });
             }
             catch (Exception exception)
             {
@@ -61,8 +64,10 @@
 
                     RunTests(log, frameworkHandle, assemblyPath, runner =>
                     {
-                        runner.Run(assemblyGroup.Select(x => x.FullyQualifiedName).ToImmutableHashSet())
-                            .GetAwaiter().GetResult();
+                        var selectedTests =
+                            assemblyGroup.Select(x => x.FullyQualifiedName).ToImmutableHashSet();
+                        
+                        runner.Run(selectedTests).GetAwaiter().GetResult();
                     });
                 }
             }

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -61,7 +61,8 @@
 
                     RunTests(log, frameworkHandle, assemblyPath, runner =>
                     {
-                        runner.Run(assemblyGroup.Select(x => x.FullyQualifiedName).ToImmutableHashSet());
+                        runner.Run(assemblyGroup.Select(x => x.FullyQualifiedName).ToImmutableHashSet())
+                            .GetAwaiter().GetResult();
                     });
                 }
             }

--- a/src/Fixie.Tests/Cases/AsyncCaseTests.cs
+++ b/src/Fixie.Tests/Cases/AsyncCaseTests.cs
@@ -10,42 +10,42 @@
     {
         public async Task ShouldAwaitThenPassUponSuccessfulAsyncExecution()
         {
-            (await Run<AwaitThenPassTestClass>())
+            (await RunAsync<AwaitThenPassTestClass>())
                 .ShouldBe(
                     For<AwaitThenPassTestClass>(".Test passed"));
         }
 
         public async Task ShouldAwaitResultThenPassUponSuccessfulAsyncExecution()
         {
-            (await Run<AwaitResultThenPassTestClass>())
+            (await RunAsync<AwaitResultThenPassTestClass>())
                 .ShouldBe(
                     For<AwaitResultThenPassTestClass>(".Test passed"));
         }
 
         public async Task ShouldCompleteTaskThenPassUponSuccessfulTaskExecution()
         {
-            (await Run<CompleteTaskThenPassTestClass>())
+            (await RunAsync<CompleteTaskThenPassTestClass>())
                 .ShouldBe(
                     For<CompleteTaskThenPassTestClass>(".Test passed"));
         }
 
         public async Task ShouldGetTaskResultThenPassUponSuccessfulTaskExecution()
         {
-            (await Run<CompleteTaskWithResultThenPassTestClass>())
+            (await RunAsync<CompleteTaskWithResultThenPassTestClass>())
                 .ShouldBe(
                     For<CompleteTaskWithResultThenPassTestClass>(".Test passed"));
         }
 
         public async Task ShouldPassForNullTask()
         {
-            (await Run<NullTaskTestClass>())
+            (await RunAsync<NullTaskTestClass>())
                 .ShouldBe(
                     For<NullTaskTestClass>(".Test passed"));
         }
 
         public async Task ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsAfterAwaiting()
         {
-            (await Run<AwaitThenFailTestClass>())
+            (await RunAsync<AwaitThenFailTestClass>())
                 .ShouldBe(
                     For<AwaitThenFailTestClass>(
                         ".Test failed: Expected: 0" + NewLine +
@@ -54,21 +54,21 @@
 
         public async Task ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsWithinTheAwaitedTask()
         {
-            (await Run<AwaitOnTaskThatThrowsTestClass>())
+            (await RunAsync<AwaitOnTaskThatThrowsTestClass>())
                 .ShouldBe(
                     For<AwaitOnTaskThatThrowsTestClass>(".Test failed: Attempted to divide by zero."));
         }
 
         public async Task ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsBeforeAwaitingOnAnyTask()
         {
-            (await Run<FailBeforeAwaitTestClass>())
+            (await RunAsync<FailBeforeAwaitTestClass>())
                 .ShouldBe(
                     For<FailBeforeAwaitTestClass>(".Test failed: 'Test' failed!"));
         }
 
         public async Task ShouldFailWithClearExplanationWhenAsyncCaseMethodReturnsNonStartedTask()
         {
-            (await Run<FailDueToNonStartedTaskTestClass>())
+            (await RunAsync<FailDueToNonStartedTaskTestClass>())
                 .ShouldBe(
                     For<FailDueToNonStartedTaskTestClass>(
                         ".Test failed: The test returned a non-started task, which cannot " +
@@ -77,7 +77,7 @@
 
         public async Task ShouldExecuteReturnedTaskDeclaredAsObject()
         {
-            (await Run<CompleteTaskDeclaredAsObjectTestClass>())
+            (await RunAsync<CompleteTaskDeclaredAsObjectTestClass>())
                 .ShouldBe(
                     For<CompleteTaskDeclaredAsObjectTestClass>(
                         ".Test failed: Expected: 0" + NewLine +
@@ -86,7 +86,7 @@
 
         public async Task ShouldFailUnsupportedAsyncVoidCases()
         {
-            (await Run<UnsupportedAsyncVoidTestTestClass>())
+            (await RunAsync<UnsupportedAsyncVoidTestTestClass>())
                 .ShouldBe(
                     For<UnsupportedAsyncVoidTestTestClass>(".Test failed: " +
                         "Async void methods are not supported. Declare async methods with a return type of " +
@@ -100,7 +100,7 @@
                 throw new FailureException(member);
             }
 
-            protected static Task<int> Divide(int numerator, int denominator)
+            protected static Task<int> DivideAsync(int numerator, int denominator)
             {
                 return Task.Run(() => numerator/denominator);
             }
@@ -110,7 +110,7 @@
         {
             public async Task Test()
             {
-                var result = await Divide(15, 5);
+                var result = await DivideAsync(15, 5);
 
                 result.ShouldBe(3);
             }
@@ -120,7 +120,7 @@
         {
             public async Task<bool> Test()
             {
-                var result = await Divide(15, 5);
+                var result = await DivideAsync(15, 5);
 
                 result.ShouldBe(3);
 
@@ -132,7 +132,7 @@
         {
             public Task Test()
             {
-                var divide = Divide(15, 5);
+                var divide = DivideAsync(15, 5);
 
                 return divide.ContinueWith(division =>
                 {
@@ -145,7 +145,7 @@
         {
             public Task<bool> Test()
             {
-                var divide = Divide(15, 5);
+                var divide = DivideAsync(15, 5);
 
                 return divide.ContinueWith(division =>
                 {
@@ -171,7 +171,7 @@
         {
             public async Task Test()
             {
-                var result = await Divide(15, 5);
+                var result = await DivideAsync(15, 5);
 
                 result.ShouldBe(0);
             }
@@ -181,7 +181,7 @@
         {
             public async Task Test()
             {
-                await Divide(15, 0);
+                await DivideAsync(15, 0);
 
                 throw new ShouldBeUnreachableException();
             }
@@ -193,7 +193,7 @@
             {
                 ThrowException();
 
-                await Divide(15, 5);
+                await DivideAsync(15, 5);
             }
         }
 
@@ -209,7 +209,7 @@
         {
             public object Test()
             {
-                var divide = Divide(15, 5);
+                var divide = DivideAsync(15, 5);
 
                 return divide.ContinueWith(division =>
                 {
@@ -224,7 +224,7 @@
         {
             public async void Test()
             {
-                await Divide(15, 5);
+                await DivideAsync(15, 5);
 
                 throw new ShouldBeUnreachableException();
             }

--- a/src/Fixie.Tests/Cases/AsyncCaseTests.cs
+++ b/src/Fixie.Tests/Cases/AsyncCaseTests.cs
@@ -8,85 +8,85 @@
 
     public class AsyncCaseTests
     {
-        public void ShouldAwaitThenPassUponSuccessfulAsyncExecution()
+        public async Task ShouldAwaitThenPassUponSuccessfulAsyncExecution()
         {
-            Run<AwaitThenPassTestClass>()
+            (await Run<AwaitThenPassTestClass>())
                 .ShouldBe(
                     For<AwaitThenPassTestClass>(".Test passed"));
         }
 
-        public void ShouldAwaitResultThenPassUponSuccessfulAsyncExecution()
+        public async Task ShouldAwaitResultThenPassUponSuccessfulAsyncExecution()
         {
-            Run<AwaitResultThenPassTestClass>()
+            (await Run<AwaitResultThenPassTestClass>())
                 .ShouldBe(
                     For<AwaitResultThenPassTestClass>(".Test passed"));
         }
 
-        public void ShouldCompleteTaskThenPassUponSuccessfulTaskExecution()
+        public async Task ShouldCompleteTaskThenPassUponSuccessfulTaskExecution()
         {
-            Run<CompleteTaskThenPassTestClass>()
+            (await Run<CompleteTaskThenPassTestClass>())
                 .ShouldBe(
                     For<CompleteTaskThenPassTestClass>(".Test passed"));
         }
 
-        public void ShouldGetTaskResultThenPassUponSuccessfulTaskExecution()
+        public async Task ShouldGetTaskResultThenPassUponSuccessfulTaskExecution()
         {
-            Run<CompleteTaskWithResultThenPassTestClass>()
+            (await Run<CompleteTaskWithResultThenPassTestClass>())
                 .ShouldBe(
                     For<CompleteTaskWithResultThenPassTestClass>(".Test passed"));
         }
 
-        public void ShouldPassForNullTask()
+        public async Task ShouldPassForNullTask()
         {
-            Run<NullTaskTestClass>()
+            (await Run<NullTaskTestClass>())
                 .ShouldBe(
                     For<NullTaskTestClass>(".Test passed"));
         }
 
-        public void ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsAfterAwaiting()
+        public async Task ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsAfterAwaiting()
         {
-            Run<AwaitThenFailTestClass>()
+            (await Run<AwaitThenFailTestClass>())
                 .ShouldBe(
                     For<AwaitThenFailTestClass>(
                         ".Test failed: Expected: 0" + NewLine +
                         "Actual:   3"));
         }
 
-        public void ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsWithinTheAwaitedTask()
+        public async Task ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsWithinTheAwaitedTask()
         {
-            Run<AwaitOnTaskThatThrowsTestClass>()
+            (await Run<AwaitOnTaskThatThrowsTestClass>())
                 .ShouldBe(
                     For<AwaitOnTaskThatThrowsTestClass>(".Test failed: Attempted to divide by zero."));
         }
 
-        public void ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsBeforeAwaitingOnAnyTask()
+        public async Task ShouldFailWithOriginalExceptionWhenAsyncCaseMethodThrowsBeforeAwaitingOnAnyTask()
         {
-            Run<FailBeforeAwaitTestClass>()
+            (await Run<FailBeforeAwaitTestClass>())
                 .ShouldBe(
                     For<FailBeforeAwaitTestClass>(".Test failed: 'Test' failed!"));
         }
 
-        public void ShouldFailWithClearExplanationWhenAsyncCaseMethodReturnsNonStartedTask()
+        public async Task ShouldFailWithClearExplanationWhenAsyncCaseMethodReturnsNonStartedTask()
         {
-            Run<FailDueToNonStartedTaskTestClass>()
+            (await Run<FailDueToNonStartedTaskTestClass>())
                 .ShouldBe(
                     For<FailDueToNonStartedTaskTestClass>(
                         ".Test failed: The test returned a non-started task, which cannot " +
                         "be awaited. Consider using Task.Run or Task.Factory.StartNew."));
         }
 
-        public void ShouldExecuteReturnedTaskDeclaredAsObject()
+        public async Task ShouldExecuteReturnedTaskDeclaredAsObject()
         {
-            Run<CompleteTaskDeclaredAsObjectTestClass>()
+            (await Run<CompleteTaskDeclaredAsObjectTestClass>())
                 .ShouldBe(
                     For<CompleteTaskDeclaredAsObjectTestClass>(
                         ".Test failed: Expected: 0" + NewLine +
                         "Actual:   3"));
         }
 
-        public void ShouldFailUnsupportedAsyncVoidCases()
+        public async Task ShouldFailUnsupportedAsyncVoidCases()
         {
-            Run<UnsupportedAsyncVoidTestTestClass>()
+            (await Run<UnsupportedAsyncVoidTestTestClass>())
                 .ShouldBe(
                     For<UnsupportedAsyncVoidTestTestClass>(".Test failed: " +
                         "Async void methods are not supported. Declare async methods with a return type of " +

--- a/src/Fixie.Tests/Cases/BasicCaseTests.cs
+++ b/src/Fixie.Tests/Cases/BasicCaseTests.cs
@@ -8,21 +8,21 @@
     {
         public async Task ShouldPassUponSuccessfulExecution()
         {
-            (await Run<PassTestClass>())
+            (await RunAsync<PassTestClass>())
                 .ShouldBe(
                     For<PassTestClass>(".Pass passed"));
         }
 
         public async Task ShouldFailWithOriginalExceptionWhenCaseMethodThrows()
         {
-            (await Run<FailTestClass>())
+            (await RunAsync<FailTestClass>())
                 .ShouldBe(
                     For<FailTestClass>(".Fail failed: 'Fail' failed!"));
         }
 
         public async Task ShouldPassOrFailCasesIndividually()
         {
-            (await Run<PassFailTestClass>())
+            (await RunAsync<PassFailTestClass>())
                 .ShouldBe(
                     For<PassFailTestClass>(
                         ".FailA failed: 'FailA' failed!",
@@ -34,7 +34,7 @@
 
         public async Task ShouldFailWhenTestClassConstructorCannotBeInvoked()
         {
-            (await Run<CannotInvokeConstructorTestClass>())
+            (await RunAsync<CannotInvokeConstructorTestClass>())
                 .ShouldBe(
                     For<CannotInvokeConstructorTestClass>(
                         ".UnreachableCase failed: No parameterless constructor defined " +

--- a/src/Fixie.Tests/Cases/BasicCaseTests.cs
+++ b/src/Fixie.Tests/Cases/BasicCaseTests.cs
@@ -1,27 +1,28 @@
 ﻿namespace Fixie.Tests.Cases
 {
+    using System.Threading.Tasks;
     using Assertions;
     using static Utility;
 
     public class BasicCaseTests
     {
-        public void ShouldPassUponSuccessfulExecution()
+        public async Task ShouldPassUponSuccessfulExecution()
         {
-            Run<PassTestClass>()
+            (await Run<PassTestClass>())
                 .ShouldBe(
                     For<PassTestClass>(".Pass passed"));
         }
 
-        public void ShouldFailWithOriginalExceptionWhenCaseMethodThrows()
+        public async Task ShouldFailWithOriginalExceptionWhenCaseMethodThrows()
         {
-            Run<FailTestClass>()
+            (await Run<FailTestClass>())
                 .ShouldBe(
                     For<FailTestClass>(".Fail failed: 'Fail' failed!"));
         }
 
-        public void ShouldPassOrFailCasesIndividually()
+        public async Task ShouldPassOrFailCasesIndividually()
         {
-            Run<PassFailTestClass>()
+            (await Run<PassFailTestClass>())
                 .ShouldBe(
                     For<PassFailTestClass>(
                         ".FailA failed: 'FailA' failed!",
@@ -31,9 +32,9 @@
                         ".PassC passed"));
         }
 
-        public void ShouldFailWhenTestClassConstructorCannotBeInvoked()
+        public async Task ShouldFailWhenTestClassConstructorCannotBeInvoked()
         {
-            Run<CannotInvokeConstructorTestClass>()
+            (await Run<CannotInvokeConstructorTestClass>())
                 .ShouldBe(
                     For<CannotInvokeConstructorTestClass>(
                         ".UnreachableCase failed: No parameterless constructor defined " +

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -13,7 +13,7 @@ namespace Fixie.Tests.Cases
         {
             using var console = new RedirectedConsole();
 
-            (await Run<SampleTestClass>())
+            (await RunAsync<SampleTestClass>())
                 .ShouldBe(
                     For<SampleTestClass>(
                         ".BoolFalse passed",
@@ -24,7 +24,7 @@ namespace Fixie.Tests.Cases
                         ".StringNull passed",
                         ".Throw failed: 'Throw' failed!"));
 
-            (await Run<SampleAsyncTestClass>())
+            (await RunAsync<SampleAsyncTestClass>())
                 .ShouldBe(
                     For<SampleAsyncTestClass>(
                         ".BoolFalse passed",
@@ -42,7 +42,7 @@ namespace Fixie.Tests.Cases
         {
             using var console = new RedirectedConsole();
 
-            (await Run<SampleTestClass, TreatBoolReturnValuesAsAssertions>())
+            (await RunAsync<SampleTestClass, TreatBoolReturnValuesAsAssertions>())
                 .ShouldBe(
                     For<SampleTestClass>(
                         ".BoolFalse failed: Boolean test case returned false!",
@@ -67,7 +67,7 @@ namespace Fixie.Tests.Cases
         {
             using var console = new RedirectedConsole();
 
-            (await Run<SampleAsyncTestClass, TreatBoolReturnValuesAsAssertions>())
+            (await RunAsync<SampleAsyncTestClass, TreatBoolReturnValuesAsAssertions>())
                 .ShouldBe(
                     For<SampleAsyncTestClass>(
                         ".BoolFalse failed: Boolean test case returned false!",
@@ -118,11 +118,11 @@ namespace Fixie.Tests.Cases
 
         class TreatBoolReturnValuesAsAssertions : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                 {
-                    await test.Run(@case =>
+                    await test.RunAsync(@case =>
                     {
                         var result = @case.Result;
 

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -9,11 +9,11 @@ namespace Fixie.Tests.Cases
 
     public class NonVoidCaseTests
     {
-        public void ShouldIgnoreCaseReturnValuesByDefault()
+        public async Task ShouldIgnoreCaseReturnValuesByDefault()
         {
             using var console = new RedirectedConsole();
 
-            Run<SampleTestClass>()
+            (await Run<SampleTestClass>())
                 .ShouldBe(
                     For<SampleTestClass>(
                         ".BoolFalse passed",
@@ -24,7 +24,7 @@ namespace Fixie.Tests.Cases
                         ".StringNull passed",
                         ".Throw failed: 'Throw' failed!"));
 
-            Run<SampleAsyncTestClass>()
+            (await Run<SampleAsyncTestClass>())
                 .ShouldBe(
                     For<SampleAsyncTestClass>(
                         ".BoolFalse passed",

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -38,11 +38,11 @@ namespace Fixie.Tests.Cases
             console.Output.ShouldBe("");
         }
 
-        public void ShouldProvideCaseReturnValuesToCustomBehaviors()
+        public async Task ShouldProvideCaseReturnValuesToCustomBehaviors()
         {
             using var console = new RedirectedConsole();
 
-            Run<SampleTestClass, TreatBoolReturnValuesAsAssertions>()
+            (await Run<SampleTestClass, TreatBoolReturnValuesAsAssertions>())
                 .ShouldBe(
                     For<SampleTestClass>(
                         ".BoolFalse failed: Boolean test case returned false!",
@@ -63,11 +63,11 @@ namespace Fixie.Tests.Cases
                 "Throw null");
         }
 
-        public void ShouldUnpackResultValuesFromStronglyTypedTaskObjectsForAsyncCases()
+        public async Task ShouldUnpackResultValuesFromStronglyTypedTaskObjectsForAsyncCases()
         {
             using var console = new RedirectedConsole();
 
-            Run<SampleAsyncTestClass, TreatBoolReturnValuesAsAssertions>()
+            (await Run<SampleAsyncTestClass, TreatBoolReturnValuesAsAssertions>())
                 .ShouldBe(
                     For<SampleAsyncTestClass>(
                         ".BoolFalse failed: Boolean test case returned false!",

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -118,11 +118,11 @@ namespace Fixie.Tests.Cases
 
         class TreatBoolReturnValuesAsAssertions : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                 {
-                    test.Run(@case =>
+                    await test.Run(@case =>
                     {
                         var result = @case.Result;
 
@@ -130,7 +130,7 @@ namespace Fixie.Tests.Cases
 
                         if (@case.Exception == null && result is bool success && !success)
                             @case.Fail("Boolean test case returned false!");
-                    }).GetAwaiter().GetResult();
+                    });
                 }
             }
         }

--- a/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
+++ b/src/Fixie.Tests/Cases/NonVoidCaseTests.cs
@@ -130,7 +130,7 @@ namespace Fixie.Tests.Cases
 
                         if (@case.Exception == null && result is bool success && !success)
                             @case.Fail("Boolean test case returned false!");
-                    });
+                    }).GetAwaiter().GetResult();
                 }
             }
         }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -19,7 +19,8 @@
             public void Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                    test.RunCases(parameterSource);
+                    test.RunCases(parameterSource)
+                        .GetAwaiter().GetResult();
             }
         }
 
@@ -32,11 +33,11 @@
                     if (test.HasParameters)
                     {
                         foreach (var parameters in InputAttributeParameterSource(test.Method))
-                            test.Run(parameters);
+                            test.Run(parameters).GetAwaiter().GetResult();
                     }
                     else
                     {
-                        test.Run();
+                        test.Run().GetAwaiter().GetResult();
                     }
                 }
             }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Assertions;
     using static Utility;
 
@@ -16,28 +17,27 @@
             public ParameterizedExecution(ParameterSource parameterSource)
                 => this.parameterSource = parameterSource;
 
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                    test.RunCases(parameterSource)
-                        .GetAwaiter().GetResult();
+                    await test.RunCases(parameterSource);
             }
         }
 
         class ExplicitlyParameterizedExecution : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                 {
                     if (test.HasParameters)
                     {
                         foreach (var parameters in InputAttributeParameterSource(test.Method))
-                            test.Run(parameters).GetAwaiter().GetResult();
+                            await test.Run(parameters);
                     }
                     else
                     {
-                        test.Run().GetAwaiter().GetResult();
+                        await test.Run();
                     }
                 }
             }

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -17,27 +17,27 @@
             public ParameterizedExecution(ParameterSource parameterSource)
                 => this.parameterSource = parameterSource;
 
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                    await test.RunCases(parameterSource);
+                    await test.RunCasesAsync(parameterSource);
             }
         }
 
         class ExplicitlyParameterizedExecution : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                 {
                     if (test.HasParameters)
                     {
                         foreach (var parameters in InputAttributeParameterSource(test.Method))
-                            await test.Run(parameters);
+                            await test.RunAsync(parameters);
                     }
                     else
                     {
-                        await test.Run();
+                        await test.RunAsync();
                     }
                 }
             }
@@ -46,7 +46,7 @@
         public async Task ShouldAllowExecutionToGeneratePotentiallyManySetsOfInputParametersPerMethod()
         {
             var execution = new ParameterizedExecution(InputAttributeOrDefaultParameterSource);
-            (await Run<ParameterizedTestClass>(execution))
+            (await RunAsync<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".IntArg(0) passed",
@@ -59,7 +59,7 @@
         public async Task ShouldSkipWhenInputParameterGenerationYieldsZeroSetsOfInputs()
         {
             var execution = new ParameterizedExecution(EmptyParameterSource);
-            (await Run<ParameterizedTestClass>(execution))
+            (await RunAsync<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".ZeroArgs passed",
@@ -77,7 +77,7 @@
                 new object[] {0, 1, 2},
                 new object[] {0, 1, 2, 3}
             });
-            (await Run<ParameterizedTestClass>(execution))
+            (await RunAsync<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".IntArg failed: Parameter count mismatch.",
@@ -98,7 +98,7 @@
         public async Task ShouldFailWithClearExplanationWhenParameterGenerationThrows()
         {
             var execution = new ParameterizedExecution(LazyBuggyParameterSource);
-            (await Run<ParameterizedTestClass>(execution))
+            (await RunAsync<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".IntArg(0) passed",
@@ -120,7 +120,7 @@
             //this test demonstrates how the failure is isolated to that test method.
 
             var execution = new ParameterizedExecution(EagerBuggyParameterSource);
-            (await Run<ParameterizedTestClass>(execution))
+            (await RunAsync<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".IntArg failed: Exception thrown while attempting to eagerly build input parameters for method: IntArg",
@@ -134,7 +134,7 @@
         public async Task ShouldFailWithClearExplanationWhenParameterGenerationExceptionPreventsGenericTypeParametersFromBeingResolvable()
         {
             var execution = new ParameterizedExecution(LazyBuggyParameterSource);
-            (await Run<ConstrainedGenericTestClass>(execution))
+            (await RunAsync<ConstrainedGenericTestClass>(execution))
                 .ShouldBe(
                     For<ConstrainedGenericTestClass>(
                         ".ConstrainedGeneric<System.Int32>(0) passed",
@@ -148,18 +148,18 @@
         public async Task ShouldResolveGenericTypeParameters()
         {
             var execution = new ParameterizedExecution(InputAttributeParameterSource);
-            await ShouldResolveGenericTypeParameters(execution);
+            await ShouldResolveGenericTypeParametersAsync(execution);
         }
 
         public async Task ShouldSupportExplicitParameterization()
         {
             var execution = new ExplicitlyParameterizedExecution();
-            await ShouldResolveGenericTypeParameters(execution);
+            await ShouldResolveGenericTypeParametersAsync(execution);
         }
 
-        async Task ShouldResolveGenericTypeParameters(Execution execution)
+        async Task ShouldResolveGenericTypeParametersAsync(Execution execution)
         {
-            (await Run<GenericTestClass>(execution))
+            (await RunAsync<GenericTestClass>(execution))
                 .ShouldBe(
                     For<GenericTestClass>(
                         ".ConstrainedGeneric<System.Int32>(1) passed",
@@ -193,7 +193,7 @@
         public async Task ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
         {
             var execution = new ParameterizedExecution(ComplexGenericParameterSource);
-            (await Run<ComplexGenericTestClass>(execution))
+            (await RunAsync<ComplexGenericTestClass>(execution))
                 .ShouldBe(
                     For<ComplexGenericTestClass>(
                         ".CompoundGenericParameter<System.Int32, System.String>([1, A], \"System.Int32\", \"System.String\") passed",

--- a/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
+++ b/src/Fixie.Tests/Cases/ParameterizedCaseTests.cs
@@ -43,10 +43,10 @@
             }
         }
 
-        public void ShouldAllowExecutionToGeneratePotentiallyManySetsOfInputParametersPerMethod()
+        public async Task ShouldAllowExecutionToGeneratePotentiallyManySetsOfInputParametersPerMethod()
         {
             var execution = new ParameterizedExecution(InputAttributeOrDefaultParameterSource);
-            Run<ParameterizedTestClass>(execution)
+            (await Run<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".IntArg(0) passed",
@@ -56,10 +56,10 @@
                         ".ZeroArgs passed"));
         }
 
-        public void ShouldSkipWhenInputParameterGenerationYieldsZeroSetsOfInputs()
+        public async Task ShouldSkipWhenInputParameterGenerationYieldsZeroSetsOfInputs()
         {
             var execution = new ParameterizedExecution(EmptyParameterSource);
-            Run<ParameterizedTestClass>(execution)
+            (await Run<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".ZeroArgs passed",
@@ -67,7 +67,7 @@
                         ".MultipleCasesFromAttributes skipped: This test did not run."));
         }
 
-        public void ShouldFailWithClearExplanationWhenParameterCountsAreMismatched()
+        public async Task ShouldFailWithClearExplanationWhenParameterCountsAreMismatched()
         {
             var execution = new ParameterizedExecution(method => new[]
             {
@@ -77,7 +77,7 @@
                 new object[] {0, 1, 2},
                 new object[] {0, 1, 2, 3}
             });
-            Run<ParameterizedTestClass>(execution)
+            (await Run<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".IntArg failed: Parameter count mismatch.",
@@ -95,10 +95,10 @@
                         ".ZeroArgs passed"));
         }
 
-        public void ShouldFailWithClearExplanationWhenParameterGenerationThrows()
+        public async Task ShouldFailWithClearExplanationWhenParameterGenerationThrows()
         {
             var execution = new ParameterizedExecution(LazyBuggyParameterSource);
-            Run<ParameterizedTestClass>(execution)
+            (await Run<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".IntArg(0) passed",
@@ -112,7 +112,7 @@
                         ".ZeroArgs passed"));
         }
 
-        public void ShouldIsolateFailureToTheAffectedTestMethodWhenEagerParameterGenerationThrows()
+        public async Task ShouldIsolateFailureToTheAffectedTestMethodWhenEagerParameterGenerationThrows()
         {
             //The EagerBuggyParameterSource attempts to realize a complete set of
             //parameter arrays before returning, but will first throw an exception
@@ -120,7 +120,7 @@
             //this test demonstrates how the failure is isolated to that test method.
 
             var execution = new ParameterizedExecution(EagerBuggyParameterSource);
-            Run<ParameterizedTestClass>(execution)
+            (await Run<ParameterizedTestClass>(execution))
                 .ShouldBe(
                     For<ParameterizedTestClass>(
                         ".IntArg failed: Exception thrown while attempting to eagerly build input parameters for method: IntArg",
@@ -131,10 +131,10 @@
                         ".ZeroArgs passed"));
         }
 
-        public void ShouldFailWithClearExplanationWhenParameterGenerationExceptionPreventsGenericTypeParametersFromBeingResolvable()
+        public async Task ShouldFailWithClearExplanationWhenParameterGenerationExceptionPreventsGenericTypeParametersFromBeingResolvable()
         {
             var execution = new ParameterizedExecution(LazyBuggyParameterSource);
-            Run<ConstrainedGenericTestClass>(execution)
+            (await Run<ConstrainedGenericTestClass>(execution))
                 .ShouldBe(
                     For<ConstrainedGenericTestClass>(
                         ".ConstrainedGeneric<System.Int32>(0) passed",
@@ -145,21 +145,21 @@
                         ".UnconstrainedGeneric<T> failed: Exception thrown while attempting to yield input parameters for method: UnconstrainedGeneric"));
         }
 
-        public void ShouldResolveGenericTypeParameters()
+        public async Task ShouldResolveGenericTypeParameters()
         {
             var execution = new ParameterizedExecution(InputAttributeParameterSource);
-            ShouldResolveGenericTypeParameters(execution);
+            await ShouldResolveGenericTypeParameters(execution);
         }
 
-        public void ShouldSupportExplicitParameterization()
+        public async Task ShouldSupportExplicitParameterization()
         {
             var execution = new ExplicitlyParameterizedExecution();
-            ShouldResolveGenericTypeParameters(execution);
+            await ShouldResolveGenericTypeParameters(execution);
         }
 
-        void ShouldResolveGenericTypeParameters(Execution execution)
+        async Task ShouldResolveGenericTypeParameters(Execution execution)
         {
-            Run<GenericTestClass>(execution)
+            (await Run<GenericTestClass>(execution))
                 .ShouldBe(
                     For<GenericTestClass>(
                         ".ConstrainedGeneric<System.Int32>(1) passed",
@@ -190,10 +190,10 @@
                         ".GenericMethodWithNoInputsProvided<T> skipped: This test did not run."));
         }
 
-        public void ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
+        public async Task ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
         {
             var execution = new ParameterizedExecution(ComplexGenericParameterSource);
-            Run<ComplexGenericTestClass>(execution)
+            (await Run<ComplexGenericTestClass>(execution))
                 .ShouldBe(
                     For<ComplexGenericTestClass>(
                         ".CompoundGenericParameter<System.Int32, System.String>([1, A], \"System.Int32\", \"System.String\") passed",

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -82,13 +82,13 @@ namespace Fixie.Tests
         }
 
         protected Output Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
-            => Run<TExecution>(typeof(TSampleTestClass));
+            => Run<TExecution>(typeof(TSampleTestClass)).GetAwaiter().GetResult();
 
         protected Output Run<TSampleTestClass>(Execution execution)
             => Run(typeof(TSampleTestClass), execution).GetAwaiter().GetResult();
 
-        protected Output Run<TExecution>(Type testClass) where TExecution : Execution, new()
-            => Run(testClass, new TExecution()).GetAwaiter().GetResult();
+        protected Task<Output> Run<TExecution>(Type testClass) where TExecution : Execution, new()
+            => Run(testClass, new TExecution());
 
         protected async Task<Output> Run(Type testClass, Execution execution)
         {

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -81,8 +81,8 @@ namespace Fixie.Tests
             }
         }
 
-        protected Output Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
-            => Run<TExecution>(typeof(TSampleTestClass)).GetAwaiter().GetResult();
+        protected Task<Output> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
+            => Run<TExecution>(typeof(TSampleTestClass));
 
         protected Task<Output> Run<TSampleTestClass>(Execution execution)
             => Run(typeof(TSampleTestClass), execution);

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -93,7 +93,7 @@ namespace Fixie.Tests
         {
             using var console = new RedirectedConsole();
 
-            var results = Utility.Run(testClass, execution);
+            var results = Utility.Run(testClass, execution).GetAwaiter().GetResult();
 
             return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
         }

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -84,8 +84,8 @@ namespace Fixie.Tests
         protected Output Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
             => Run<TExecution>(typeof(TSampleTestClass)).GetAwaiter().GetResult();
 
-        protected Output Run<TSampleTestClass>(Execution execution)
-            => Run(typeof(TSampleTestClass), execution).GetAwaiter().GetResult();
+        protected Task<Output> Run<TSampleTestClass>(Execution execution)
+            => Run(typeof(TSampleTestClass), execution);
 
         protected Task<Output> Run<TExecution>(Type testClass) where TExecution : Execution, new()
             => Run(testClass, new TExecution());

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -81,20 +81,20 @@ namespace Fixie.Tests
             }
         }
 
-        protected Task<Output> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
-            => Run<TExecution>(typeof(TSampleTestClass));
+        protected Task<Output> RunAsync<TSampleTestClass, TExecution>() where TExecution : Execution, new()
+            => RunAsync<TExecution>(typeof(TSampleTestClass));
 
-        protected Task<Output> Run<TSampleTestClass>(Execution execution)
-            => Run(typeof(TSampleTestClass), execution);
+        protected Task<Output> RunAsync<TSampleTestClass>(Execution execution)
+            => RunAsync(typeof(TSampleTestClass), execution);
 
-        protected Task<Output> Run<TExecution>(Type testClass) where TExecution : Execution, new()
-            => Run(testClass, new TExecution());
+        protected Task<Output> RunAsync<TExecution>(Type testClass) where TExecution : Execution, new()
+            => RunAsync(testClass, new TExecution());
 
-        protected async Task<Output> Run(Type testClass, Execution execution)
+        protected async Task<Output> RunAsync(Type testClass, Execution execution)
         {
             using var console = new RedirectedConsole();
 
-            var results = await Utility.Run(testClass, execution);
+            var results = await Utility.RunAsync(testClass, execution);
 
             return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
         }

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -3,6 +3,7 @@ namespace Fixie.Tests
     using System;
     using System.Linq;
     using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
     using Assertions;
     using Fixie.Internal;
 
@@ -84,16 +85,16 @@ namespace Fixie.Tests
             => Run<TExecution>(typeof(TSampleTestClass));
 
         protected Output Run<TSampleTestClass>(Execution execution)
-            => Run(typeof(TSampleTestClass), execution);
+            => Run(typeof(TSampleTestClass), execution).GetAwaiter().GetResult();
 
         protected Output Run<TExecution>(Type testClass) where TExecution : Execution, new()
-            => Run(testClass, new TExecution());
+            => Run(testClass, new TExecution()).GetAwaiter().GetResult();
 
-        protected Output Run(Type testClass, Execution execution)
+        protected async Task<Output> Run(Type testClass, Execution execution)
         {
             using var console = new RedirectedConsole();
 
-            var results = Utility.Run(testClass, execution).GetAwaiter().GetResult();
+            var results = await Utility.Run(testClass, execution);
 
             return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
         }

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -93,7 +93,7 @@
             public void Handle(Event message)
                 => Log<CombinationEventHandler, Event>(message.Id);
 
-            public Task Handle(AnotherEvent message)
+            public Task HandleAsync(AnotherEvent message)
             {
                 Log<CombinationEventHandler, AnotherEvent>(message.Id);
                 return Task.CompletedTask;

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -8,7 +8,7 @@
 
     public class BusTests
     {
-        public void ShouldPublishEventsForAllListeners()
+        public async Task ShouldPublishEventsForAllListeners()
         {
             var listeners = new Listener[]
             {
@@ -20,9 +20,9 @@
             var bus = new Bus(listeners);
             using var console = new RedirectedConsole();
 
-            bus.Publish(new Event(1));
-            bus.Publish(new AnotherEvent(2));
-            bus.Publish(new Event(3));
+            await bus.PublishAsync(new Event(1));
+            await bus.PublishAsync(new AnotherEvent(2));
+            await bus.PublishAsync(new Event(3));
 
             console.Lines()
                 .ShouldBe(
@@ -34,7 +34,7 @@
                     FullName<CombinationEventHandler>() + " handled Event 3");
         }
 
-        public void ShouldCatchAndLogExceptionsThrowByProblematicListenersRatherThanInterruptExecution()
+        public async Task ShouldCatchAndLogExceptionsThrowByProblematicListenersRatherThanInterruptExecution()
         {
             var listeners = new Listener[]
             {
@@ -45,9 +45,9 @@
             var bus = new Bus(listeners);
             using var console = new RedirectedConsole();
 
-            bus.Publish(new Event(1));
-            bus.Publish(new AnotherEvent(2));
-            bus.Publish(new Event(3));
+            await bus.PublishAsync(new Event(1));
+            await bus.PublishAsync(new AnotherEvent(2));
+            await bus.PublishAsync(new Event(3));
 
             console.Lines()
                 .ShouldBe(

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -57,7 +57,7 @@
 
         class SampleExecution : Execution
         {
-            public Task Execute(TestClass testClass)
+            public Task ExecuteAsync(TestClass testClass)
                 => Task.CompletedTask;
         }
         

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
     using Assertions;
     using Fixie.Internal;
 
@@ -56,9 +57,8 @@
 
         class SampleExecution : Execution
         {
-            public void Execute(TestClass testClass)
-            {
-            }
+            public Task Execute(TestClass testClass)
+                => Task.CompletedTask;
         }
         
         public void ShouldConsiderOnlyConcreteClasses()

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Fixie.Tests.Internal
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Assertions;
     using Fixie.Internal;
     using static Utility;
@@ -53,11 +54,11 @@
 
         class CreateInstancePerCase : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                     if (!test.Method.Name.Contains("Skip"))
-                        test.Run().GetAwaiter().GetResult();
+                        await test.Run();
             }
         }
     }

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -15,7 +15,8 @@
 
             var listener = new StubExecutionSummaryListener();
 
-            Run(listener, discovery, execution, typeof(FirstSampleTestClass), typeof(SecondSampleTestClass));
+            Run(listener, discovery, execution, typeof(FirstSampleTestClass), typeof(SecondSampleTestClass))
+                .GetAwaiter().GetResult();
 
             listener.AssemblySummary.Count.ShouldBe(1);
 

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -57,7 +57,7 @@
             {
                 foreach (var test in testClass.Tests)
                     if (!test.Method.Name.Contains("Skip"))
-                        test.Run();
+                        test.Run().GetAwaiter().GetResult();
             }
         }
     }

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -8,15 +8,14 @@
 
     public class ExecutionSummaryTests
     {
-        public void ShouldAccumulateCaseStatusCounts()
+        public async Task ShouldAccumulateCaseStatusCounts()
         {
             var discovery = new SelfTestDiscovery();
             var execution = new CreateInstancePerCase();
 
             var listener = new StubExecutionSummaryListener();
 
-            Run(listener, discovery, execution, typeof(FirstSampleTestClass), typeof(SecondSampleTestClass))
-                .GetAwaiter().GetResult();
+            await Run(listener, discovery, execution, typeof(FirstSampleTestClass), typeof(SecondSampleTestClass));
 
             listener.AssemblySummary.Count.ShouldBe(1);
 

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -15,7 +15,7 @@
 
             var listener = new StubExecutionSummaryListener();
 
-            await Run(listener, discovery, execution, typeof(FirstSampleTestClass), typeof(SecondSampleTestClass));
+            await RunAsync(listener, discovery, execution, typeof(FirstSampleTestClass), typeof(SecondSampleTestClass));
 
             listener.AssemblySummary.Count.ShouldBe(1);
 
@@ -54,11 +54,11 @@
 
         class CreateInstancePerCase : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                     if (!test.Method.Name.Contains("Skip"))
-                        await test.Run();
+                        await test.RunAsync();
             }
         }
     }

--- a/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
@@ -2,18 +2,19 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Assertions;
     using Fixie.Internal;
     using Fixie.Internal.Listeners;
 
     public class LifecycleMessageTests : MessagingTests
     {
-        public void ShouldDescribeTestLifecycleMessagesEmittedDuringExecution()
+        public async Task ShouldDescribeTestLifecycleMessagesEmittedDuringExecution()
         {
             var assembly = typeof(LifecycleMessageTests).Assembly;
             var listener = new StubCaseCompletedListener();
 
-            Run(listener);
+            await Run(listener);
 
             listener.Messages.Count.ShouldBe(14);
             

--- a/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
@@ -14,7 +14,7 @@
             var assembly = typeof(LifecycleMessageTests).Assembly;
             var listener = new StubCaseCompletedListener();
 
-            await Run(listener);
+            await RunAsync(listener);
 
             listener.Messages.Count.ShouldBe(14);
             

--- a/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Internal/LifecycleMessageTests.cs
@@ -13,7 +13,7 @@
             var assembly = typeof(LifecycleMessageTests).Assembly;
             var listener = new StubCaseCompletedListener();
 
-            Run(listener, out _);
+            Run(listener);
 
             listener.Messages.Count.ShouldBe(14);
             

--- a/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
@@ -18,7 +18,7 @@
                 return Task.CompletedTask;
             });
 
-            var output = await Run(listener);
+            var output = await RunAsync(listener);
 
             output.Console
                 .ShouldBe(

--- a/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
@@ -7,7 +7,7 @@
 
     public class AppVeyorListenerTests : MessagingTests
     {
-        public void ShouldReportResultsToAppVeyorBuildWorkerApi()
+        public async Task ShouldReportResultsToAppVeyorBuildWorkerApi()
         {
             var results = new List<AppVeyorListener.TestResult>();
 
@@ -18,7 +18,7 @@
                 return Task.CompletedTask;
             });
 
-            var output = Run(listener);
+            var output = await Run(listener);
 
             output.Console
                 .ShouldBe(

--- a/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AppVeyorListenerTests.cs
@@ -18,9 +18,9 @@
                 return Task.CompletedTask;
             });
 
-            Run(listener, out var console);
+            var output = Run(listener);
 
-            console
+            output.Console
                 .ShouldBe(
                     "Console.Out: Fail",
                     "Console.Error: Fail",

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -25,7 +25,7 @@
             public TContent Content { get; }
         }
 
-        public void ShouldReportResultsToAzureDevOpsApi()
+        public async Task ShouldReportResultsToAzureDevOpsApi()
         {
             var project = Guid.NewGuid().ToString();
             var accessToken = Guid.NewGuid().ToString();
@@ -64,7 +64,7 @@
                     return Task.FromResult("");
                 }, batchSize);
 
-            var output = Run(listener);
+            var output = await Run(listener);
 
             output.Console
                 .ShouldBe(

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -64,7 +64,7 @@
                     return Task.FromResult("");
                 }, batchSize);
 
-            var output = await Run(listener);
+            var output = await RunAsync(listener);
 
             output.Console
                 .ShouldBe(

--- a/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/AzureListenerTests.cs
@@ -64,9 +64,9 @@
                     return Task.FromResult("");
                 }, batchSize);
 
-            Run(listener, out var console);
+            var output = Run(listener);
 
-            console
+            output.Console
                 .ShouldBe(
                     "Console.Out: Fail",
                     "Console.Error: Fail",

--- a/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
@@ -12,9 +12,9 @@
         {
             var listener = new ConsoleListener();
 
-            Run(listener, out var console);
+            var output = Run(listener);
 
-            console
+            output.Console
                 .CleanStackTraceLineNumbers()
                 .CleanDuration()
                 .ShouldBe(
@@ -64,9 +64,9 @@
         {
             var listener = new ConsoleListener(outputCasePassed: true);
 
-            Run(listener, out var console);
+            var output = Run(listener);
 
-            console
+            output.Console
                 .CleanStackTraceLineNumbers()
                 .CleanDuration()
                 .ShouldBe(
@@ -129,9 +129,9 @@
             var listener = new ConsoleListener();
             var discovery = new ZeroPassed();
 
-            Run(listener, discovery, out var console);
+            var output = Run(listener, discovery);
 
-            console
+            output.Console
                 .CleanDuration()
                 .Last()
                 .ShouldBe("2 failed, 2 skipped, took 1.23 seconds");
@@ -148,9 +148,9 @@
             var listener = new ConsoleListener();
             var discovery = new ZeroFailed();
 
-            Run(listener, discovery, out var console);
+            var output = Run(listener, discovery);
 
-            console
+            output.Console
                 .CleanDuration()
                 .Last()
                 .ShouldBe("1 passed, 2 skipped, took 1.23 seconds");
@@ -167,9 +167,9 @@
             var listener = new ConsoleListener();
             var discovery = new ZeroSkipped();
 
-            Run(listener, discovery, out var console);
+            var output = Run(listener, discovery);
 
-            console
+            output.Console
                 .CleanDuration()
                 .Last()
                 .ShouldBe("1 passed, 2 failed, took 1.23 seconds");
@@ -186,9 +186,9 @@
             var listener = new ConsoleListener();
             var discovery = new NoTestsFound();
 
-            Run(listener, discovery, out var console);
+            var output = Run(listener, discovery);
 
-            console
+            output.Console
                 .Last()
                 .ShouldBe("No tests found.");
         }

--- a/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
@@ -13,7 +13,7 @@
         {
             var listener = new ConsoleListener();
 
-            var output = await Run(listener);
+            var output = await RunAsync(listener);
 
             output.Console
                 .CleanStackTraceLineNumbers()
@@ -65,7 +65,7 @@
         {
             var listener = new ConsoleListener(outputCasePassed: true);
 
-            var output = await Run(listener);
+            var output = await RunAsync(listener);
 
             output.Console
                 .CleanStackTraceLineNumbers()
@@ -130,7 +130,7 @@
             var listener = new ConsoleListener();
             var discovery = new ZeroPassed();
 
-            var output = await Run(listener, discovery);
+            var output = await RunAsync(listener, discovery);
 
             output.Console
                 .CleanDuration()
@@ -149,7 +149,7 @@
             var listener = new ConsoleListener();
             var discovery = new ZeroFailed();
 
-            var output = await Run(listener, discovery);
+            var output = await RunAsync(listener, discovery);
 
             output.Console
                 .CleanDuration()
@@ -168,7 +168,7 @@
             var listener = new ConsoleListener();
             var discovery = new ZeroSkipped();
 
-            var output = await Run(listener, discovery);
+            var output = await RunAsync(listener, discovery);
 
             output.Console
                 .CleanDuration()
@@ -187,7 +187,7 @@
             var listener = new ConsoleListener();
             var discovery = new NoTestsFound();
 
-            var output = await Run(listener, discovery);
+            var output = await RunAsync(listener, discovery);
 
             output.Console
                 .Last()

--- a/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Fixie.Internal.Listeners;
     using Assertions;
 
@@ -124,12 +125,12 @@
                 => publicMethods.Where(x => !x.Name.StartsWith("Pass") && x.ReflectedType == TestClassType);
         }
 
-        public void ShouldNotReportPassCountsWhenZeroTestsHavePassed()
+        public async Task ShouldNotReportPassCountsWhenZeroTestsHavePassed()
         {
             var listener = new ConsoleListener();
             var discovery = new ZeroPassed();
 
-            var output = Run(listener, discovery);
+            var output = await Run(listener, discovery);
 
             output.Console
                 .CleanDuration()
@@ -143,12 +144,12 @@
                 => publicMethods.Where(x => !x.Name.StartsWith("Fail") && x.ReflectedType == TestClassType);
         }
 
-        public void ShouldNotReportFailCountsWhenZeroTestsHaveFailed()
+        public async Task ShouldNotReportFailCountsWhenZeroTestsHaveFailed()
         {
             var listener = new ConsoleListener();
             var discovery = new ZeroFailed();
 
-            var output = Run(listener, discovery);
+            var output = await Run(listener, discovery);
 
             output.Console
                 .CleanDuration()
@@ -162,12 +163,12 @@
                 => publicMethods.Where(x => !x.Name.StartsWith("Skip") && x.ReflectedType == TestClassType);
         }
 
-        public void ShouldNotReportSkipCountsWhenZeroTestsHaveBeenSkipped()
+        public async Task ShouldNotReportSkipCountsWhenZeroTestsHaveBeenSkipped()
         {
             var listener = new ConsoleListener();
             var discovery = new ZeroSkipped();
 
-            var output = Run(listener, discovery);
+            var output = await Run(listener, discovery);
 
             output.Console
                 .CleanDuration()
@@ -181,12 +182,12 @@
                 => publicMethods.Where(x => false);
         }
 
-        public void ShouldProvideDiagnosticDescriptionWhenNoTestsWereExecuted()
+        public async Task ShouldProvideDiagnosticDescriptionWhenNoTestsWereExecuted()
         {
             var listener = new ConsoleListener();
             var discovery = new NoTestsFound();
 
-            var output = Run(listener, discovery);
+            var output = await Run(listener, discovery);
 
             output.Console
                 .Last()

--- a/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ConsoleListenerTests.cs
@@ -9,11 +9,11 @@
 
     public class ConsoleListenerTests : MessagingTests
     {
-        public void ShouldReportResults()
+        public async Task ShouldReportResults()
         {
             var listener = new ConsoleListener();
 
-            var output = Run(listener);
+            var output = await Run(listener);
 
             output.Console
                 .CleanStackTraceLineNumbers()
@@ -61,11 +61,11 @@
                     "2 passed, 3 failed, 2 skipped, took 1.23 seconds");
         }
 
-        public void CanOptionallyIncludePassingResults()
+        public async Task CanOptionallyIncludePassingResults()
         {
             var listener = new ConsoleListener(outputCasePassed: true);
 
-            var output = Run(listener);
+            var output = await Run(listener);
 
             output.Console
                 .CleanStackTraceLineNumbers()

--- a/src/Fixie.Tests/Internal/Listeners/ReportListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ReportListenerTests.cs
@@ -4,18 +4,19 @@
     using System.IO;
     using System.Linq;
     using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
     using System.Xml.Linq;
     using Assertions;
     using Fixie.Internal.Listeners;
 
     public class ReportListenerTests : MessagingTests
     {
-        public void ShouldProduceValidXmlDocument()
+        public async Task ShouldProduceValidXmlDocument()
         {
             XDocument? actual = null;
             var listener = new ReportListener(report => actual = report);
 
-            var output = Run(listener);
+            var output = await Run(listener);
 
             output.Console
                 .ShouldBe(

--- a/src/Fixie.Tests/Internal/Listeners/ReportListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ReportListenerTests.cs
@@ -16,7 +16,7 @@
             XDocument? actual = null;
             var listener = new ReportListener(report => actual = report);
 
-            var output = await Run(listener);
+            var output = await RunAsync(listener);
 
             output.Console
                 .ShouldBe(

--- a/src/Fixie.Tests/Internal/Listeners/ReportListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/ReportListenerTests.cs
@@ -15,9 +15,9 @@
             XDocument? actual = null;
             var listener = new ReportListener(report => actual = report);
 
-            Run(listener, out var console);
+            var output = Run(listener);
 
-            console
+            output.Console
                 .ShouldBe(
                     "Console.Out: Fail",
                     "Console.Error: Fail",

--- a/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
@@ -3,18 +3,19 @@
     using System;
     using System.Linq;
     using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
     using Assertions;
     using Fixie.Internal.Listeners;
 
     public class TeamCityListenerTests : MessagingTests
     {
-        public void ShouldReportResultsToTheConsoleInTeamCityFormat()
+        public async Task ShouldReportResultsToTheConsoleInTeamCityFormat()
         {
             var eol = Environment.NewLine == "\r\n" ? "|r|n" : "|n";
 
             var listener = new TeamCityListener();
 
-            var output = Run(listener);
+            var output = await Run(listener);
 
             output.Console
                 .CleanStackTraceLineNumbers()

--- a/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
@@ -14,9 +14,9 @@
 
             var listener = new TeamCityListener();
 
-            Run(listener, out var console);
+            var output = Run(listener);
 
-            console
+            output.Console
                 .CleanStackTraceLineNumbers()
                 .Select(x => Regex.Replace(x, @"duration='\d+'", "duration='#'"))
                 .ShouldBe(

--- a/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
+++ b/src/Fixie.Tests/Internal/Listeners/TeamCityListenerTests.cs
@@ -15,7 +15,7 @@
 
             var listener = new TeamCityListener();
 
-            var output = await Run(listener);
+            var output = await RunAsync(listener);
 
             output.Console
                 .CleanStackTraceLineNumbers()

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -1,6 +1,7 @@
 namespace Fixie.Tests.Internal
 {
     using System.Collections.Immutable;
+    using System.Threading.Tasks;
     using Assertions;
     using Fixie.Internal;
     using static Utility;
@@ -56,11 +57,11 @@ namespace Fixie.Tests.Internal
 
         class CreateInstancePerCase : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                     if (!test.Method.Name.Contains("Skip"))
-                        test.Run().GetAwaiter().GetResult();
+                        await test.Run();
             }
         }
 

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -60,7 +60,7 @@ namespace Fixie.Tests.Internal
             {
                 foreach (var test in testClass.Tests)
                     if (!test.Method.Name.Contains("Skip"))
-                        test.Run();
+                        test.Run().GetAwaiter().GetResult();
             }
         }
 

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -10,7 +10,7 @@ namespace Fixie.Tests.Internal
     {
         static readonly string Self = FullName<RunnerTests>();
 
-        public void ShouldDiscoverAllTestsInAllDiscoveredTestClasses()
+        public async Task ShouldDiscoverAllTestsInAllDiscoveredTestClasses()
         {
             var listener = new StubListener();
 
@@ -20,8 +20,9 @@ namespace Fixie.Tests.Internal
                 typeof(PassFailTestClass), typeof(SkipTestClass)
             };
             var discovery = new SelfTestDiscovery();
-
-            new Runner(GetType().Assembly, listener).Discover(candidateTypes, discovery);
+            
+            var runner = new Runner(GetType().Assembly, listener);
+            await runner.DiscoverAsync(candidateTypes, discovery);
 
             listener.Entries.ShouldBe(
                 Self + "+PassTestClass.PassA discovered",

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -32,7 +32,7 @@ namespace Fixie.Tests.Internal
                 Self + "+SkipTestClass.SkipB discovered");
         }
 
-        public void ShouldExecuteAllCasesInAllDiscoveredTestClasses()
+        public async Task ShouldExecuteAllCasesInAllDiscoveredTestClasses()
         {
             var listener = new StubListener();
 
@@ -44,8 +44,8 @@ namespace Fixie.Tests.Internal
             var discovery = new SelfTestDiscovery();
             var execution = new CreateInstancePerCase();
 
-            new Runner(GetType().Assembly, listener).Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty)
-                .GetAwaiter().GetResult();
+            var runner = new Runner(GetType().Assembly, listener);
+            await runner.Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
 
             listener.Entries.ShouldBe(
                 Self + "+PassTestClass.PassA passed",

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -44,7 +44,8 @@ namespace Fixie.Tests.Internal
             var discovery = new SelfTestDiscovery();
             var execution = new CreateInstancePerCase();
 
-            new Runner(GetType().Assembly, listener).Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
+            new Runner(GetType().Assembly, listener).Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty)
+                .GetAwaiter().GetResult();
 
             listener.Entries.ShouldBe(
                 Self + "+PassTestClass.PassA passed",

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -45,7 +45,7 @@ namespace Fixie.Tests.Internal
             var execution = new CreateInstancePerCase();
 
             var runner = new Runner(GetType().Assembly, listener);
-            await runner.Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
+            await runner.RunAsync(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
 
             listener.Entries.ShouldBe(
                 Self + "+PassTestClass.PassA passed",
@@ -58,11 +58,11 @@ namespace Fixie.Tests.Internal
 
         class CreateInstancePerCase : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                     if (!test.Method.Name.Contains("Skip"))
-                        await test.Run();
+                        await test.RunAsync();
             }
         }
 

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -108,7 +108,7 @@ namespace Fixie.Tests
                 }
                 catch (Exception exception)
                 {
-                    test.Fail(exception);
+                    await test.FailAsync(exception);
                 }
             }
 
@@ -122,7 +122,7 @@ namespace Fixie.Tests
                 }
                 catch (Exception exception)
                 {
-                    test.Fail(exception);
+                    await test.FailAsync(exception);
                 }
             }
 

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -158,10 +158,10 @@ namespace Fixie.Tests
                 foreach (var test in testClass.Tests)
                     if (!test.Method.Name.Contains("Skip"))
                         foreach (var parameters in Cases(test))
-                            await RunWithRetries(test, parameters);
+                            await RunWithRetriesAsync(test, parameters);
             }
 
-            static async Task RunWithRetries(TestMethod test, object?[] parameters)
+            static async Task RunWithRetriesAsync(TestMethod test, object?[] parameters)
             {
                 var remainingAttempts = MaxAttempts;
 

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -235,9 +235,9 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldSupportStaticTestClassesAndMethods()
+        public async Task ShouldSupportStaticTestClassesAndMethods()
         {
-            var output = Run<InstrumentedExecution>(typeof(StaticTestClass));
+            var output = await Run<InstrumentedExecution>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
                 "StaticTestClass.Fail failed: 'Fail' failed!",

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -116,7 +116,7 @@ namespace Fixie.Tests
                 try
                 {
                     CaseSetUp();
-                    test.Run(parameters, @case => CaseInspection());
+                    test.Run(parameters, @case => CaseInspection()).GetAwaiter().GetResult();
                     CaseTearDown();
                 }
                 catch (Exception exception)
@@ -174,7 +174,7 @@ namespace Fixie.Tests
                             @case.Skip(@case.Exception?.Message + " Retrying...");
                         else
                             remainingAttempts = 0;
-                    });
+                    }).GetAwaiter().GetResult();
                 }
             }
 

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -196,9 +196,9 @@ namespace Fixie.Tests
             static readonly object[] EmptyParameters = {};
         }
 
-        public void ShouldRunAllTestsByDefault()
+        public async Task ShouldRunAllTestsByDefault()
         {
-            var output = Run<SampleTestClass, DefaultExecution>();
+            var output = await Run<SampleTestClass, DefaultExecution>();
 
             //NOTE: With no input parameter or skip behaviors,
             //      all test methods are attempted and with zero
@@ -213,9 +213,9 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("Fail", "Skip");
         }
 
-        public void ShouldSupportExecutionHooksAtClassAndTestAndCaseLevels()
+        public async Task ShouldSupportExecutionHooksAtClassAndTestAndCaseLevels()
         {
-            var output = Run<SampleTestClass, InstrumentedExecution>();
+            var output = await Run<SampleTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -251,11 +251,11 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenClassSetUpThrows()
+        public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenClassSetUpThrows()
         {
             FailDuring("ClassSetUp");
         
-            var output = Run<SampleTestClass, InstrumentedExecution>();
+            var output = await Run<SampleTestClass, InstrumentedExecution>();
         
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'ClassSetUp' failed!",
@@ -270,11 +270,11 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("ClassSetUp");
         }
 
-        public void ShouldFailTestWhenTestSetUpThrows()
+        public async Task ShouldFailTestWhenTestSetUpThrows()
         {
             FailDuring("TestSetUp", occurrence: 2);
 
-            var output = Run<SampleTestClass, InstrumentedExecution>();
+            var output = await Run<SampleTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -310,11 +310,11 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailTestWhenCaseSetUpThrows()
+        public async Task ShouldFailTestWhenCaseSetUpThrows()
         {
             FailDuring("CaseSetUp", occurrence: 2);
 
-            var output = Run<SampleTestClass, InstrumentedExecution>();
+            var output = await Run<SampleTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -334,11 +334,11 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailCaseWithoutHidingPrimaryFailuresWhenCaseInspectionThrows()
+        public async Task ShouldFailCaseWithoutHidingPrimaryFailuresWhenCaseInspectionThrows()
         {
             FailDuring("CaseInspection");
 
-            var output = Run<SampleTestClass, InstrumentedExecution>();
+            var output = await Run<SampleTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -359,11 +359,11 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailTestWithoutHidingPrimaryCaseResultsWhenCaseTearDownThrows()
+        public async Task ShouldFailTestWithoutHidingPrimaryCaseResultsWhenCaseTearDownThrows()
         {
             FailDuring("CaseTearDown");
 
-            var output = Run<SampleTestClass, InstrumentedExecution>();
+            var output = await Run<SampleTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -386,11 +386,11 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailTestWithoutHidingPrimaryCaseResultsWhenTestTearDownThrows()
+        public async Task ShouldFailTestWithoutHidingPrimaryCaseResultsWhenTestTearDownThrows()
         {
             FailDuring("TestTearDown");
 
-            var output = Run<SampleTestClass, InstrumentedExecution>();
+            var output = await Run<SampleTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -414,11 +414,11 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailAllTestsWithoutHidingPrimaryCaseResultsWhenClassTearDownThrows()
+        public async Task ShouldFailAllTestsWithoutHidingPrimaryCaseResultsWhenClassTearDownThrows()
         {
             FailDuring("ClassTearDown");
 
-            var output = Run<SampleTestClass, InstrumentedExecution>();
+            var output = await Run<SampleTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -442,9 +442,9 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldSkipTestLifecyclesWhenAllTestsAreSkipped()
+        public async Task ShouldSkipTestLifecyclesWhenAllTestsAreSkipped()
         {
-            var output = Run<AllSkippedTestClass, InstrumentedExecution>();
+            var output = await Run<AllSkippedTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
                 "AllSkippedTestClass.SkipA skipped: This test did not run.",
@@ -454,11 +454,11 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("ClassSetUp", "ClassTearDown");
         }
 
-        public void ShouldAllowRunningTestsMultipleTimesWithDistinctResultPerInvocation()
+        public async Task ShouldAllowRunningTestsMultipleTimesWithDistinctResultPerInvocation()
         {
             FailDuring("Pass", occurrence: 1);
 
-            var output = Run<SampleTestClass, RetryExecution>();
+            var output = await Run<SampleTestClass, RetryExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail skipped: 'Fail' failed! Retrying...",
@@ -472,9 +472,9 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("Fail", "Fail", "Fail", "Pass(1)", "Pass(1)", "Pass(2)");
         }
 
-        public void ShouldSkipAllTestsWhenShortCircuitingTestExecution()
+        public async Task ShouldSkipAllTestsWhenShortCircuitingTestExecution()
         {
-            var output = Run<SampleTestClass, ShortCircuitTestExecution>();
+            var output = await Run<SampleTestClass, ShortCircuitTestExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail skipped: This test did not run.",

--- a/src/Fixie.Tests/LifecycleTests.cs
+++ b/src/Fixie.Tests/LifecycleTests.cs
@@ -290,11 +290,11 @@ namespace Fixie.Tests
                 "ClassTearDown");
         }
 
-        public void ShouldFailTestWhenCustomParameterGenerationThrows()
+        public async Task ShouldFailTestWhenCustomParameterGenerationThrows()
         {
             var execution = new InstrumentedExecution(method =>
                 throw new Exception("Failed to yield input parameters."));
-            var output = Run<SampleTestClass>(execution);
+            var output = await Run<SampleTestClass>(execution);
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -70,7 +70,7 @@
                 {
                     if (test.Method.Has<SkipAttribute>(out var skip))
                     {
-                        test.Skip(skip.Reason);
+                        await test.SkipAsync(skip.Reason);
                         continue;
                     }
 

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -50,7 +50,7 @@
 
             using var console = new RedirectedConsole();
 
-            Utility.Run(listener, discovery, execution, candidateTypes);
+            Utility.Run(listener, discovery, execution, candidateTypes).GetAwaiter().GetResult();
 
             consoleLines = console.Lines();
         }

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -47,9 +47,9 @@
             consoleLines = console.Lines();
         }
 
-        protected Output Run(Listener listener)
+        protected Task<Output> Run(Listener listener)
         {
-            return Run(listener, new SelfTestDiscovery()).GetAwaiter().GetResult();
+            return Run(listener, new SelfTestDiscovery());
         }
 
         protected async Task<Output> Run(Listener listener, Discovery discovery)

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -66,7 +66,8 @@
                         continue;
                     }
 
-                    test.RunCases(UsingInputAttributes);
+                    test.RunCases(UsingInputAttributes)
+                        .GetAwaiter().GetResult();
                 }
             }
         }

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace Fixie.Tests
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
@@ -36,15 +35,15 @@
             public string[] Console { get; }
         }
 
-        protected void Discover(Listener listener, out IEnumerable<string> consoleLines)
+        protected async Task DiscoverAsync(Listener listener)
         {
             var discovery = new SelfTestDiscovery();
 
             using var console = new RedirectedConsole();
 
-            Utility.DiscoverAsync(listener, discovery, candidateTypes).GetAwaiter().GetResult();
+            await Utility.DiscoverAsync(listener, discovery, candidateTypes);
 
-            consoleLines = console.Lines();
+            console.Lines().ShouldBeEmpty();
         }
 
         protected Task<Output> RunAsync(Listener listener)

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -47,25 +47,25 @@
             consoleLines = console.Lines();
         }
 
-        protected Task<Output> Run(Listener listener)
+        protected Task<Output> RunAsync(Listener listener)
         {
-            return Run(listener, new SelfTestDiscovery());
+            return RunAsync(listener, new SelfTestDiscovery());
         }
 
-        protected async Task<Output> Run(Listener listener, Discovery discovery)
+        protected async Task<Output> RunAsync(Listener listener, Discovery discovery)
         {
             var execution = new MessagingTestsExecution();
 
             using var console = new RedirectedConsole();
 
-            await Utility.Run(listener, discovery, execution, candidateTypes);
+            await Utility.RunAsync(listener, discovery, execution, candidateTypes);
 
             return new Output(console.Lines().ToArray());
         }
 
         class MessagingTestsExecution : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                 {
@@ -75,7 +75,7 @@
                         continue;
                     }
 
-                    await test.RunCases(UsingInputAttributes);
+                    await test.RunCasesAsync(UsingInputAttributes);
                 }
             }
         }

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -42,7 +42,7 @@
 
             using var console = new RedirectedConsole();
 
-            Utility.Discover(listener, discovery, candidateTypes);
+            Utility.DiscoverAsync(listener, discovery, candidateTypes).GetAwaiter().GetResult();
 
             consoleLines = console.Lines();
         }

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -28,6 +28,14 @@
             typeof(EmptyTestClass)
         };
 
+        protected class Output
+        {
+            public Output(string[] console)
+                => Console = console;
+
+            public string[] Console { get; }
+        }
+
         protected void Discover(Listener listener, out IEnumerable<string> consoleLines)
         {
             var discovery = new SelfTestDiscovery();
@@ -39,12 +47,12 @@
             consoleLines = console.Lines();
         }
 
-        protected void Run(Listener listener, out IEnumerable<string> consoleLines)
+        protected Output Run(Listener listener)
         {
-            Run(listener, new SelfTestDiscovery(), out consoleLines);
+            return Run(listener, new SelfTestDiscovery());
         }
 
-        protected void Run(Listener listener, Discovery discovery, out IEnumerable<string> consoleLines)
+        protected Output Run(Listener listener, Discovery discovery)
         {
             var execution = new MessagingTestsExecution();
 
@@ -52,7 +60,7 @@
 
             Utility.Run(listener, discovery, execution, candidateTypes).GetAwaiter().GetResult();
 
-            consoleLines = console.Lines();
+            return new Output(console.Lines().ToArray());
         }
 
         class MessagingTestsExecution : Execution

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
     using Assertions;
     using Fixie.Internal;
     using static Utility;
@@ -56,7 +57,7 @@
 
         class MessagingTestsExecution : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                 {
@@ -66,8 +67,7 @@
                         continue;
                     }
 
-                    test.RunCases(UsingInputAttributes)
-                        .GetAwaiter().GetResult();
+                    await test.RunCases(UsingInputAttributes);
                 }
             }
         }

--- a/src/Fixie.Tests/MessagingTests.cs
+++ b/src/Fixie.Tests/MessagingTests.cs
@@ -49,16 +49,16 @@
 
         protected Output Run(Listener listener)
         {
-            return Run(listener, new SelfTestDiscovery());
+            return Run(listener, new SelfTestDiscovery()).GetAwaiter().GetResult();
         }
 
-        protected Output Run(Listener listener, Discovery discovery)
+        protected async Task<Output> Run(Listener listener, Discovery discovery)
         {
             var execution = new MessagingTestsExecution();
 
             using var console = new RedirectedConsole();
 
-            Utility.Run(listener, discovery, execution, candidateTypes).GetAwaiter().GetResult();
+            await Utility.Run(listener, discovery, execution, candidateTypes);
 
             return new Output(console.Lines().ToArray());
         }

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -20,7 +20,7 @@
                     if (@case.Exception is AssertException exception && !exception.HasCompactRepresentations)
                         if (testClass.TestAssembly.SelectedTests.Count == 1)
                             LaunchDiffTool(exception);
-                });
+                }).GetAwaiter().GetResult();
             }
         }
 

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -5,22 +5,23 @@
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Threading.Tasks;
     using Assertions;
     using static System.Environment;
     using static Fixie.Internal.Maybe;
 
     class PrimaryConvention : Execution
     {
-        public void Execute(TestClass testClass)
+        public async Task Execute(TestClass testClass)
         {
             foreach (var test in testClass.Tests)
             {
-                test.Run(@case =>
+                await test.Run(@case =>
                 {
                     if (@case.Exception is AssertException exception && !exception.HasCompactRepresentations)
                         if (testClass.TestAssembly.SelectedTests.Count == 1)
                             LaunchDiffTool(exception);
-                }).GetAwaiter().GetResult();
+                });
             }
         }
 

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -12,11 +12,11 @@
 
     class PrimaryConvention : Execution
     {
-        public async Task Execute(TestClass testClass)
+        public async Task ExecuteAsync(TestClass testClass)
         {
             foreach (var test in testClass.Tests)
             {
-                await test.Run(@case =>
+                await test.RunAsync(@case =>
                 {
                     if (@case.Exception is AssertException exception && !exception.HasCompactRepresentations)
                         if (testClass.TestAssembly.SelectedTests.Count == 1)

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -118,20 +118,20 @@
 
         class ImplicitConstruction : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                    test.Run().GetAwaiter().GetResult();
+                    await test.Run();
             }
         }
 
         class ExplicitConstruction : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 var instance = testClass.Construct();
                 foreach (var test in testClass.Tests)
-                    test.Run(instance).GetAwaiter().GetResult();
+                    await test.Run(instance);
             }
         }
 

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -121,7 +121,7 @@
             public void Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                    test.Run();
+                    test.Run().GetAwaiter().GetResult();
             }
         }
 
@@ -131,7 +131,7 @@
             {
                 var instance = testClass.Construct();
                 foreach (var test in testClass.Tests)
-                    test.Run(instance);
+                    test.Run(instance).GetAwaiter().GetResult();
             }
         }
 

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -109,7 +109,7 @@
             
             using var console = new RedirectedConsole();
 
-            Utility.Run(listener, discovery, execution, typeof(TSampleTestClass));
+            Utility.Run(listener, discovery, execution, typeof(TSampleTestClass)).GetAwaiter().GetResult();
 
             return console.Lines()
                 .CleanStackTraceLineNumbers()

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -10,9 +10,9 @@
 
     public class StackTracePresentationTests
     {
-        public void ShouldProvideCleanStackTraceForImplicitTestClassConstructionFailures()
+        public async Task ShouldProvideCleanStackTraceForImplicitTestClassConstructionFailures()
         {
-            Run<ConstructionFailureTestClass, ImplicitConstruction>()
+            (await Run<ConstructionFailureTestClass, ImplicitConstruction>())
                 .ShouldBe(
                     "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
                     "",
@@ -24,9 +24,9 @@
                     "1 failed, took 1.23 seconds");
         }
         
-        public void ShouldProvideCleanStackTraceForExplicitTestClassConstructionFailures()
+        public async Task ShouldProvideCleanStackTraceForExplicitTestClassConstructionFailures()
         {
-            Run<ConstructionFailureTestClass, ExplicitConstruction>()
+            (await Run<ConstructionFailureTestClass, ExplicitConstruction>())
                 .ShouldBe(
                     "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
                     "",
@@ -41,9 +41,9 @@
                     "1 failed, 1 skipped, took 1.23 seconds");
         }
 
-        public void ShouldProvideCleanStackTraceTestMethodFailures()
+        public async Task ShouldProvideCleanStackTraceTestMethodFailures()
         {
-            Run<FailureTestClass, ImplicitConstruction>()
+            (await Run<FailureTestClass, ImplicitConstruction>())
                 .ShouldBe(
                     "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
                     "",
@@ -62,9 +62,9 @@
                     "2 failed, took 1.23 seconds");
         }
 
-        public void ShouldProvideLiterateStackTraceIncludingAllNestedExceptions()
+        public async Task ShouldProvideLiterateStackTraceIncludingAllNestedExceptions()
         {
-            Run<NestedFailureTestClass, ImplicitConstruction>()
+            (await Run<NestedFailureTestClass, ImplicitConstruction>())
                 .ShouldBe(
                     "Test '" + FullName<NestedFailureTestClass>() + ".Asynchronous' failed:",
                     "",
@@ -101,7 +101,7 @@
                     "2 failed, took 1.23 seconds");
         }
 
-        static IEnumerable<string> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
+        static async Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
         {
             var listener = new ConsoleListener();
             var discovery = new SelfTestDiscovery();
@@ -109,7 +109,7 @@
             
             using var console = new RedirectedConsole();
 
-            Utility.Run(listener, discovery, execution, typeof(TSampleTestClass)).GetAwaiter().GetResult();
+            await Utility.Run(listener, discovery, execution, typeof(TSampleTestClass));
 
             return console.Lines()
                 .CleanStackTraceLineNumbers()

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -12,7 +12,7 @@
     {
         public async Task ShouldProvideCleanStackTraceForImplicitTestClassConstructionFailures()
         {
-            (await Run<ConstructionFailureTestClass, ImplicitConstruction>())
+            (await RunAsync<ConstructionFailureTestClass, ImplicitConstruction>())
                 .ShouldBe(
                     "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
                     "",
@@ -26,7 +26,7 @@
         
         public async Task ShouldProvideCleanStackTraceForExplicitTestClassConstructionFailures()
         {
-            (await Run<ConstructionFailureTestClass, ExplicitConstruction>())
+            (await RunAsync<ConstructionFailureTestClass, ExplicitConstruction>())
                 .ShouldBe(
                     "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
                     "",
@@ -43,7 +43,7 @@
 
         public async Task ShouldProvideCleanStackTraceTestMethodFailures()
         {
-            (await Run<FailureTestClass, ImplicitConstruction>())
+            (await RunAsync<FailureTestClass, ImplicitConstruction>())
                 .ShouldBe(
                     "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
                     "",
@@ -64,7 +64,7 @@
 
         public async Task ShouldProvideLiterateStackTraceIncludingAllNestedExceptions()
         {
-            (await Run<NestedFailureTestClass, ImplicitConstruction>())
+            (await RunAsync<NestedFailureTestClass, ImplicitConstruction>())
                 .ShouldBe(
                     "Test '" + FullName<NestedFailureTestClass>() + ".Asynchronous' failed:",
                     "",
@@ -101,7 +101,7 @@
                     "2 failed, took 1.23 seconds");
         }
 
-        static async Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
+        static async Task<IEnumerable<string>> RunAsync<TSampleTestClass, TExecution>() where TExecution : Execution, new()
         {
             var listener = new ConsoleListener();
             var discovery = new SelfTestDiscovery();
@@ -109,7 +109,7 @@
             
             using var console = new RedirectedConsole();
 
-            await Utility.Run(listener, discovery, execution, typeof(TSampleTestClass));
+            await Utility.RunAsync(listener, discovery, execution, typeof(TSampleTestClass));
 
             return console.Lines()
                 .CleanStackTraceLineNumbers()
@@ -118,20 +118,20 @@
 
         class ImplicitConstruction : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
-                    await test.Run();
+                    await test.RunAsync();
             }
         }
 
         class ExplicitConstruction : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 var instance = testClass.Construct();
                 foreach (var test in testClass.Tests)
-                    await test.Run(instance);
+                    await test.RunAsync(instance);
             }
         }
 

--- a/src/Fixie.Tests/TestAdapter/DiscoveryListenerTests.cs
+++ b/src/Fixie.Tests/TestAdapter/DiscoveryListenerTests.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.IO;
+    using System.Threading.Tasks;
     using Assertions;
     using Fixie.TestAdapter;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -11,7 +12,7 @@
 
     public class DiscoveryListenerTests : MessagingTests
     {
-        public void ShouldMapDiscoveredTestsToVsTestDiscoverySink()
+        public async Task ShouldMapDiscoveredTestsToVsTestDiscoverySink()
         {
             var assemblyPath = typeof(MessagingTests).Assembly.Location;
 
@@ -20,9 +21,7 @@
 
             var listener = new DiscoveryListener(log, discoverySink, assemblyPath);
 
-            Discover(listener, out var console);
-
-            console.ShouldBeEmpty();
+            await DiscoverAsync(listener);
 
             log.Messages.ShouldBeEmpty();
 
@@ -35,7 +34,7 @@
                 x => x.ShouldBeDiscoveryTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath));
         }
 
-        public void ShouldDefaultSourceLocationPropertiesWhenSourceInspectionThrows()
+        public async Task ShouldDefaultSourceLocationPropertiesWhenSourceInspectionThrows()
         {
             const string invalidAssemblyPath = "assembly.path.dll";
 
@@ -44,9 +43,7 @@
 
             var listener = new DiscoveryListener(log, discoverySink, invalidAssemblyPath);
 
-            Discover(listener, out var console);
-
-            console.ShouldBeEmpty();
+            await DiscoverAsync(listener);
 
             var expectedError =
                 $"Error: {typeof(FileNotFoundException).FullName}: " +

--- a/src/Fixie.Tests/TestAdapter/ExecutionListenerTests.cs
+++ b/src/Fixie.Tests/TestAdapter/ExecutionListenerTests.cs
@@ -19,7 +19,7 @@
 
             var listener = new ExecutionListener(recorder, assemblyPath);
 
-            var output = await Run(listener);
+            var output = await RunAsync(listener);
 
             output.Console
                 .ShouldBe(

--- a/src/Fixie.Tests/TestAdapter/ExecutionListenerTests.cs
+++ b/src/Fixie.Tests/TestAdapter/ExecutionListenerTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Fixie.TestAdapter;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -11,14 +12,14 @@
 
     public class ExecutionListenerTests : MessagingTests
     {
-        public void ShouldMapMessagesToVsTestExecutionRecorder()
+        public async Task ShouldMapMessagesToVsTestExecutionRecorder()
         {
             const string assemblyPath = "assembly.path.dll";
             var recorder = new StubExecutionRecorder();
 
             var listener = new ExecutionListener(recorder, assemblyPath);
 
-            var output = Run(listener);
+            var output = await Run(listener);
 
             output.Console
                 .ShouldBe(

--- a/src/Fixie.Tests/TestAdapter/ExecutionListenerTests.cs
+++ b/src/Fixie.Tests/TestAdapter/ExecutionListenerTests.cs
@@ -18,9 +18,9 @@
 
             var listener = new ExecutionListener(recorder, assemblyPath);
 
-            Run(listener, out var console);
+            var output = Run(listener);
 
-            console
+            output.Console
                 .ShouldBe(
                     "Console.Out: Fail",
                     "Console.Error: Fail",

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -109,7 +109,8 @@ namespace Fixie.Tests
             {
                 foreach (var test in testClass.Tests)
                     if (!ShouldSkip(test))
-                        test.RunCases(Utility.UsingInputAttributes, @case => CaseInspection());
+                        test.RunCases(Utility.UsingInputAttributes, @case => CaseInspection())
+                            .GetAwaiter().GetResult();
             }
         }
 
@@ -122,7 +123,8 @@ namespace Fixie.Tests
 
                 foreach (var test in testClass.Tests)
                     if (!ShouldSkip(test))
-                        test.RunCases(Utility.UsingInputAttributes, instance, @case => CaseInspection());
+                        test.RunCases(Utility.UsingInputAttributes, instance, @case => CaseInspection())
+                            .GetAwaiter().GetResult();
 
                 instance.Dispose();
             }

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -287,9 +287,9 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(".ctor", "Dispose");
         }
 
-        public void ShouldBypassConstructionAttemptsWhenTestMethodsAreStatic()
+        public async Task ShouldBypassConstructionAttemptsWhenTestMethodsAreStatic()
         {
-            var output = Run<DefaultExecution>(typeof(StaticTestClass));
+            var output = await Run<DefaultExecution>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
                 "StaticTestClass.Fail failed: 'Fail' failed!",
@@ -300,7 +300,7 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("Fail", "Pass", "Skip");
 
 
-            output = Run<CreateInstancePerCase>(typeof(StaticTestClass));
+            output = await Run<CreateInstancePerCase>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
                 "StaticTestClass.Fail failed: 'Fail' failed!",
@@ -313,7 +313,7 @@ namespace Fixie.Tests
                 "Pass", "CaseInspection");
 
 
-            output = Run<CreateInstancePerClass>(typeof(StaticTestClass));
+            output = await Run<CreateInstancePerClass>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
                 "StaticTestClass.Fail failed: 'Fail' failed!",

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -1,6 +1,7 @@
 namespace Fixie.Tests
 {
     using System;
+    using System.Threading.Tasks;
     using Fixie.Internal;
 
     public class TestClassConstructionTests : InstrumentedExecutionTests
@@ -105,26 +106,24 @@ namespace Fixie.Tests
 
         class CreateInstancePerCase : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                     if (!ShouldSkip(test))
-                        test.RunCases(Utility.UsingInputAttributes, @case => CaseInspection())
-                            .GetAwaiter().GetResult();
+                        await test.RunCases(Utility.UsingInputAttributes, @case => CaseInspection());
             }
         }
 
         class CreateInstancePerClass : Execution
         {
-            public void Execute(TestClass testClass)
+            public async Task Execute(TestClass testClass)
             {
                 var type = testClass.Type;
                 var instance = type.IsStatic() ? null : testClass.Construct();
 
                 foreach (var test in testClass.Tests)
                     if (!ShouldSkip(test))
-                        test.RunCases(Utility.UsingInputAttributes, instance, @case => CaseInspection())
-                            .GetAwaiter().GetResult();
+                        await test.RunCases(Utility.UsingInputAttributes, instance, @case => CaseInspection());
 
                 instance.Dispose();
             }

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -131,14 +131,14 @@ namespace Fixie.Tests
 
         static void CaseInspection() => WhereAmI();
 
-        public void ShouldConstructPerCaseByDefault()
+        public async Task ShouldConstructPerCaseByDefault()
         {
             //NOTE: With no input parameter or skip behaviors,
             //      all test methods are attempted once and with zero
             //      parameters, so Skip() is reached and Pass(int)
             //      is attempted once but never reached.
 
-            var output = Run<SampleTestClass, DefaultExecution>();
+            var output = await Run<SampleTestClass, DefaultExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -151,9 +151,9 @@ namespace Fixie.Tests
                 ".ctor", "Skip", "Dispose");
         }
 
-        public void ShouldAllowConstructingPerCase()
+        public async Task ShouldAllowConstructingPerCase()
         {
-            var output = Run<SampleTestClass, CreateInstancePerCase>();
+            var output = await Run<SampleTestClass, CreateInstancePerCase>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -167,11 +167,11 @@ namespace Fixie.Tests
                 ".ctor", "Pass(2)", "CaseInspection", "Dispose");
         }
 
-        public void ShouldFailCaseInAbsenseOfPrimaryCaseResultAndProceedWithCaseInspectionWhenConstructingPerCaseAndConstructorThrows()
+        public async Task ShouldFailCaseInAbsenseOfPrimaryCaseResultAndProceedWithCaseInspectionWhenConstructingPerCaseAndConstructorThrows()
         {
             FailDuring(".ctor");
             
-            var output = Run<SampleTestClass, CreateInstancePerCase>();
+            var output = await Run<SampleTestClass, CreateInstancePerCase>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: '.ctor' failed!",
@@ -185,11 +185,11 @@ namespace Fixie.Tests
                 ".ctor", "CaseInspection");
         }
 
-        public void ShouldFailCaseWithoutHidingPrimaryFailuresAndProceedWithCaseInspectionWhenConstructingPerCaseAndDisposeThrows()
+        public async Task ShouldFailCaseWithoutHidingPrimaryFailuresAndProceedWithCaseInspectionWhenConstructingPerCaseAndDisposeThrows()
         {
             FailDuring("Dispose");
 
-            var output = Run<SampleTestClass, CreateInstancePerCase>();
+            var output = await Run<SampleTestClass, CreateInstancePerCase>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -204,9 +204,9 @@ namespace Fixie.Tests
                 ".ctor", "Pass(2)", "CaseInspection", "Dispose");
         }
 
-        public void ShouldAllowConstructingPerClass()
+        public async Task ShouldAllowConstructingPerClass()
         {
-            var output = Run<SampleTestClass, CreateInstancePerClass>();
+            var output = await Run<SampleTestClass, CreateInstancePerClass>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -222,11 +222,11 @@ namespace Fixie.Tests
                 "Dispose");
         }
 
-        public void ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenConstructingPerClassAndConstructorThrows()
+        public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenConstructingPerClassAndConstructorThrows()
         {
             FailDuring(".ctor");
 
-            var output = Run<SampleTestClass, CreateInstancePerClass>();
+            var output = await Run<SampleTestClass, CreateInstancePerClass>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: '.ctor' failed!",
@@ -240,11 +240,11 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(".ctor");
         }
 
-        public void ShouldFailAllTestsWithoutHidingPrimaryCaseResultsWhenConstructingPerClassAndDisposeThrows()
+        public async Task ShouldFailAllTestsWithoutHidingPrimaryCaseResultsWhenConstructingPerClassAndDisposeThrows()
         {
             FailDuring("Dispose");
 
-            var output = Run<SampleTestClass, CreateInstancePerClass>();
+            var output = await Run<SampleTestClass, CreateInstancePerClass>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -263,9 +263,9 @@ namespace Fixie.Tests
                 "Dispose");
         }
 
-        public void ShouldBypassConstructionWhenConstructingPerCaseAndAllCasesAreSkipped()
+        public async Task ShouldBypassConstructionWhenConstructingPerCaseAndAllCasesAreSkipped()
         {
-            var output = Run<AllSkippedTestClass, CreateInstancePerCase>();
+            var output = await Run<AllSkippedTestClass, CreateInstancePerCase>();
 
             output.ShouldHaveResults(
                 "AllSkippedTestClass.SkipA skipped: This test did not run.",
@@ -275,9 +275,9 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle();
         }
 
-        public void ShouldNotBypassConstructionWhenConstructingPerClassAndAllCasesAreSkipped()
+        public async Task ShouldNotBypassConstructionWhenConstructingPerClassAndAllCasesAreSkipped()
         {
-            var output = Run<AllSkippedTestClass, CreateInstancePerClass>();
+            var output = await Run<AllSkippedTestClass, CreateInstancePerClass>();
 
             output.ShouldHaveResults(
                 "AllSkippedTestClass.SkipA skipped: This test did not run.",

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -106,24 +106,24 @@ namespace Fixie.Tests
 
         class CreateInstancePerCase : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 foreach (var test in testClass.Tests)
                     if (!ShouldSkip(test))
-                        await test.RunCases(Utility.UsingInputAttributes, @case => CaseInspection());
+                        await test.RunCasesAsync(Utility.UsingInputAttributes, @case => CaseInspection());
             }
         }
 
         class CreateInstancePerClass : Execution
         {
-            public async Task Execute(TestClass testClass)
+            public async Task ExecuteAsync(TestClass testClass)
             {
                 var type = testClass.Type;
                 var instance = type.IsStatic() ? null : testClass.Construct();
 
                 foreach (var test in testClass.Tests)
                     if (!ShouldSkip(test))
-                        await test.RunCases(Utility.UsingInputAttributes, instance, @case => CaseInspection());
+                        await test.RunCasesAsync(Utility.UsingInputAttributes, instance, @case => CaseInspection());
 
                 instance.Dispose();
             }
@@ -138,7 +138,7 @@ namespace Fixie.Tests
             //      parameters, so Skip() is reached and Pass(int)
             //      is attempted once but never reached.
 
-            var output = await Run<SampleTestClass, DefaultExecution>();
+            var output = await RunAsync<SampleTestClass, DefaultExecution>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -153,7 +153,7 @@ namespace Fixie.Tests
 
         public async Task ShouldAllowConstructingPerCase()
         {
-            var output = await Run<SampleTestClass, CreateInstancePerCase>();
+            var output = await RunAsync<SampleTestClass, CreateInstancePerCase>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -171,7 +171,7 @@ namespace Fixie.Tests
         {
             FailDuring(".ctor");
             
-            var output = await Run<SampleTestClass, CreateInstancePerCase>();
+            var output = await RunAsync<SampleTestClass, CreateInstancePerCase>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: '.ctor' failed!",
@@ -189,7 +189,7 @@ namespace Fixie.Tests
         {
             FailDuring("Dispose");
 
-            var output = await Run<SampleTestClass, CreateInstancePerCase>();
+            var output = await RunAsync<SampleTestClass, CreateInstancePerCase>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -206,7 +206,7 @@ namespace Fixie.Tests
 
         public async Task ShouldAllowConstructingPerClass()
         {
-            var output = await Run<SampleTestClass, CreateInstancePerClass>();
+            var output = await RunAsync<SampleTestClass, CreateInstancePerClass>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -226,7 +226,7 @@ namespace Fixie.Tests
         {
             FailDuring(".ctor");
 
-            var output = await Run<SampleTestClass, CreateInstancePerClass>();
+            var output = await RunAsync<SampleTestClass, CreateInstancePerClass>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: '.ctor' failed!",
@@ -244,7 +244,7 @@ namespace Fixie.Tests
         {
             FailDuring("Dispose");
 
-            var output = await Run<SampleTestClass, CreateInstancePerClass>();
+            var output = await RunAsync<SampleTestClass, CreateInstancePerClass>();
 
             output.ShouldHaveResults(
                 "SampleTestClass.Fail failed: 'Fail' failed!",
@@ -265,7 +265,7 @@ namespace Fixie.Tests
 
         public async Task ShouldBypassConstructionWhenConstructingPerCaseAndAllCasesAreSkipped()
         {
-            var output = await Run<AllSkippedTestClass, CreateInstancePerCase>();
+            var output = await RunAsync<AllSkippedTestClass, CreateInstancePerCase>();
 
             output.ShouldHaveResults(
                 "AllSkippedTestClass.SkipA skipped: This test did not run.",
@@ -277,7 +277,7 @@ namespace Fixie.Tests
 
         public async Task ShouldNotBypassConstructionWhenConstructingPerClassAndAllCasesAreSkipped()
         {
-            var output = await Run<AllSkippedTestClass, CreateInstancePerClass>();
+            var output = await RunAsync<AllSkippedTestClass, CreateInstancePerClass>();
 
             output.ShouldHaveResults(
                 "AllSkippedTestClass.SkipA skipped: This test did not run.",
@@ -289,7 +289,7 @@ namespace Fixie.Tests
 
         public async Task ShouldBypassConstructionAttemptsWhenTestMethodsAreStatic()
         {
-            var output = await Run<DefaultExecution>(typeof(StaticTestClass));
+            var output = await RunAsync<DefaultExecution>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
                 "StaticTestClass.Fail failed: 'Fail' failed!",
@@ -300,7 +300,7 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("Fail", "Pass", "Skip");
 
 
-            output = await Run<CreateInstancePerCase>(typeof(StaticTestClass));
+            output = await RunAsync<CreateInstancePerCase>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
                 "StaticTestClass.Fail failed: 'Fail' failed!",
@@ -313,7 +313,7 @@ namespace Fixie.Tests
                 "Pass", "CaseInspection");
 
 
-            output = await Run<CreateInstancePerClass>(typeof(StaticTestClass));
+            output = await RunAsync<CreateInstancePerClass>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
                 "StaticTestClass.Fail failed: 'Fail' failed!",

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -27,10 +27,10 @@
             => path;
 
         public static IEnumerable<string> Run<TSampleTestClass>()
-            => Run<TSampleTestClass, DefaultExecution>();
+            => Run<TSampleTestClass, DefaultExecution>().GetAwaiter().GetResult();
 
-        public static IEnumerable<string> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
-            => Run<TSampleTestClass>(new TExecution()).GetAwaiter().GetResult();
+        public static Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
+            => Run<TSampleTestClass>(new TExecution());
 
         public static Task<IEnumerable<string>> Run<TSampleTestClass>(Execution execution)
             => Run(typeof(TSampleTestClass), execution);

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -30,10 +30,10 @@
             => Run<TSampleTestClass, DefaultExecution>();
 
         public static IEnumerable<string> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
-            => Run<TSampleTestClass>(new TExecution());
+            => Run<TSampleTestClass>(new TExecution()).GetAwaiter().GetResult();
 
-        public static IEnumerable<string> Run<TSampleTestClass>(Execution execution)
-            => Run(typeof(TSampleTestClass), execution).GetAwaiter().GetResult();
+        public static Task<IEnumerable<string>> Run<TSampleTestClass>(Execution execution)
+            => Run(typeof(TSampleTestClass), execution);
 
         public static IEnumerable<string> Run<TExecution>(Type testClass) where TExecution : Execution, new()
             => Run(testClass, new TExecution()).GetAwaiter().GetResult();

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -58,7 +58,8 @@
             if (candidateTypes.Length == 0)
                 throw new InvalidOperationException("At least one type must be specified.");
 
-            new Runner(candidateTypes[0].Assembly, listener).Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
+            new Runner(candidateTypes[0].Assembly, listener).Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty)
+                .GetAwaiter().GetResult();
         }
 
         public static IEnumerable<object?[]> UsingInputAttributes(MethodInfo method)

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -46,14 +46,14 @@
             return listener.Entries;
         }
 
-        public static void Discover(Listener listener, Discovery discovery, params Type[] candidateTypes)
+        public static async Task DiscoverAsync(Listener listener, Discovery discovery, params Type[] candidateTypes)
         {
             if (candidateTypes.Length == 0)
                 throw new InvalidOperationException("At least one type must be specified.");
 
             var runner = new Runner(candidateTypes[0].Assembly, listener);
 
-            runner.DiscoverAsync(candidateTypes, discovery).GetAwaiter().GetResult();
+            await runner.DiscoverAsync(candidateTypes, discovery);
         }
 
         public static Task RunAsync(Listener listener, Discovery discovery, Execution execution, params Type[] candidateTypes)

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
     using Fixie.Internal;
 
     public static class Utility
@@ -41,7 +42,7 @@
         {
             var listener = new StubListener();
             var discovery = new SelfTestDiscovery();
-            Run(listener, discovery, execution, testClass);
+            Run(listener, discovery, execution, testClass).GetAwaiter().GetResult();
             return listener.Entries;
         }
 
@@ -53,13 +54,14 @@
             new Runner(candidateTypes[0].Assembly, listener).Discover(candidateTypes, discovery);
         }
 
-        public static void Run(Listener listener, Discovery discovery, Execution execution, params Type[] candidateTypes)
+        public static Task Run(Listener listener, Discovery discovery, Execution execution, params Type[] candidateTypes)
         {
             if (candidateTypes.Length == 0)
                 throw new InvalidOperationException("At least one type must be specified.");
 
-            new Runner(candidateTypes[0].Assembly, listener).Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty)
-                .GetAwaiter().GetResult();
+            var runner = new Runner(candidateTypes[0].Assembly, listener);
+
+            return runner.Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
         }
 
         public static IEnumerable<object?[]> UsingInputAttributes(MethodInfo method)

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -26,8 +26,8 @@
         public static string PathToThisFile([CallerFilePath] string path = default!)
             => path;
 
-        public static IEnumerable<string> Run<TSampleTestClass>()
-            => Run<TSampleTestClass, DefaultExecution>().GetAwaiter().GetResult();
+        public static Task<IEnumerable<string>> Run<TSampleTestClass>()
+            => Run<TSampleTestClass, DefaultExecution>();
 
         public static Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
             => Run<TSampleTestClass>(new TExecution());

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -26,23 +26,23 @@
         public static string PathToThisFile([CallerFilePath] string path = default!)
             => path;
 
-        public static Task<IEnumerable<string>> Run<TSampleTestClass>()
-            => Run<TSampleTestClass, DefaultExecution>();
+        public static Task<IEnumerable<string>> RunAsync<TSampleTestClass>()
+            => RunAsync<TSampleTestClass, DefaultExecution>();
 
-        public static Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : Execution, new()
-            => Run<TSampleTestClass>(new TExecution());
+        public static Task<IEnumerable<string>> RunAsync<TSampleTestClass, TExecution>() where TExecution : Execution, new()
+            => RunAsync<TSampleTestClass>(new TExecution());
 
-        public static Task<IEnumerable<string>> Run<TSampleTestClass>(Execution execution)
-            => Run(typeof(TSampleTestClass), execution);
+        public static Task<IEnumerable<string>> RunAsync<TSampleTestClass>(Execution execution)
+            => RunAsync(typeof(TSampleTestClass), execution);
 
-        public static Task<IEnumerable<string>> Run<TExecution>(Type testClass) where TExecution : Execution, new()
-            => Run(testClass, new TExecution());
+        public static Task<IEnumerable<string>> RunAsync<TExecution>(Type testClass) where TExecution : Execution, new()
+            => RunAsync(testClass, new TExecution());
 
-        public static async Task<IEnumerable<string>> Run(Type testClass, Execution execution)
+        public static async Task<IEnumerable<string>> RunAsync(Type testClass, Execution execution)
         {
             var listener = new StubListener();
             var discovery = new SelfTestDiscovery();
-            await Run(listener, discovery, execution, testClass);
+            await RunAsync(listener, discovery, execution, testClass);
             return listener.Entries;
         }
 
@@ -54,14 +54,14 @@
             new Runner(candidateTypes[0].Assembly, listener).Discover(candidateTypes, discovery);
         }
 
-        public static Task Run(Listener listener, Discovery discovery, Execution execution, params Type[] candidateTypes)
+        public static Task RunAsync(Listener listener, Discovery discovery, Execution execution, params Type[] candidateTypes)
         {
             if (candidateTypes.Length == 0)
                 throw new InvalidOperationException("At least one type must be specified.");
 
             var runner = new Runner(candidateTypes[0].Assembly, listener);
 
-            return runner.Run(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
+            return runner.RunAsync(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
         }
 
         public static IEnumerable<object?[]> UsingInputAttributes(MethodInfo method)

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -51,7 +51,9 @@
             if (candidateTypes.Length == 0)
                 throw new InvalidOperationException("At least one type must be specified.");
 
-            new Runner(candidateTypes[0].Assembly, listener).Discover(candidateTypes, discovery);
+            var runner = new Runner(candidateTypes[0].Assembly, listener);
+
+            runner.DiscoverAsync(candidateTypes, discovery).GetAwaiter().GetResult();
         }
 
         public static Task RunAsync(Listener listener, Discovery discovery, Execution execution, params Type[] candidateTypes)

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -56,14 +56,14 @@
             await runner.DiscoverAsync(candidateTypes, discovery);
         }
 
-        public static Task RunAsync(Listener listener, Discovery discovery, Execution execution, params Type[] candidateTypes)
+        public static async Task RunAsync(Listener listener, Discovery discovery, Execution execution, params Type[] candidateTypes)
         {
             if (candidateTypes.Length == 0)
                 throw new InvalidOperationException("At least one type must be specified.");
 
             var runner = new Runner(candidateTypes[0].Assembly, listener);
 
-            return runner.RunAsync(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
+            await runner.RunAsync(candidateTypes, discovery, execution, ImmutableHashSet<string>.Empty);
         }
 
         public static IEnumerable<object?[]> UsingInputAttributes(MethodInfo method)

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -35,8 +35,8 @@
         public static Task<IEnumerable<string>> Run<TSampleTestClass>(Execution execution)
             => Run(typeof(TSampleTestClass), execution);
 
-        public static IEnumerable<string> Run<TExecution>(Type testClass) where TExecution : Execution, new()
-            => Run(testClass, new TExecution()).GetAwaiter().GetResult();
+        public static Task<IEnumerable<string>> Run<TExecution>(Type testClass) where TExecution : Execution, new()
+            => Run(testClass, new TExecution());
 
         public static async Task<IEnumerable<string>> Run(Type testClass, Execution execution)
         {

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -33,16 +33,16 @@
             => Run<TSampleTestClass>(new TExecution());
 
         public static IEnumerable<string> Run<TSampleTestClass>(Execution execution)
-            => Run(typeof(TSampleTestClass), execution);
+            => Run(typeof(TSampleTestClass), execution).GetAwaiter().GetResult();
 
         public static IEnumerable<string> Run<TExecution>(Type testClass) where TExecution : Execution, new()
-            => Run(testClass, new TExecution());
+            => Run(testClass, new TExecution()).GetAwaiter().GetResult();
 
-        public static IEnumerable<string> Run(Type testClass, Execution execution)
+        public static async Task<IEnumerable<string>> Run(Type testClass, Execution execution)
         {
             var listener = new StubListener();
             var discovery = new SelfTestDiscovery();
-            Run(listener, discovery, execution, testClass).GetAwaiter().GetResult();
+            await Run(listener, discovery, execution, testClass);
             return listener.Entries;
         }
 

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Internal;
 
     /// <summary>
@@ -124,12 +125,11 @@
         /// Run the test case against the given instance of the test class,
         /// causing the case state to become either passing or failing.
         /// </summary>
-        internal void Run(object? instance)
+        internal async Task Run(object? instance)
         {
             try
             {
-                var result = Method.Execute(instance, parameters)
-                    .GetAwaiter().GetResult();
+                var result = await Method.Execute(instance, parameters);
                 Pass();
                 Result = result;
             }

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -125,11 +125,11 @@
         /// Run the test case against the given instance of the test class,
         /// causing the case state to become either passing or failing.
         /// </summary>
-        internal async Task Run(object? instance)
+        internal async Task RunAsync(object? instance)
         {
             try
             {
-                var result = await Method.Execute(instance, parameters);
+                var result = await Method.ExecuteAsync(instance, parameters);
                 Pass();
                 Result = result;
             }

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -128,7 +128,8 @@
         {
             try
             {
-                var result = Method.Execute(instance, parameters);
+                var result = Method.Execute(instance, parameters)
+                    .GetAwaiter().GetResult();
                 Pass();
                 Result = result;
             }

--- a/src/Fixie/Execution.cs
+++ b/src/Fixie/Execution.cs
@@ -1,10 +1,12 @@
 ﻿namespace Fixie
 {
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Defines a test class lifecycle, to be executed once per test class.
     /// </summary>
     public interface Execution
     {
-        void Execute(TestClass testClass);
+        Task Execute(TestClass testClass);
     }
 }

--- a/src/Fixie/Execution.cs
+++ b/src/Fixie/Execution.cs
@@ -7,6 +7,6 @@
     /// </summary>
     public interface Execution
     {
-        Task Execute(TestClass testClass);
+        Task ExecuteAsync(TestClass testClass);
     }
 }

--- a/src/Fixie/Internal/Bus.cs
+++ b/src/Fixie/Internal/Bus.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     class Bus
     {
@@ -17,14 +18,17 @@
             this.listeners = new List<Listener>(listeners);
         }
 
-        public void Publish<TMessage>(TMessage message) where TMessage : Message
+        public async Task PublishAsync<TMessage>(TMessage message) where TMessage : Message
         {
             foreach (var listener in listeners)
             {
                 try
                 {
-                    (listener as Handler<TMessage>)?.Handle(message);
-                    (listener as AsyncHandler<TMessage>)?.HandleAsync(message).GetAwaiter().GetResult();
+                    if (listener is Handler<TMessage> handler)
+                        handler.Handle(message);
+
+                    if (listener is AsyncHandler<TMessage> asyncHandler)
+                        await asyncHandler.HandleAsync(message);
                 }
                 catch (Exception exception)
                 {

--- a/src/Fixie/Internal/Bus.cs
+++ b/src/Fixie/Internal/Bus.cs
@@ -24,7 +24,7 @@
                 try
                 {
                     (listener as Handler<TMessage>)?.Handle(message);
-                    (listener as AsyncHandler<TMessage>)?.Handle(message).GetAwaiter().GetResult();
+                    (listener as AsyncHandler<TMessage>)?.HandleAsync(message).GetAwaiter().GetResult();
                 }
                 catch (Exception exception)
                 {

--- a/src/Fixie/Internal/DefaultExecution.cs
+++ b/src/Fixie/Internal/DefaultExecution.cs
@@ -1,11 +1,13 @@
 ﻿namespace Fixie.Internal
 {
+    using System.Threading.Tasks;
+
     class DefaultExecution : Execution
     {
-        public void Execute(TestClass testClass)
+        public async Task Execute(TestClass testClass)
         {
             foreach (var test in testClass.Tests)
-                test.Run().GetAwaiter().GetResult();
+                await test.Run();
         }
     }
 }

--- a/src/Fixie/Internal/DefaultExecution.cs
+++ b/src/Fixie/Internal/DefaultExecution.cs
@@ -5,7 +5,7 @@
         public void Execute(TestClass testClass)
         {
             foreach (var test in testClass.Tests)
-                test.Run();
+                test.Run().GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Fixie/Internal/DefaultExecution.cs
+++ b/src/Fixie/Internal/DefaultExecution.cs
@@ -4,10 +4,10 @@
 
     class DefaultExecution : Execution
     {
-        public async Task Execute(TestClass testClass)
+        public async Task ExecuteAsync(TestClass testClass)
         {
             foreach (var test in testClass.Tests)
-                await test.Run();
+                await test.RunAsync();
         }
     }
 }

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -42,7 +42,7 @@
 
             var summary = pattern == null
                 ? runner.Run().GetAwaiter().GetResult()
-                : runner.Run(new TestPattern(pattern));
+                : runner.Run(new TestPattern(pattern)).GetAwaiter().GetResult();
 
             if (summary.Total == 0)
                 return ExitCode.FatalError;

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -19,11 +19,11 @@
             FatalError = -1
         }
 
-        public static int Main(Assembly assembly, string[] customArguments)
+        public static async Task<int> Main(Assembly assembly, string[] customArguments)
         {
             try
             {
-                return (int)RunAssembly(assembly, customArguments).GetAwaiter().GetResult();
+                return (int) await RunAssembly(assembly, customArguments);
             }
             catch (Exception exception)
             {

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -41,7 +41,7 @@
             var pattern = GetEnvironmentVariable("FIXIE:TESTS");
 
             var summary = pattern == null
-                ? runner.Run()
+                ? runner.Run().GetAwaiter().GetResult()
                 : runner.Run(new TestPattern(pattern));
 
             if (summary.Total == 0)

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -23,7 +23,7 @@
         {
             try
             {
-                return (int) await RunAssembly(assembly, customArguments);
+                return (int) await RunAssemblyAsync(assembly, customArguments);
             }
             catch (Exception exception)
             {
@@ -34,7 +34,7 @@
             }
         }
 
-        static async Task<ExitCode> RunAssembly(Assembly assembly, string[] customArguments)
+        static async Task<ExitCode> RunAssemblyAsync(Assembly assembly, string[] customArguments)
         {
             var listeners = DefaultExecutionListeners().ToArray();
             var runner = new Runner(assembly, customArguments, listeners);
@@ -42,8 +42,8 @@
             var pattern = GetEnvironmentVariable("FIXIE:TESTS");
 
             var summary = pattern == null
-                ? await runner.Run()
-                : await runner.Run(new TestPattern(pattern));
+                ? await runner.RunAsync()
+                : await runner.RunAsync(new TestPattern(pattern));
 
             if (summary.Total == 0)
                 return ExitCode.FatalError;

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Listeners;
     using static System.Console;
     using static System.Environment;
@@ -22,7 +23,7 @@
         {
             try
             {
-                return (int)RunAssembly(assembly, customArguments);
+                return (int)RunAssembly(assembly, customArguments).GetAwaiter().GetResult();
             }
             catch (Exception exception)
             {
@@ -33,7 +34,7 @@
             }
         }
 
-        static ExitCode RunAssembly(Assembly assembly, string[] customArguments)
+        static async Task<ExitCode> RunAssembly(Assembly assembly, string[] customArguments)
         {
             var listeners = DefaultExecutionListeners().ToArray();
             var runner = new Runner(assembly, customArguments, listeners);
@@ -41,8 +42,8 @@
             var pattern = GetEnvironmentVariable("FIXIE:TESTS");
 
             var summary = pattern == null
-                ? runner.Run().GetAwaiter().GetResult()
-                : runner.Run(new TestPattern(pattern)).GetAwaiter().GetResult();
+                ? await runner.Run()
+                : await runner.Run(new TestPattern(pattern));
 
             if (summary.Total == 0)
                 return ExitCode.FatalError;

--- a/src/Fixie/Internal/ExecutionRecorder.cs
+++ b/src/Fixie/Internal/ExecutionRecorder.cs
@@ -25,14 +25,14 @@
 
         public void Start(TestAssembly testAssembly)
         {
-            bus.Publish(new AssemblyStarted(testAssembly.Assembly));
+            bus.PublishAsync(new AssemblyStarted(testAssembly.Assembly)).GetAwaiter().GetResult();
             assemblyStopwatch.Restart();
             caseStopwatch.Restart();
         }
 
         public void Start(Case @case)
         {
-            bus.Publish(new CaseStarted(@case));
+            bus.PublishAsync(new CaseStarted(@case)).GetAwaiter().GetResult();
         }
 
         public void Skip(Case @case, string output = "")
@@ -41,7 +41,7 @@
 
             var message = new CaseSkipped(@case, duration, output);
             assemblySummary.Add(message);
-            bus.Publish(message);
+            bus.PublishAsync(message).GetAwaiter().GetResult();
 
             caseStopwatch.Restart();
         }
@@ -59,7 +59,7 @@
 
             var message = new CasePassed(@case, duration, output);
             assemblySummary.Add(message);
-            bus.Publish(message);
+            bus.PublishAsync(message).GetAwaiter().GetResult();
 
             caseStopwatch.Restart();
         }
@@ -70,7 +70,7 @@
 
             var message = new CaseFailed(@case, duration, output);
             assemblySummary.Add(message);
-            bus.Publish(message);
+            bus.PublishAsync(message).GetAwaiter().GetResult();
 
             caseStopwatch.Restart();
         }
@@ -86,7 +86,8 @@
         {
             var duration = assemblyStopwatch.Elapsed;
 
-            bus.Publish(new AssemblyCompleted(testAssembly.Assembly, assemblySummary, duration));
+            bus.PublishAsync(new AssemblyCompleted(testAssembly.Assembly, assemblySummary, duration))
+                .GetAwaiter().GetResult();
 
             caseStopwatch.Stop();
             assemblyStopwatch.Stop();

--- a/src/Fixie/Internal/Handler.cs
+++ b/src/Fixie/Internal/Handler.cs
@@ -9,6 +9,6 @@
 
     public interface AsyncHandler<in TMessage> : Listener where TMessage : Message
     {
-        Task Handle(TMessage message);
+        Task HandleAsync(TMessage message);
     }
 }

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -32,7 +32,7 @@
             {
                 var uri = GetEnvironmentVariable("APPVEYOR_API_URL");
                 if (uri != null)
-                    return new AppVeyorListener(uri, Post);
+                    return new AppVeyorListener(uri, PostAsync);
             }
 
             return null;
@@ -63,22 +63,22 @@
                 runName = $"{runName} ({framework})";
         }
 
-        public async Task Handle(CaseSkipped message)
+        public async Task HandleAsync(CaseSkipped message)
         {
-            await Post(new TestResult(runName, message, "Skipped")
+            await PostAsync(new TestResult(runName, message, "Skipped")
             {
                 ErrorMessage = message.Reason
             });
         }
 
-        public async Task Handle(CasePassed message)
+        public async Task HandleAsync(CasePassed message)
         {
-            await Post(new TestResult(runName, message, "Passed"));
+            await PostAsync(new TestResult(runName, message, "Passed"));
         }
 
-        public async Task Handle(CaseFailed message)
+        public async Task HandleAsync(CaseFailed message)
         {
-            await Post(new TestResult(runName, message, "Failed")
+            await PostAsync(new TestResult(runName, message, "Failed")
             {
                 ErrorMessage = message.Exception.Message,
                 ErrorStackTrace =
@@ -88,12 +88,12 @@
             });
         }
 
-        async Task Post(TestResult testResult)
+        async Task PostAsync(TestResult testResult)
         {
             await postAction(uri, testResult);
         }
 
-        static async Task Post(string uri, TestResult testResult)
+        static async Task PostAsync(string uri, TestResult testResult)
         {
             var content = Serialize(testResult);
             var response = await Client.PostAsync(uri, new StringContent(content, Encoding.UTF8, "application/json"));

--- a/src/Fixie/Internal/Listeners/AppVeyorListener.cs
+++ b/src/Fixie/Internal/Listeners/AppVeyorListener.cs
@@ -20,7 +20,7 @@
     {
         public delegate Task PostAction(string uri, TestResult testResult);
 
-        readonly PostAction postAction;
+        readonly PostAction postActionAsync;
         readonly string uri;
         string runName;
 
@@ -44,9 +44,9 @@
             Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
-        public AppVeyorListener(string uri, PostAction postAction)
+        public AppVeyorListener(string uri, PostAction postActionAsync)
         {
-            this.postAction = postAction;
+            this.postActionAsync = postActionAsync;
             this.uri = new Uri(new Uri(uri), "api/tests").ToString();
             runName = "Unknown";
         }
@@ -90,7 +90,7 @@
 
         async Task PostAsync(TestResult testResult)
         {
-            await postAction(uri, testResult);
+            await postActionAsync(uri, testResult);
         }
 
         static async Task PostAsync(string uri, TestResult testResult)

--- a/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
+++ b/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
@@ -43,8 +43,8 @@
 
             if (lines.Length >= 2)
             {
-                if (lines[^2].Contains(" Fixie.MethodInfoExtensions.Execute(MethodInfo method, Object instance, Object[] parameters)") &&
-                    lines[^1].Contains(" Fixie.Case.Run(Object instance)"))
+                if (lines[^2].Contains(" Fixie.MethodInfoExtensions.ExecuteAsync(MethodInfo method, Object instance, Object[] parameters)") &&
+                    lines[^1].Contains(" Fixie.Case.RunAsync(Object instance)"))
 
                     return string.Join(NewLine, lines[..^2]);
             }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -46,7 +46,7 @@
             return RunAsync(assembly.GetTypes(), selectedTests);
         }
 
-        public Task<ExecutionSummary> RunAsync(TestPattern testPattern)
+        public async Task<ExecutionSummary> RunAsync(TestPattern testPattern)
         {
             var matchingTests = ImmutableHashSet<string>.Empty;
             var discovery = new BehaviorDiscoverer(assembly, customArguments).GetDiscovery();
@@ -71,7 +71,7 @@
                 discovery.Dispose();
             }
 
-            return RunAsync(matchingTests);
+            return await RunAsync(matchingTests);
         }
 
         async Task<ExecutionSummary> RunAsync(IReadOnlyList<Type> candidateTypes, ImmutableHashSet<string> selectedTests)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Reflection;
+    using System.Threading.Tasks;
 
     class Runner
     {
@@ -80,7 +81,7 @@
 
             try
             {
-                return Run(candidateTypes, discovery, execution, selectedTests);
+                return Run(candidateTypes, discovery, execution, selectedTests).GetAwaiter().GetResult();
             }
             finally
             {
@@ -102,7 +103,7 @@
                 bus.Publish(new TestDiscovered(new Test(testMethod)));
         }
 
-        internal ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, Discovery discovery, Execution execution, ImmutableHashSet<string> selectedTests)
+        internal async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, Discovery discovery, Execution execution, ImmutableHashSet<string> selectedTests)
         {
             var recorder = new ExecutionRecorder(bus);
             var classDiscoverer = new ClassDiscoverer(discovery);
@@ -111,7 +112,7 @@
 
             var testAssembly = new TestAssembly(assembly, selectedTests, recorder, classes, methodDiscoverer, execution);
             recorder.Start(testAssembly);
-            testAssembly.Run().GetAwaiter().GetResult();
+            await testAssembly.Run();
             return recorder.Complete(testAssembly);
         }
     }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -36,17 +36,17 @@
             }
         }
 
-        public Task<ExecutionSummary> Run()
+        public Task<ExecutionSummary> RunAsync()
         {
-            return Run(assembly.GetTypes(), ImmutableHashSet<string>.Empty);
+            return RunAsync(assembly.GetTypes(), ImmutableHashSet<string>.Empty);
         }
 
-        public Task<ExecutionSummary> Run(ImmutableHashSet<string> selectedTests)
+        public Task<ExecutionSummary> RunAsync(ImmutableHashSet<string> selectedTests)
         {
-            return Run(assembly.GetTypes(), selectedTests);
+            return RunAsync(assembly.GetTypes(), selectedTests);
         }
 
-        public Task<ExecutionSummary> Run(TestPattern testPattern)
+        public Task<ExecutionSummary> RunAsync(TestPattern testPattern)
         {
             var matchingTests = ImmutableHashSet<string>.Empty;
             var discovery = new BehaviorDiscoverer(assembly, customArguments).GetDiscovery();
@@ -71,17 +71,17 @@
                 discovery.Dispose();
             }
 
-            return Run(matchingTests);
+            return RunAsync(matchingTests);
         }
 
-        async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, ImmutableHashSet<string> selectedTests)
+        async Task<ExecutionSummary> RunAsync(IReadOnlyList<Type> candidateTypes, ImmutableHashSet<string> selectedTests)
         {
             new BehaviorDiscoverer(assembly, customArguments)
                 .GetBehaviors(out var discovery, out var execution);
 
             try
             {
-                return await Run(candidateTypes, discovery, execution, selectedTests);
+                return await RunAsync(candidateTypes, discovery, execution, selectedTests);
             }
             finally
             {
@@ -103,7 +103,7 @@
                 bus.Publish(new TestDiscovered(new Test(testMethod)));
         }
 
-        internal async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, Discovery discovery, Execution execution, ImmutableHashSet<string> selectedTests)
+        internal async Task<ExecutionSummary> RunAsync(IReadOnlyList<Type> candidateTypes, Discovery discovery, Execution execution, ImmutableHashSet<string> selectedTests)
         {
             var recorder = new ExecutionRecorder(bus);
             var classDiscoverer = new ClassDiscoverer(discovery);
@@ -112,7 +112,7 @@
 
             var testAssembly = new TestAssembly(assembly, selectedTests, recorder, classes, methodDiscoverer, execution);
             recorder.Start(testAssembly);
-            await testAssembly.Run();
+            await testAssembly.RunAsync();
             return recorder.Complete(testAssembly);
         }
     }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -111,7 +111,7 @@
 
             var testAssembly = new TestAssembly(assembly, selectedTests, recorder, classes, methodDiscoverer, execution);
             recorder.Start(testAssembly);
-            testAssembly.Run();
+            testAssembly.Run().GetAwaiter().GetResult();
             return recorder.Complete(testAssembly);
         }
     }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -22,13 +22,13 @@
             bus = new Bus(listeners);
         }
 
-        public void Discover()
+        public async Task DiscoverAsync()
         {
             var discovery = new BehaviorDiscoverer(assembly, customArguments).GetDiscovery();
 
             try
             {
-                Discover(assembly.GetTypes(), discovery);
+                await DiscoverAsync(assembly.GetTypes(), discovery);
             }
             finally
             {
@@ -92,7 +92,7 @@
             }
         }
 
-        internal void Discover(IReadOnlyList<Type> candidateTypes, Discovery discovery)
+        internal async Task DiscoverAsync(IReadOnlyList<Type> candidateTypes, Discovery discovery)
         {
             var classDiscoverer = new ClassDiscoverer(discovery);
             var classes = classDiscoverer.TestClasses(candidateTypes);
@@ -100,8 +100,7 @@
             var methodDiscoverer = new MethodDiscoverer(discovery);
             foreach (var testClass in classes)
             foreach (var testMethod in methodDiscoverer.TestMethods(testClass))
-                bus.PublishAsync(new TestDiscovered(new Test(testMethod)))
-                    .GetAwaiter().GetResult();
+                await bus.PublishAsync(new TestDiscovered(new Test(testMethod)));
         }
 
         internal async Task<ExecutionSummary> RunAsync(IReadOnlyList<Type> candidateTypes, Discovery discovery, Execution execution, ImmutableHashSet<string> selectedTests)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -111,9 +111,9 @@
             var methodDiscoverer = new MethodDiscoverer(discovery);
 
             var testAssembly = new TestAssembly(assembly, selectedTests, recorder, classes, methodDiscoverer, execution);
-            recorder.Start(testAssembly);
+            await recorder.StartAsync(testAssembly);
             await testAssembly.RunAsync();
-            return recorder.Complete(testAssembly);
+            return await recorder.CompleteAsync(testAssembly);
         }
     }
 }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -46,7 +46,7 @@
             return Run(assembly.GetTypes(), selectedTests);
         }
 
-        public ExecutionSummary Run(TestPattern testPattern)
+        public Task<ExecutionSummary> Run(TestPattern testPattern)
         {
             var matchingTests = ImmutableHashSet<string>.Empty;
             var discovery = new BehaviorDiscoverer(assembly, customArguments).GetDiscovery();
@@ -71,7 +71,7 @@
                 discovery.Dispose();
             }
 
-            return Run(matchingTests).GetAwaiter().GetResult();
+            return Run(matchingTests);
         }
 
         async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, ImmutableHashSet<string> selectedTests)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -36,9 +36,9 @@
             }
         }
 
-        public ExecutionSummary Run()
+        public Task<ExecutionSummary> Run()
         {
-            return Run(assembly.GetTypes(), ImmutableHashSet<string>.Empty).GetAwaiter().GetResult();
+            return Run(assembly.GetTypes(), ImmutableHashSet<string>.Empty);
         }
 
         public Task<ExecutionSummary> Run(ImmutableHashSet<string> selectedTests)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -38,12 +38,12 @@
 
         public ExecutionSummary Run()
         {
-            return Run(assembly.GetTypes(), ImmutableHashSet<string>.Empty);
+            return Run(assembly.GetTypes(), ImmutableHashSet<string>.Empty).GetAwaiter().GetResult();
         }
 
         public ExecutionSummary Run(ImmutableHashSet<string> selectedTests)
         {
-            return Run(assembly.GetTypes(), selectedTests);
+            return Run(assembly.GetTypes(), selectedTests).GetAwaiter().GetResult();
         }
 
         public ExecutionSummary Run(TestPattern testPattern)
@@ -74,14 +74,14 @@
             return Run(matchingTests);
         }
 
-        ExecutionSummary Run(IReadOnlyList<Type> candidateTypes, ImmutableHashSet<string> selectedTests)
+        async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, ImmutableHashSet<string> selectedTests)
         {
             new BehaviorDiscoverer(assembly, customArguments)
                 .GetBehaviors(out var discovery, out var execution);
 
             try
             {
-                return Run(candidateTypes, discovery, execution, selectedTests).GetAwaiter().GetResult();
+                return await Run(candidateTypes, discovery, execution, selectedTests);
             }
             finally
             {

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -100,7 +100,8 @@
             var methodDiscoverer = new MethodDiscoverer(discovery);
             foreach (var testClass in classes)
             foreach (var testMethod in methodDiscoverer.TestMethods(testClass))
-                bus.Publish(new TestDiscovered(new Test(testMethod)));
+                bus.PublishAsync(new TestDiscovered(new Test(testMethod)))
+                    .GetAwaiter().GetResult();
         }
 
         internal async Task<ExecutionSummary> RunAsync(IReadOnlyList<Type> candidateTypes, Discovery discovery, Execution execution, ImmutableHashSet<string> selectedTests)

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -41,9 +41,9 @@
             return Run(assembly.GetTypes(), ImmutableHashSet<string>.Empty).GetAwaiter().GetResult();
         }
 
-        public ExecutionSummary Run(ImmutableHashSet<string> selectedTests)
+        public Task<ExecutionSummary> Run(ImmutableHashSet<string> selectedTests)
         {
-            return Run(assembly.GetTypes(), selectedTests).GetAwaiter().GetResult();
+            return Run(assembly.GetTypes(), selectedTests);
         }
 
         public ExecutionSummary Run(TestPattern testPattern)
@@ -71,7 +71,7 @@
                 discovery.Dispose();
             }
 
-            return Run(matchingTests);
+            return Run(matchingTests).GetAwaiter().GetResult();
         }
 
         async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, ImmutableHashSet<string> selectedTests)

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -20,7 +20,7 @@
         /// For async Task methods, returns null after awaiting the Task.
         /// For async Task<![CDATA[<T>]]> methods, returns the Result T after awaiting the Task.
         /// </returns>
-        public static object? Execute(this MethodInfo method, object? instance, params object?[] parameters)
+        public static async Task<object?> Execute(this MethodInfo method, object? instance, params object?[] parameters)
         {
             if (method.IsVoid() && method.HasAsyncKeyword())
                 throw new NotSupportedException(
@@ -50,7 +50,7 @@
             if (task.Status == TaskStatus.Created)
                 throw new InvalidOperationException("The test returned a non-started task, which cannot be awaited. Consider using Task.Run or Task.Factory.StartNew.");
 
-            task.GetAwaiter().GetResult();
+            await task;
 
             if (method.ReturnType.IsGenericType)
             {

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -20,7 +20,7 @@
         /// For async Task methods, returns null after awaiting the Task.
         /// For async Task<![CDATA[<T>]]> methods, returns the Result T after awaiting the Task.
         /// </returns>
-        public static async Task<object?> Execute(this MethodInfo method, object? instance, params object?[] parameters)
+        public static async Task<object?> ExecuteAsync(this MethodInfo method, object? instance, params object?[] parameters)
         {
             if (method.IsVoid() && method.HasAsyncKeyword())
                 throw new NotSupportedException(

--- a/src/Fixie/TestAssembly.cs
+++ b/src/Fixie/TestAssembly.cs
@@ -5,6 +5,7 @@
     using System.Collections.Immutable;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Internal;
 
     public class TestAssembly
@@ -35,7 +36,7 @@
         /// </summary>
         public ImmutableHashSet<string> SelectedTests { get; }
 
-        internal void Run()
+        internal async Task Run()
         {
             foreach (var @class in classes)
             {
@@ -56,7 +57,7 @@
 
                     try
                     {
-                        execution.Execute(testClass).GetAwaiter().GetResult();
+                        await execution.Execute(testClass);
                     }
                     catch (Exception exception)
                     {

--- a/src/Fixie/TestAssembly.cs
+++ b/src/Fixie/TestAssembly.cs
@@ -56,7 +56,7 @@
 
                     try
                     {
-                        execution.Execute(testClass);
+                        execution.Execute(testClass).GetAwaiter().GetResult();
                     }
                     catch (Exception exception)
                     {

--- a/src/Fixie/TestAssembly.cs
+++ b/src/Fixie/TestAssembly.cs
@@ -69,10 +69,10 @@
                         var testNeverRan = !testMethod.RecordedResult;
 
                         if (classLifecycleFailure != null)
-                            testMethod.Fail(classLifecycleFailure);
+                            await testMethod.FailAsync(classLifecycleFailure);
                         
                         if (testNeverRan)
-                            testMethod.Skip("This test did not run.");
+                            await testMethod.SkipAsync("This test did not run.");
                     }
                 }
             }

--- a/src/Fixie/TestAssembly.cs
+++ b/src/Fixie/TestAssembly.cs
@@ -36,7 +36,7 @@
         /// </summary>
         public ImmutableHashSet<string> SelectedTests { get; }
 
-        internal async Task Run()
+        internal async Task RunAsync()
         {
             foreach (var @class in classes)
             {
@@ -57,7 +57,7 @@
 
                     try
                     {
-                        await execution.Execute(testClass);
+                        await execution.ExecuteAsync(testClass);
                     }
                     catch (Exception exception)
                     {

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -27,7 +27,7 @@
 
         internal bool RecordedResult { get; private set; }
 
-        void RunCore(object?[] parameters, object? instance, Action<Case>? inspectCase)
+        async Task RunCore(object?[] parameters, object? instance, Action<Case>? inspectCase)
         {
             var @case = new Case(Method, parameters);
 
@@ -41,7 +41,7 @@
             {
                 if (instance != null)
                 {
-                    TryRunCase(@case, instance).GetAwaiter().GetResult();
+                    await TryRunCase(@case, instance);
                     TryInspectCase(@case, inspectCase, out caseInspectionFailure);
                 }
                 else
@@ -50,7 +50,7 @@
                     {
                         var automaticInstance = @case.Method.IsStatic ? null : Construct(@case.Method.ReflectedType!);
 
-                        TryRunCase(@case, automaticInstance).GetAwaiter().GetResult();
+                        await TryRunCase(@case, automaticInstance);
                         TryInspectCase(@case, inspectCase, out caseInspectionFailure);
                         TryDispose(automaticInstance, out disposalFailure);
                     }
@@ -135,12 +135,12 @@
 
         public void Run(Action<Case>? inspectCase = null)
         {
-            RunCore(EmptyParameters, instance: null, inspectCase);
+            RunCore(EmptyParameters, instance: null, inspectCase).GetAwaiter().GetResult();
         }
 
         public void Run(object?[] parameters, Action<Case>? inspectCase = null)
         {
-            RunCore(parameters, instance: null, inspectCase);
+            RunCore(parameters, instance: null, inspectCase).GetAwaiter().GetResult();
         }
 
         public void RunCases(ParameterSource parameterSource, Action<Case>? inspectCase = null)
@@ -148,7 +148,7 @@
             try
             {
                 foreach (var parameters in GetCases(parameterSource))
-                    RunCore(parameters, instance: null, inspectCase);
+                    RunCore(parameters, instance: null, inspectCase).GetAwaiter().GetResult();
             }
             catch (Exception exception)
             {
@@ -158,12 +158,12 @@
 
         public void Run(object? instance, Action<Case>? inspectCase = null)
         {
-            RunCore(EmptyParameters, instance, inspectCase);
+            RunCore(EmptyParameters, instance, inspectCase).GetAwaiter().GetResult();
         }
 
         public void Run(object?[] parameters, object? instance, Action<Case>? inspectCase = null)
         {
-            RunCore(parameters, instance, inspectCase);
+            RunCore(parameters, instance, inspectCase).GetAwaiter().GetResult();
         }
 
         public void RunCases(ParameterSource parameterSource, object? instance, Action<Case>? inspectCase = null)
@@ -171,7 +171,7 @@
             try
             {
                 foreach (var parameters in GetCases(parameterSource))
-                    RunCore(parameters, instance, inspectCase);
+                    RunCore(parameters, instance, inspectCase).GetAwaiter().GetResult();
             }
             catch (Exception exception)
             {

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -27,7 +27,7 @@
 
         internal bool RecordedResult { get; private set; }
 
-        async Task RunCore(object?[] parameters, object? instance, Action<Case>? inspectCase)
+        async Task RunCoreAsync(object?[] parameters, object? instance, Action<Case>? inspectCase)
         {
             var @case = new Case(Method, parameters);
 
@@ -41,7 +41,7 @@
             {
                 if (instance != null)
                 {
-                    await TryRunCase(@case, instance);
+                    await TryRunCaseAsync(@case, instance);
                     TryInspectCase(@case, inspectCase, out caseInspectionFailure);
                 }
                 else
@@ -50,7 +50,7 @@
                     {
                         var automaticInstance = @case.Method.IsStatic ? null : Construct(@case.Method.ReflectedType!);
 
-                        await TryRunCase(@case, automaticInstance);
+                        await TryRunCaseAsync(@case, automaticInstance);
                         TryInspectCase(@case, inspectCase, out caseInspectionFailure);
                         TryDispose(automaticInstance, out disposalFailure);
                     }
@@ -100,9 +100,9 @@
             RecordedResult = true;
         }
 
-        static Task TryRunCase(Case @case, object? instance)
+        static Task TryRunCaseAsync(Case @case, object? instance)
         {
-            return @case.Run(instance);
+            return @case.RunAsync(instance);
         }
 
         static void TryInspectCase(Case @case, Action<Case>? inspectCase, out Exception? caseInspectionFailure)
@@ -133,22 +133,22 @@
             }
         }
 
-        public Task Run(Action<Case>? inspectCase = null)
+        public Task RunAsync(Action<Case>? inspectCase = null)
         {
-            return RunCore(EmptyParameters, instance: null, inspectCase);
+            return RunCoreAsync(EmptyParameters, instance: null, inspectCase);
         }
 
-        public Task Run(object?[] parameters, Action<Case>? inspectCase = null)
+        public Task RunAsync(object?[] parameters, Action<Case>? inspectCase = null)
         {
-            return RunCore(parameters, instance: null, inspectCase);
+            return RunCoreAsync(parameters, instance: null, inspectCase);
         }
 
-        public async Task RunCases(ParameterSource parameterSource, Action<Case>? inspectCase = null)
+        public async Task RunCasesAsync(ParameterSource parameterSource, Action<Case>? inspectCase = null)
         {
             try
             {
                 foreach (var parameters in GetCases(parameterSource))
-                    await RunCore(parameters, instance: null, inspectCase);
+                    await RunCoreAsync(parameters, instance: null, inspectCase);
             }
             catch (Exception exception)
             {
@@ -156,22 +156,22 @@
             }
         }
 
-        public Task Run(object? instance, Action<Case>? inspectCase = null)
+        public Task RunAsync(object? instance, Action<Case>? inspectCase = null)
         {
-            return RunCore(EmptyParameters, instance, inspectCase);
+            return RunCoreAsync(EmptyParameters, instance, inspectCase);
         }
 
-        public Task Run(object?[] parameters, object? instance, Action<Case>? inspectCase = null)
+        public Task RunAsync(object?[] parameters, object? instance, Action<Case>? inspectCase = null)
         {
-            return RunCore(parameters, instance, inspectCase);
+            return RunCoreAsync(parameters, instance, inspectCase);
         }
 
-        public async Task RunCases(ParameterSource parameterSource, object? instance, Action<Case>? inspectCase = null)
+        public async Task RunCasesAsync(ParameterSource parameterSource, object? instance, Action<Case>? inspectCase = null)
         {
             try
             {
                 foreach (var parameters in GetCases(parameterSource))
-                    await RunCore(parameters, instance, inspectCase);
+                    await RunCoreAsync(parameters, instance, inspectCase);
             }
             catch (Exception exception)
             {

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -31,7 +31,7 @@
         {
             var @case = new Case(Method, parameters);
 
-            recorder.Start(@case);
+            await recorder.StartAsync(@case);
 
             Exception? caseInspectionFailure = null;
             Exception? disposalFailure = null;
@@ -70,31 +70,31 @@
             bool accounted = false;
             if (@case.State == CaseState.Skipped)
             {
-                recorder.Skip(@case, output);
+                await recorder.SkipAsync(@case, output);
                 accounted = true;
             }
 
             if (@case.State == CaseState.Failed)
             {
-                recorder.Fail(@case, output);
+                await recorder.FailAsync(@case, output);
                 accounted = true;
             }
 
             if (caseInspectionFailure != null)
             {
-                recorder.Fail(new Case(@case, caseInspectionFailure), output);
+                await recorder.FailAsync(new Case(@case, caseInspectionFailure), output);
                 accounted = true;
             }
 
             if (disposalFailure != null)
             {
-                recorder.Fail(new Case(@case, disposalFailure), output);
+                await recorder.FailAsync(new Case(@case, disposalFailure), output);
                 accounted = true;
             }
             
             if (@case.State == CaseState.Passed && !accounted)
             {
-                recorder.Pass(@case, output);
+                await recorder.PassAsync(@case, output);
             }
 
             RecordedResult = true;
@@ -152,7 +152,7 @@
             }
             catch (Exception exception)
             {
-                Fail(exception);
+                await FailAsync(exception);
             }
         }
 
@@ -175,7 +175,7 @@
             }
             catch (Exception exception)
             {
-                Fail(exception);
+                await FailAsync(exception);
             }
         }
 
@@ -189,18 +189,18 @@
         /// <summary>
         /// Emit a skip result for this test, with the given reason.
         /// </summary>
-        public void Skip(string? reason = null)
+        public async Task SkipAsync(string? reason = null)
         {
-            recorder.Skip(this, reason);
+            await recorder.SkipAsync(this, reason);
             RecordedResult = true;
         }
 
         /// <summary>
         /// Emit a fail result for this test, with the given reason.
         /// </summary>
-        public void Fail(Exception reason)
+        public async Task FailAsync(Exception reason)
         {
-            recorder.Fail(this, reason);
+            await recorder.FailAsync(this, reason);
             RecordedResult = true;
         }
 

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Internal;
 
     public class TestMethod
@@ -40,7 +41,7 @@
             {
                 if (instance != null)
                 {
-                    TryRunCase(@case, instance);
+                    TryRunCase(@case, instance).GetAwaiter().GetResult();
                     TryInspectCase(@case, inspectCase, out caseInspectionFailure);
                 }
                 else
@@ -49,7 +50,7 @@
                     {
                         var automaticInstance = @case.Method.IsStatic ? null : Construct(@case.Method.ReflectedType!);
 
-                        TryRunCase(@case, automaticInstance);
+                        TryRunCase(@case, automaticInstance).GetAwaiter().GetResult();
                         TryInspectCase(@case, inspectCase, out caseInspectionFailure);
                         TryDispose(automaticInstance, out disposalFailure);
                     }
@@ -99,10 +100,9 @@
             RecordedResult = true;
         }
 
-        static void TryRunCase(Case @case, object? instance)
+        static Task TryRunCase(Case @case, object? instance)
         {
-            @case.Run(instance)
-                .GetAwaiter().GetResult();
+            return @case.Run(instance);
         }
 
         static void TryInspectCase(Case @case, Action<Case>? inspectCase, out Exception? caseInspectionFailure)

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -133,22 +133,22 @@
             }
         }
 
-        public void Run(Action<Case>? inspectCase = null)
+        public Task Run(Action<Case>? inspectCase = null)
         {
-            RunCore(EmptyParameters, instance: null, inspectCase).GetAwaiter().GetResult();
+            return RunCore(EmptyParameters, instance: null, inspectCase);
         }
 
-        public void Run(object?[] parameters, Action<Case>? inspectCase = null)
+        public Task Run(object?[] parameters, Action<Case>? inspectCase = null)
         {
-            RunCore(parameters, instance: null, inspectCase).GetAwaiter().GetResult();
+            return RunCore(parameters, instance: null, inspectCase);
         }
 
-        public void RunCases(ParameterSource parameterSource, Action<Case>? inspectCase = null)
+        public async Task RunCases(ParameterSource parameterSource, Action<Case>? inspectCase = null)
         {
             try
             {
                 foreach (var parameters in GetCases(parameterSource))
-                    RunCore(parameters, instance: null, inspectCase).GetAwaiter().GetResult();
+                    await RunCore(parameters, instance: null, inspectCase);
             }
             catch (Exception exception)
             {
@@ -156,22 +156,22 @@
             }
         }
 
-        public void Run(object? instance, Action<Case>? inspectCase = null)
+        public Task Run(object? instance, Action<Case>? inspectCase = null)
         {
-            RunCore(EmptyParameters, instance, inspectCase).GetAwaiter().GetResult();
+            return RunCore(EmptyParameters, instance, inspectCase);
         }
 
-        public void Run(object?[] parameters, object? instance, Action<Case>? inspectCase = null)
+        public Task Run(object?[] parameters, object? instance, Action<Case>? inspectCase = null)
         {
-            RunCore(parameters, instance, inspectCase).GetAwaiter().GetResult();
+            return RunCore(parameters, instance, inspectCase);
         }
 
-        public void RunCases(ParameterSource parameterSource, object? instance, Action<Case>? inspectCase = null)
+        public async Task RunCases(ParameterSource parameterSource, object? instance, Action<Case>? inspectCase = null)
         {
             try
             {
                 foreach (var parameters in GetCases(parameterSource))
-                    RunCore(parameters, instance, inspectCase).GetAwaiter().GetResult();
+                    await RunCore(parameters, instance, inspectCase);
             }
             catch (Exception exception)
             {

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -101,7 +101,8 @@
 
         static void TryRunCase(Case @case, object? instance)
         {
-            @case.Run(instance);
+            @case.Run(instance)
+                .GetAwaiter().GetResult();
         }
 
         static void TryInspectCase(Case @case, Action<Case>? inspectCase, out Exception? caseInspectionFailure)


### PR DESCRIPTION
Previous versions rely on `GetAwaiter().GetResult()` deep within Fixie's core loop: when a test method is invoked, it either returns a `Task` or not, and if it returns a task we waited on its result immediately. The benefit was that a test method itself could be written in async style with no false "Pass" results.

We also performed a similar `GetAwaiter().GetResult()` upon each asynchronous `Listener` event handler, supporting cases such as when the Azure DevOps listener needs to issue async API calls to their reporting endpoints.

This "sync over async" approach had consequences throughout the user-facing API. Users who needed to perform async calls in their customized test execution logic were stuck having to use GetAwaiter().GetResult() themselves:

```cs
    public class TestingConvention : Execution
    {
        public void Execute(TestClass testClass)
        {
            MyCustomSetupAsync().GetAwaiter().GetResult();
            foreach (var test in testClass.Tests)
                test.Run();
        }
    }
```

This PR applies the `await` keyword to the invocation of asynchronous test methods, and then necessarily applies async/await to the caller, and the caller of that, and the caller of that, all the way back to an `async Main`. Custom behaviors are now fully async:

```cs
    public class TestingConvention : Execution
    {
        public async Task ExecuteAsync(TestClass testClass)
        {
            await MyCustomSetupAsync();
            foreach (var test in testClass.Tests)
                await test.RunAsync();
        }
    }
```

This also sets us up for improving the ability for custom behaviors to have assembly-level setup/teardown which are themselves capable of doing async calls, but that will be added in a separate PR.

Note that in the Test Explorer "Test Adapter", we still call `GetAwaiter().GetResult()` explicitly. These void methods are entry points in our code invoked by VsTest, and it's unclear whether we can do any better here.