### PR TITLE
Support IAsyncDisposable on conventions and test classes.

### DIFF
--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -75,18 +75,23 @@
             DiscoveredTestMethods<DisposableSample>(discovery)
                 .ShouldBe(
                     "Dispose(disposing)",
+                    "DisposeAsync(disposing)",
                     "NotNamedDispose()");
 
             DiscoveredTestMethods<NonDisposableSample>(discovery)
                 .ShouldBe(
                     "Dispose()",
                     "Dispose(disposing)",
+                    "DisposeAsync()",
+                    "DisposeAsync(disposing)",
                     "NotNamedDispose()");
 
             DiscoveredTestMethods<NonDisposableByReturnTypeSample>(discovery)
                 .ShouldBe(
                     "Dispose()",
                     "Dispose(disposing)",
+                    "DisposeAsync()",
+                    "DisposeAsync(disposing)",
                     "NotNamedDispose()");
         }
 
@@ -180,7 +185,7 @@
             public void Dispose() { }
         }
 
-        class AsyncSample
+        class AsyncSample : IAsyncDisposable
         {
             public static async Task<int> PublicStaticWithArgsWithReturn(int x) { return await Zero(); }
             public static async Task<int> PublicStaticNoArgsWithReturn() { return await Zero(); }
@@ -206,10 +211,14 @@
             {
                 return Task.Run(() => 0);
             }
+
+            public ValueTask DisposeAsync() => default;
         }
 
-        class DisposableSample : IDisposable
+        class DisposableSample : IAsyncDisposable, IDisposable
         {
+            public ValueTask DisposeAsync(bool disposing) => default;
+            public ValueTask DisposeAsync() => default;
             public void Dispose(bool disposing) { }
             public void Dispose() { }
             public void NotNamedDispose() { }
@@ -217,6 +226,8 @@
 
         class NonDisposableSample
         {
+            public ValueTask DisposeAsync(bool disposing) => default;
+            public ValueTask DisposeAsync() => default;
             public void Dispose(bool disposing) { }
             public void Dispose() { }
             public void NotNamedDispose() { }
@@ -224,6 +235,8 @@
 
         class NonDisposableByReturnTypeSample
         {
+            public int DisposeAsync(bool disposing) => 0;
+            public int DisposeAsync() => 0;
             public void Dispose(bool disposing) { }
             public int Dispose() => 0;
             public void NotNamedDispose() { }

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -68,7 +68,7 @@
                     "PublicStaticWithArgsWithReturn(x)");
         }
 
-        public void ShouldNotConsiderIDisposableDisposeMethod()
+        public void ShouldNotConsiderIDisposableOrIAsyncDisposableMethods()
         {
             var discovery = new MaximumDiscovery();
 

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -7,12 +7,6 @@
 
     public class ReflectionExtensionsTests
     {
-        public void CanDetectVoidReturnType()
-        {
-            Method("ReturnsVoid").IsVoid().ShouldBe(true);
-            Method("ReturnsInt").IsVoid().ShouldBe(false);
-        }
-
         public void CanDetectStaticTypes()
         {
             typeof(StaticClass).IsStatic().ShouldBe(true);

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -125,7 +125,7 @@ namespace Fixie.Tests
                     if (!ShouldSkip(test))
                         await test.RunCasesAsync(Utility.UsingInputAttributes, instance, @case => CaseInspection());
 
-                instance.Dispose();
+                await instance.DisposeIfApplicableAsync();
             }
         }
 

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -6,8 +6,9 @@ namespace Fixie.Tests
 
     public class TestClassConstructionTests : InstrumentedExecutionTests
     {
-        class SampleTestClass : IDisposable
+        class SampleTestClass : IAsyncDisposable, IDisposable
         {
+            bool asyncDisposed;
             bool disposed;
 
             public SampleTestClass()
@@ -42,10 +43,22 @@ namespace Fixie.Tests
 
                 WhereAmI();
             }
+
+            public ValueTask DisposeAsync()
+            {
+                if (asyncDisposed)
+                    throw new ShouldBeUnreachableException();
+                asyncDisposed = true;
+            
+                WhereAmI();
+            
+                return default;
+            }
         }
 
-        class AllSkippedTestClass : IDisposable
+        class AllSkippedTestClass : IAsyncDisposable, IDisposable
         {
+            bool asyncDisposed;
             bool disposed;
 
             public AllSkippedTestClass()
@@ -78,6 +91,17 @@ namespace Fixie.Tests
                 disposed = true;
 
                 WhereAmI();
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                if (asyncDisposed)
+                    throw new ShouldBeUnreachableException();
+                asyncDisposed = true;
+            
+                WhereAmI();
+            
+                return default;
             }
         }
 
@@ -146,9 +170,9 @@ namespace Fixie.Tests
                 "SampleTestClass.Skip failed: 'Skip' reached a line of code thought to be unreachable.");
 
             output.ShouldHaveLifecycle(
-                ".ctor", "Fail", "Dispose",
-                ".ctor", "Dispose",
-                ".ctor", "Skip", "Dispose");
+                ".ctor", "Fail", "DisposeAsync", "Dispose",
+                ".ctor", "DisposeAsync", "Dispose",
+                ".ctor", "Skip", "DisposeAsync", "Dispose");
         }
 
         public async Task ShouldAllowConstructingPerCase()
@@ -162,9 +186,9 @@ namespace Fixie.Tests
                 "SampleTestClass.Skip skipped: This test did not run.");
 
             output.ShouldHaveLifecycle(
-                ".ctor", "Fail", "CaseInspection", "Dispose",
-                ".ctor", "Pass(1)", "CaseInspection", "Dispose",
-                ".ctor", "Pass(2)", "CaseInspection", "Dispose");
+                ".ctor", "Fail", "CaseInspection", "DisposeAsync", "Dispose",
+                ".ctor", "Pass(1)", "CaseInspection", "DisposeAsync","Dispose",
+                ".ctor", "Pass(2)", "CaseInspection", "DisposeAsync","Dispose");
         }
 
         public async Task ShouldFailCaseInAbsenseOfPrimaryCaseResultAndProceedWithCaseInspectionWhenConstructingPerCaseAndConstructorThrows()
@@ -199,9 +223,28 @@ namespace Fixie.Tests
                 "SampleTestClass.Skip skipped: This test did not run.");
 
             output.ShouldHaveLifecycle(
-                ".ctor", "Fail", "CaseInspection", "Dispose",
-                ".ctor", "Pass(1)", "CaseInspection", "Dispose",
-                ".ctor", "Pass(2)", "CaseInspection", "Dispose");
+                ".ctor", "Fail", "CaseInspection", "DisposeAsync", "Dispose",
+                ".ctor", "Pass(1)", "CaseInspection", "DisposeAsync", "Dispose",
+                ".ctor", "Pass(2)", "CaseInspection", "DisposeAsync", "Dispose");
+        }
+
+        public async Task ShouldFailCaseWithoutHidingPrimaryFailuresAndProceedWithCaseInspectionAndShortCircuitSynchronousDisposeWhenConstructingPerCaseAndDisposeAsyncThrows()
+        {
+            FailDuring("DisposeAsync");
+
+            var output = await RunAsync<SampleTestClass, CreateInstancePerCase>();
+
+            output.ShouldHaveResults(
+                "SampleTestClass.Fail failed: 'Fail' failed!",
+                "SampleTestClass.Fail failed: 'DisposeAsync' failed!",
+                "SampleTestClass.Pass(1) failed: 'DisposeAsync' failed!",
+                "SampleTestClass.Pass(2) failed: 'DisposeAsync' failed!",
+                "SampleTestClass.Skip skipped: This test did not run.");
+
+            output.ShouldHaveLifecycle(
+                ".ctor", "Fail", "CaseInspection", "DisposeAsync",
+                ".ctor", "Pass(1)", "CaseInspection", "DisposeAsync",
+                ".ctor", "Pass(2)", "CaseInspection", "DisposeAsync");
         }
 
         public async Task ShouldAllowConstructingPerClass()
@@ -219,6 +262,7 @@ namespace Fixie.Tests
                 "Fail", "CaseInspection",
                 "Pass(1)", "CaseInspection",
                 "Pass(2)", "CaseInspection",
+                "DisposeAsync",
                 "Dispose");
         }
 
@@ -260,7 +304,31 @@ namespace Fixie.Tests
                 "Fail", "CaseInspection",
                 "Pass(1)", "CaseInspection",
                 "Pass(2)", "CaseInspection",
+                "DisposeAsync",
                 "Dispose");
+        }
+
+        public async Task ShouldFailAllTestsWithoutHidingPrimaryCaseResultsAndShortCircuitSynchronousDisposeWhenConstructingPerClassAndDisposeAsyncThrows()
+        {
+            FailDuring("DisposeAsync");
+
+            var output = await RunAsync<SampleTestClass, CreateInstancePerClass>();
+
+            output.ShouldHaveResults(
+                "SampleTestClass.Fail failed: 'Fail' failed!",
+                "SampleTestClass.Pass(1) passed",
+                "SampleTestClass.Pass(2) passed",
+                "SampleTestClass.Fail failed: 'DisposeAsync' failed!",
+                "SampleTestClass.Pass failed: 'DisposeAsync' failed!",
+                "SampleTestClass.Skip failed: 'DisposeAsync' failed!",
+                "SampleTestClass.Skip skipped: This test did not run.");
+
+            output.ShouldHaveLifecycle(
+                ".ctor",
+                "Fail", "CaseInspection",
+                "Pass(1)", "CaseInspection",
+                "Pass(2)", "CaseInspection",
+                "DisposeAsync");
         }
 
         public async Task ShouldBypassConstructionWhenConstructingPerCaseAndAllCasesAreSkipped()
@@ -284,7 +352,7 @@ namespace Fixie.Tests
                 "AllSkippedTestClass.SkipB skipped: This test did not run.",
                 "AllSkippedTestClass.SkipC skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(".ctor", "Dispose");
+            output.ShouldHaveLifecycle(".ctor", "DisposeAsync", "Dispose");
         }
 
         public async Task ShouldBypassConstructionAttemptsWhenTestMethodsAreStatic()

--- a/src/Fixie/Internal/MethodDiscoverer.cs
+++ b/src/Fixie/Internal/MethodDiscoverer.cs
@@ -46,6 +46,6 @@
             => type.GetInterfaces().Contains(typeof(IDisposable));
 
         static bool HasDisposeSignature(MethodInfo method)
-            => method.Name == "Dispose" && method.IsVoid() && method.GetParameters().Length == 0;
+            => method.Name == "Dispose" && method.ReturnType == typeof(void) && method.GetParameters().Length == 0;
     }
 }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -32,7 +32,7 @@
             }
             finally
             {
-                discovery.Dispose();
+                await discovery.DisposeIfApplicableAsync();
             }
         }
 
@@ -68,7 +68,7 @@
             }
             finally
             {
-                discovery.Dispose();
+                await discovery.DisposeIfApplicableAsync();
             }
 
             return await RunAsync(matchingTests);
@@ -86,9 +86,9 @@
             finally
             {
                 if (execution != discovery)
-                    execution.Dispose();
+                    await execution.DisposeIfApplicableAsync();
 
-                discovery.Dispose();
+                await discovery.DisposeIfApplicableAsync();
             }
         }
 

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -22,7 +22,7 @@
         /// </returns>
         public static async Task<object?> ExecuteAsync(this MethodInfo method, object? instance, params object?[] parameters)
         {
-            if (method.IsVoid() && method.HasAsyncKeyword())
+            if (method.ReturnType == typeof(void) && method.HasAsyncKeyword())
                 throw new NotSupportedException(
                     "Async void methods are not supported. Declare async methods with a " +
                     "return type of Task to ensure the task actually runs to completion.");

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -29,7 +29,7 @@
             return Try(() => member.GetCustomAttribute<TAttribute>(true), out matchingAttribute);
         }
 
-        public static async Task DisposeIfApplicableAsync(this object? o)
+        internal static async Task DisposeIfApplicableAsync(this object? o)
         {
             if (o is IAsyncDisposable asyncDisposable)
                 await asyncDisposable.DisposeAsync();

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -4,6 +4,7 @@
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using static Internal.Maybe;
 
     public static class ReflectionExtensions
@@ -28,8 +29,11 @@
             return Try(() => member.GetCustomAttribute<TAttribute>(true), out matchingAttribute);
         }
 
-        public static void Dispose(this object? o)
+        public static async Task DisposeIfApplicableAsync(this object? o)
         {
+            if (o is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+
             if (o is IDisposable disposable)
                 disposable.Dispose();
         }

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -9,11 +9,6 @@
 
     public static class ReflectionExtensions
     {
-        public static bool IsVoid(this MethodInfo method)
-        {
-            return method.ReturnType == typeof(void);
-        }
-
         public static bool IsStatic(this Type type)
         {
             return type.IsAbstract && type.IsSealed;

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -30,7 +30,8 @@
 
         public static void Dispose(this object? o)
         {
-            (o as IDisposable)?.Dispose();
+            if (o is IDisposable disposable)
+                disposable.Dispose();
         }
     }
 }

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -52,7 +52,7 @@
 
                         await TryRunCaseAsync(@case, automaticInstance);
                         TryInspectCase(@case, inspectCase, out caseInspectionFailure);
-                        disposalFailure = await TryDispose(automaticInstance);
+                        disposalFailure = await TryDisposeAsync(automaticInstance);
                     }
                     catch (Exception constructionFailure)
                     {
@@ -119,7 +119,7 @@
             }
         }
 
-        static async Task<Exception?> TryDispose(object? automaticInstance)
+        static async Task<Exception?> TryDisposeAsync(object? automaticInstance)
         {
             Exception? disposalFailure = null;
 

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -52,7 +52,7 @@
 
                         await TryRunCaseAsync(@case, automaticInstance);
                         TryInspectCase(@case, inspectCase, out caseInspectionFailure);
-                        TryDispose(automaticInstance, out disposalFailure);
+                        disposalFailure = await TryDispose(automaticInstance);
                     }
                     catch (Exception constructionFailure)
                     {
@@ -119,18 +119,20 @@
             }
         }
 
-        static void TryDispose(object? automaticInstance, out Exception? disposalFailure)
+        static async Task<Exception?> TryDispose(object? automaticInstance)
         {
-            disposalFailure = null;
+            Exception? disposalFailure = null;
 
             try
             {
-                automaticInstance.Dispose();
+                await automaticInstance.DisposeIfApplicableAsync();
             }
             catch (Exception exception)
             {
                 disposalFailure = exception;
             }
+
+            return disposalFailure;
         }
 
         public Task RunAsync(Action<Case>? inspectCase = null)


### PR DESCRIPTION
Previous versions include special treatment of `IDisposable` on `Discovery`, `Execution`, and test classes. When these classes implement `IDisposable`, the `Dispose()` method is naturally *not* mistaken for a test method, and it is called appropriately. If Fixie constructs such a type, Fixie is responsible for calling `Dispose()` when it is done with it. If you construct such a type yourself (a custom convention which explicitly constructs a test class), it's your job to `Dispose()`.

This PR adds the same support for the recently-added `IAsyncDisposable` interface. `IAsyncDisposable.DisposeAsync()` is not mistaken for a test method, and Fixie invokes it and awaits it appropriately for any such object that Fixie constructed on your behalf. In the bizarre case that both interfaces are implemented, we invoke and await `DisposeAsync()` first, and then `Dispose()`, mirroring the pattern of a synchronous constructor call followed by an async initialization method.