### PR TITLE
Assembly start/complete customization hooks

### DIFF
--- a/src/Fixie.Tests/AssemblyLifecycleTests.cs
+++ b/src/Fixie.Tests/AssemblyLifecycleTests.cs
@@ -1,0 +1,93 @@
+﻿namespace Fixie.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Assertions;
+    using Fixie.Internal;
+
+    public class AssemblyLifecycleTests : InstrumentedExecutionTests
+    {
+        class FirstTestClass
+        {
+            public void Fail()
+            {
+                WhereAmI();
+                throw new FailureException();
+            }
+        }
+
+        class SecondTestClass
+        {
+            public void Pass() => WhereAmI();
+        }
+
+        class CustomExecution : Execution
+        {
+            public Task StartAsync()
+            {
+                WhereAmI();
+                return Task.CompletedTask;
+            }
+
+            public async Task ExecuteAsync(TestClass testClass)
+            {
+                foreach (var test in testClass.Tests)
+                    await test.RunAsync();
+            }
+
+            public Task CompleteAsync()
+            {
+                WhereAmI();
+                return Task.CompletedTask;
+            }
+        }
+
+        static readonly Type[] TestClasses = {typeof(FirstTestClass), typeof(SecondTestClass)};
+
+        public async Task ShouldPerformNoAssemblyLevelBehaviorsByDefault()
+        {
+            var output = await RunAsync(TestClasses, new DefaultExecution());
+
+            output.ShouldHaveResults(
+                "FirstTestClass.Fail failed: 'Fail' failed!",
+                "SecondTestClass.Pass passed");
+
+            output.ShouldHaveLifecycle(
+                "Fail", "Pass");
+        }
+
+        public async Task ShouldPerformOptionalAssemblyLevelBehaviorsOncePerRun()
+        {
+            var output = await RunSampleAsync();
+
+            output.ShouldHaveResults(
+                "FirstTestClass.Fail failed: 'Fail' failed!",
+                "SecondTestClass.Pass passed");
+
+            output.ShouldHaveLifecycle(
+                "StartAsync",
+                "Fail", "Pass",
+                "CompleteAsync");
+        }
+
+        public async Task ShouldFailEntireRunWhenAssemblyStartThrows()
+        {
+            FailDuring("StartAsync");
+
+            Func<Task> attemptInvalidRun = RunSampleAsync;
+
+            await attemptInvalidRun.ShouldThrowAsync<FailureException>("'StartAsync' failed!");
+        }
+
+        public async Task ShouldFailEntireRunWhenAssemblyCompletionThrows()
+        {
+            FailDuring("CompleteAsync");
+
+            Func<Task> attemptInvalidRun = RunSampleAsync;
+
+            await attemptInvalidRun.ShouldThrowAsync<FailureException>("'CompleteAsync' failed!");
+        }
+
+        async Task<Output> RunSampleAsync() => await RunAsync(TestClasses, new CustomExecution());
+    }
+}

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -5,6 +5,7 @@ namespace Fixie.Tests.Assertions
     using System.Linq;
     using System.Text.Json;
     using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
 
     public static class AssertionExtensions
     {
@@ -61,6 +62,23 @@ namespace Fixie.Tests.Assertions
             try
             {
                 shouldThrow();
+            }
+            catch (Exception actual)
+            {
+                actual
+                    .ShouldBe<TException>()
+                    .Message.ShouldBe(expectedMessage);
+                return (TException)actual;
+            }
+
+            throw new AssertException(typeof(TException).FullName, "No exception was thrown.");
+        }
+
+        public static async Task<TException> ShouldThrowAsync<TException>(this Func<Task> shouldThrowAsync, string expectedMessage) where TException : Exception
+        {
+            try
+            {
+                await shouldThrowAsync();
             }
             catch (Exception actual)
             {

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -98,5 +98,14 @@ namespace Fixie.Tests
 
             return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
         }
+
+        protected async Task<Output> RunAsync(Type[] testClasses, Execution execution)
+        {
+            using var console = new RedirectedConsole();
+
+            var results = await Utility.RunAsync(testClasses, execution);
+
+            return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
+        }
     }
 }

--- a/src/Fixie.Tests/TestClassLifecycleTests.cs
+++ b/src/Fixie.Tests/TestClassLifecycleTests.cs
@@ -5,7 +5,7 @@ namespace Fixie.Tests
     using System.Threading.Tasks;
     using Fixie.Internal;
 
-    public class LifecycleTests : InstrumentedExecutionTests
+    public class TestClassLifecycleTests : InstrumentedExecutionTests
     {
         class SampleTestClass
         {

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -46,6 +46,14 @@
             return listener.Entries;
         }
 
+        public static async Task<IEnumerable<string>> RunAsync(Type[] testClasses, Execution execution)
+        {
+            var listener = new StubListener();
+            var discovery = new SelfTestDiscovery();
+            await RunAsync(listener, discovery, execution, testClasses);
+            return listener.Entries;
+        }
+
         public static async Task DiscoverAsync(Listener listener, Discovery discovery, params Type[] candidateTypes)
         {
             if (candidateTypes.Length == 0)

--- a/src/Fixie/Execution.cs
+++ b/src/Fixie/Execution.cs
@@ -7,6 +7,8 @@
     /// </summary>
     public interface Execution
     {
+        Task StartAsync() => Task.CompletedTask;
         Task ExecuteAsync(TestClass testClass);
+        Task CompleteAsync() => Task.CompletedTask;
     }
 }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -112,7 +112,9 @@
 
             var testAssembly = new TestAssembly(assembly, selectedTests, recorder, classes, methodDiscoverer, execution);
             await recorder.StartAsync(testAssembly);
+            await execution.StartAsync();
             await testAssembly.RunAsync();
+            await execution.CompleteAsync();
             return await recorder.CompleteAsync(testAssembly);
         }
     }


### PR DESCRIPTION
This is experimental, and may be adjusted if we address custom reports prior to 3.x leaving beta.

When customizing the test class lifecycle, you can optionally provide StartAsync() and CompleteAsync() methods, each awaited once at the start and end of the test assembly run, respectively:

```cs
public class CustomExecution : Execution
{
    public Task StartAsync()
    {
        // One-time set up for the entire test run.
    }

    public async Task ExecuteAsync(TestClass testClass)
    {
        foreach (var test in testClass.Tests)
            await test.RunAsync();
    }

    public Task CompleteAsync()
    {
        // One-time tear down for the entire test run.
    }
}
```

