### PR TITLE
Enable `RollForward=Major` for 2.2.1 (master)

### DIFF
--- a/src/Fixie.Console/Fixie.Console.csproj
+++ b/src/Fixie.Console/Fixie.Console.csproj
@@ -7,6 +7,7 @@
     <PackageId>Fixie.Console</PackageId>
     <PackageType>DotnetCliTool</PackageType>
     <Description>`dotnet fixie` console test runner for the Fixie test framework.</Description>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
As suggested in https://github.com/fixie/fixie/issues/246#issuecomment-727609379, enabling `RollForward=Major` on the `master` branch, i.e. for Fixie CLI tool 2.2.1. Fixes #246 

This should unblock running Fixie 2.x tools when only later .NET Core versions (e.g. 3.x and 5) are available.

Hopefully PRs against `master` branch still work with CI.