### PR TITLE
Build and run with .NET SDK 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: .NET SDK (Run)
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.404'
-    - name: .NET SDK (Build)
+    - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.100'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: .NET SDK (Run)
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.404'
-    - name: .NET SDK (Build)
+    - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.100'

--- a/src/Fixie.Console/Fixie.Console.csproj
+++ b/src/Fixie.Console/Fixie.Console.csproj
@@ -8,6 +8,7 @@
     <ToolCommandName>fixie</ToolCommandName>
     <Description>`dotnet fixie` console test runner for the Fixie test framework.</Description>
     <DebugType>embedded</DebugType>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>embedded</DebugType>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Enable `RollForward=Major` for Fixie.Console, so that it can run on .NET Core 3.1 *and later versions*.

Hopefully illustrates the benefits of the change suggested in https://github.com/fixie/fixie/issues/246 

Sending a PR to verify this builds and runs as expected (GitHub actions did not run in my fork).