### PR TITLE
Drop deprecated failure inspection hook

### DIFF
--- a/src/Fixie.Tests/Internal/CaseTests.cs
+++ b/src/Fixie.Tests/Internal/CaseTests.cs
@@ -1,8 +1,9 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests.Internal
 {
     using System;
     using System.Linq;
     using Assertions;
+    using Fixie.Internal;
 
     public class CaseTests
     {
@@ -10,7 +11,7 @@
         {
             var @case = Case("Returns");
 
-            @case.Name.ShouldBe("Fixie.Tests.CaseTests.Returns");
+            @case.Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Returns");
         }
 
         public void ShouldExposeParameterValues()
@@ -26,140 +27,140 @@
         {
             var @case = Case("Parameterized", 123, true, 'a', "with \"quotes\"", "long \"string\" gets truncated", null, this, new ObjectWithNullStringRepresentation());
 
-            @case.Name.ShouldBe("Fixie.Tests.CaseTests.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseTests, Fixie.Tests.CaseTests+ObjectWithNullStringRepresentation)");
+            @case.Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.Internal.CaseTests, Fixie.Tests.Internal.CaseTests+ObjectWithNullStringRepresentation)");
         }
 
         public void ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()
         {
-            Case("Char", '\"').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\"')");
-            Case("Char", '"').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\"')");
-            Case("Char", '\'').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\'')");
+            Case("Char", '\"').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\"')");
+            Case("Char", '"').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\"')");
+            Case("Char", '\'').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\'')");
 
-            Case("Char", '\\').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\\\')");
-            Case("Char", '\0').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\0')");
-            Case("Char", '\a').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\a')");
-            Case("Char", '\b').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\b')");
-            Case("Char", '\f').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\f')");
-            Case("Char", '\n').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\n')");
-            Case("Char", '\r').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\r')");
-            Case("Char", '\t').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\t')");
-            Case("Char", '\v').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\v')");
+            Case("Char", '\\').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\\\')");
+            Case("Char", '\0').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\0')");
+            Case("Char", '\a').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\a')");
+            Case("Char", '\b').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\b')");
+            Case("Char", '\f').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\f')");
+            Case("Char", '\n').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\n')");
+            Case("Char", '\r').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\r')");
+            Case("Char", '\t').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\t')");
+            Case("Char", '\v').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\v')");
 
             // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
             // Just like \r and \n, we escape these in order to present a readable string literal.  All other unicode sequences pass through
             // with no additional special treatment.
 
             // \uxxxx - Unicode escape sequence for character with hex value xxxx.
-            Case("Char", '\u0000').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\0')");
-            Case("Char", '\u0085').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u0085')");
-            Case("Char", '\u2028').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u2028')");
-            Case("Char", '\u2029').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u2029')");
-            Case("Char", '\u263A').Name.ShouldBe("Fixie.Tests.CaseTests.Char('☺')");
+            Case("Char", '\u0000').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\0')");
+            Case("Char", '\u0085').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u0085')");
+            Case("Char", '\u2028').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u2028')");
+            Case("Char", '\u2029').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u2029')");
+            Case("Char", '\u263A').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('☺')");
 
             // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
-            Case("Char", '\x0000').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\0')");
-            Case("Char", '\x000').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\0')");
-            Case("Char", '\x00').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\0')");
-            Case("Char", '\x0').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\0')");
-            Case("Char", '\x0085').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u0085')");
-            Case("Char", '\x085').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u0085')");
-            Case("Char", '\x85').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u0085')");
-            Case("Char", '\x2028').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u2028')");
-            Case("Char", '\x2029').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u2029')");
-            Case("Char", '\x263A').Name.ShouldBe("Fixie.Tests.CaseTests.Char('☺')");
+            Case("Char", '\x0000').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\0')");
+            Case("Char", '\x000').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\0')");
+            Case("Char", '\x00').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\0')");
+            Case("Char", '\x0').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\0')");
+            Case("Char", '\x0085').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u0085')");
+            Case("Char", '\x085').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u0085')");
+            Case("Char", '\x85').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u0085')");
+            Case("Char", '\x2028').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u2028')");
+            Case("Char", '\x2029').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u2029')");
+            Case("Char", '\x263A').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('☺')");
 
             //\Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
-            Case("Char", '\U00000000').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\0')");
-            Case("Char", '\U00000085').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u0085')");
-            Case("Char", '\U00002028').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u2028')");
-            Case("Char", '\U00002029').Name.ShouldBe("Fixie.Tests.CaseTests.Char('\\u2029')");
-            Case("Char", '\U0000263A').Name.ShouldBe("Fixie.Tests.CaseTests.Char('☺')");
+            Case("Char", '\U00000000').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\0')");
+            Case("Char", '\U00000085').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u0085')");
+            Case("Char", '\U00002028').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u2028')");
+            Case("Char", '\U00002029').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('\\u2029')");
+            Case("Char", '\U0000263A').Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Char('☺')");
         }
 
         public void ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasStringParameters()
         {
-            Case("String", "\'").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"'\")");
-            Case("String", "'").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"'\")");
-            Case("String", "\"").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\\"\")");
+            Case("String", "\'").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"'\")");
+            Case("String", "'").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"'\")");
+            Case("String", "\"").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\\"\")");
 
-            Case("String", "\\").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\\\\")");
-            Case("String", "\0").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\0\")");
-            Case("String", "\a").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\a\")");
-            Case("String", "\b").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\b\")");
-            Case("String", "\f").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\f\")");
-            Case("String", "\n").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\n\")");
-            Case("String", "\r").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\r\")");
-            Case("String", "\t").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\t\")");
-            Case("String", "\v").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\v\")");
+            Case("String", "\\").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\\\\")");
+            Case("String", "\0").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\0\")");
+            Case("String", "\a").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\a\")");
+            Case("String", "\b").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\b\")");
+            Case("String", "\f").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\f\")");
+            Case("String", "\n").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\n\")");
+            Case("String", "\r").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\r\")");
+            Case("String", "\t").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\t\")");
+            Case("String", "\v").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\v\")");
 
             // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
             // Just like \r and \n, we escape these in order to present a readable string literal.  All other unicode sequences pass through
             // with no additional special treatment.
 
             // \uxxxx - Unicode escape sequence for character with hex value xxxx.
-            Case("String", "\u0000").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\0\")");
-            Case("String", "\u0085").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u0085\")");
-            Case("String", "\u2028").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u2028\")");
-            Case("String", "\u2029").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u2029\")");
-            Case("String", "\u263A").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"☺\")");
+            Case("String", "\u0000").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\0\")");
+            Case("String", "\u0085").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u0085\")");
+            Case("String", "\u2028").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u2028\")");
+            Case("String", "\u2029").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u2029\")");
+            Case("String", "\u263A").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"☺\")");
 
             // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
-            Case("String", "\x0000").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\0\")");
-            Case("String", "\x000").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\0\")");
-            Case("String", "\x00").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\0\")");
-            Case("String", "\x0").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\0\")");
-            Case("String", "\x0085").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u0085\")");
-            Case("String", "\x085").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u0085\")");
-            Case("String", "\x85").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u0085\")");
-            Case("String", "\x2028").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u2028\")");
-            Case("String", "\x2029").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u2029\")");
-            Case("String", "\x263A").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"☺\")");
+            Case("String", "\x0000").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\0\")");
+            Case("String", "\x000").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\0\")");
+            Case("String", "\x00").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\0\")");
+            Case("String", "\x0").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\0\")");
+            Case("String", "\x0085").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u0085\")");
+            Case("String", "\x085").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u0085\")");
+            Case("String", "\x85").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u0085\")");
+            Case("String", "\x2028").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u2028\")");
+            Case("String", "\x2029").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u2029\")");
+            Case("String", "\x263A").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"☺\")");
 
             //\Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
-            Case("String", "\U00000000").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\0\")");
-            Case("String", "\U00000085").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u0085\")");
-            Case("String", "\U00002028").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u2028\")");
-            Case("String", "\U00002029").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"\\u2029\")");
-            Case("String", "\U0000263A").Name.ShouldBe("Fixie.Tests.CaseTests.String(\"☺\")");
+            Case("String", "\U00000000").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\0\")");
+            Case("String", "\U00000085").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u0085\")");
+            Case("String", "\U00002028").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u2028\")");
+            Case("String", "\U00002029").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"\\u2029\")");
+            Case("String", "\U0000263A").Name.ShouldBe("Fixie.Tests.Internal.CaseTests.String(\"☺\")");
         }
 
         public void ShouldIncludeResolvedGenericArgumentsInNameWhenTheUnderlyingMethodIsGeneric()
         {
             Case("Generic", 123, true, "a", "b")
-                .Name.ShouldBe("Fixie.Tests.CaseTests.Generic<System.Boolean, System.String>(123, True, \"a\", \"b\")");
+                .Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Generic<System.Boolean, System.String>(123, True, \"a\", \"b\")");
 
             Case("Generic", 123, true, 1, null)
-                .Name.ShouldBe("Fixie.Tests.CaseTests.Generic<System.Boolean, System.Int32>(123, True, 1, null)");
+                .Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Generic<System.Boolean, System.Int32>(123, True, 1, null)");
 
             Case("Generic", 123, 1.23m, "a", null)
-                .Name.ShouldBe("Fixie.Tests.CaseTests.Generic<System.Decimal, System.String>(123, 1.23, \"a\", null)");
+                .Name.ShouldBe("Fixie.Tests.Internal.CaseTests.Generic<System.Decimal, System.String>(123, 1.23, \"a\", null)");
 
             Case("ConstrainedGeneric", 1)
-                .Name.ShouldBe("Fixie.Tests.CaseTests.ConstrainedGeneric<System.Int32>(1)");
+                .Name.ShouldBe("Fixie.Tests.Internal.CaseTests.ConstrainedGeneric<System.Int32>(1)");
 
             Case("ConstrainedGeneric", true)
-                .Name.ShouldBe("Fixie.Tests.CaseTests.ConstrainedGeneric<System.Boolean>(True)");
+                .Name.ShouldBe("Fixie.Tests.Internal.CaseTests.ConstrainedGeneric<System.Boolean>(True)");
         }
 
         public void ShouldUseGenericTypeParametersInNameWhenGenericTypeParametersCannotBeResolved()
         {
             Case("ConstrainedGeneric", "Incompatible")
-                .Name.ShouldBe("Fixie.Tests.CaseTests.ConstrainedGeneric<T>(\"Incompatible\")");
+                .Name.ShouldBe("Fixie.Tests.Internal.CaseTests.ConstrainedGeneric<T>(\"Incompatible\")");
         }
 
         public void ShouldInferAppropriateClassGivenCaseMethod()
         {
             var methodDeclaredInChildClass =
                 Case<SampleChildTestClass>("TestMethodDefinedWithinChildClass");
-            methodDeclaredInChildClass.Name.ShouldBe("Fixie.Tests.CaseTests+SampleChildTestClass.TestMethodDefinedWithinChildClass");
+            methodDeclaredInChildClass.Name.ShouldBe("Fixie.Tests.Internal.CaseTests+SampleChildTestClass.TestMethodDefinedWithinChildClass");
 
             var methodDeclaredInParentClass =
                 Case<SampleParentTestClass>("TestMethodDefinedWithinParentClass");
-            methodDeclaredInParentClass.Name.ShouldBe("Fixie.Tests.CaseTests+SampleParentTestClass.TestMethodDefinedWithinParentClass");
+            methodDeclaredInParentClass.Name.ShouldBe("Fixie.Tests.Internal.CaseTests+SampleParentTestClass.TestMethodDefinedWithinParentClass");
 
             var parentMethodInheritedByChildClass =
                 Case<SampleChildTestClass>("TestMethodDefinedWithinParentClass");
-            parentMethodInheritedByChildClass.Name.ShouldBe("Fixie.Tests.CaseTests+SampleChildTestClass.TestMethodDefinedWithinParentClass");
+            parentMethodInheritedByChildClass.Name.ShouldBe("Fixie.Tests.Internal.CaseTests+SampleChildTestClass.TestMethodDefinedWithinParentClass");
         }
 
         public void ShouldHaveMethodInfoIncludingResolvedGenericArguments()

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Assertions;
+    using Fixie.Internal;
 
     public class GenericArgumentResolverTests
     {

--- a/src/Fixie.Tests/PrimaryConvention.cs
+++ b/src/Fixie.Tests/PrimaryConvention.cs
@@ -14,12 +14,11 @@
         {
             foreach (var test in testClass.Tests)
             {
-                await test.RunAsync(failure =>
-                {
-                    if (failure.Exception is AssertException exception && !exception.HasCompactRepresentations)
-                        if (testClass.TestAssembly.SelectedTests.Count == 1)
-                            LaunchDiffTool(exception);
-                });
+                var result = await test.RunAsync();
+
+                if (result is AssertException exception && !exception.HasCompactRepresentations)
+                    if (testClass.TestAssembly.SelectedTests.Count == 1)
+                        LaunchDiffTool(exception);
             }
         }
 

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -134,7 +134,7 @@ namespace Fixie.Tests
             {
                 foreach (var test in testClass.Tests)
                     if (!ShouldSkip(test))
-                        await test.RunAsync(Utility.UsingInputAttributes, failure => InspectFailure());
+                        await test.RunAsync(Utility.UsingInputAttributes);
             }
         }
 
@@ -147,13 +147,11 @@ namespace Fixie.Tests
 
                 foreach (var test in testClass.Tests)
                     if (!ShouldSkip(test))
-                        await test.RunAsync(Utility.UsingInputAttributes, instance, failure => InspectFailure());
+                        await test.RunAsync(Utility.UsingInputAttributes, instance);
 
                 await instance.DisposeIfApplicableAsync();
             }
         }
-
-        static void InspectFailure() => WhereAmI();
 
         public async Task ShouldConstructPerCaseByDefault()
         {
@@ -186,7 +184,7 @@ namespace Fixie.Tests
                 "SampleTestClass.Skip skipped: This test did not run.");
 
             output.ShouldHaveLifecycle(
-                ".ctor", "Fail", "InspectFailure", "DisposeAsync", "Dispose",
+                ".ctor", "Fail", "DisposeAsync", "Dispose",
                 ".ctor", "Pass(1)", "DisposeAsync","Dispose",
                 ".ctor", "Pass(2)", "DisposeAsync","Dispose");
         }
@@ -204,9 +202,9 @@ namespace Fixie.Tests
                 "SampleTestClass.Skip skipped: This test did not run.");
 
             output.ShouldHaveLifecycle(
-                ".ctor", "InspectFailure",
-                ".ctor", "InspectFailure",
-                ".ctor", "InspectFailure");
+                ".ctor",
+                ".ctor",
+                ".ctor");
         }
 
         public async Task ShouldFailCaseWithoutHidingPrimaryFailuresWhenConstructingPerCaseAndDisposeThrows()
@@ -223,7 +221,7 @@ namespace Fixie.Tests
                 "SampleTestClass.Skip skipped: This test did not run.");
 
             output.ShouldHaveLifecycle(
-                ".ctor", "Fail", "InspectFailure", "DisposeAsync", "Dispose",
+                ".ctor", "Fail", "DisposeAsync", "Dispose",
                 ".ctor", "Pass(1)", "DisposeAsync", "Dispose",
                 ".ctor", "Pass(2)", "DisposeAsync", "Dispose");
         }
@@ -242,7 +240,7 @@ namespace Fixie.Tests
                 "SampleTestClass.Skip skipped: This test did not run.");
 
             output.ShouldHaveLifecycle(
-                ".ctor", "Fail", "InspectFailure", "DisposeAsync",
+                ".ctor", "Fail", "DisposeAsync",
                 ".ctor", "Pass(1)", "DisposeAsync",
                 ".ctor", "Pass(2)", "DisposeAsync");
         }
@@ -259,7 +257,7 @@ namespace Fixie.Tests
 
             output.ShouldHaveLifecycle(
                 ".ctor",
-                "Fail", "InspectFailure",
+                "Fail",
                 "Pass(1)",
                 "Pass(2)",
                 "DisposeAsync",
@@ -301,7 +299,7 @@ namespace Fixie.Tests
 
             output.ShouldHaveLifecycle(
                 ".ctor",
-                "Fail", "InspectFailure",
+                "Fail",
                 "Pass(1)",
                 "Pass(2)",
                 "DisposeAsync",
@@ -325,7 +323,7 @@ namespace Fixie.Tests
 
             output.ShouldHaveLifecycle(
                 ".ctor",
-                "Fail", "InspectFailure",
+                "Fail",
                 "Pass(1)",
                 "Pass(2)",
                 "DisposeAsync");
@@ -376,9 +374,7 @@ namespace Fixie.Tests
                 "StaticTestClass.Skip skipped: This test did not run."
             );
 
-            output.ShouldHaveLifecycle(
-                "Fail", "InspectFailure",
-                "Pass");
+            output.ShouldHaveLifecycle("Fail", "Pass");
 
             output = await RunAsync<CreateInstancePerClass>(typeof(StaticTestClass));
 
@@ -388,9 +384,7 @@ namespace Fixie.Tests
                 "StaticTestClass.Skip skipped: This test did not run."
             );
 
-            output.ShouldHaveLifecycle(
-                "Fail", "InspectFailure",
-                "Pass");
+            output.ShouldHaveLifecycle("Fail", "Pass");
         }
     }
 }

--- a/src/Fixie.Tests/TestClassLifecycleTests.cs
+++ b/src/Fixie.Tests/TestClassLifecycleTests.cs
@@ -117,7 +117,7 @@ namespace Fixie.Tests
                 try
                 {
                     CaseSetUp();
-                    await test.RunAsync(parameters, failure => InspectFailure());
+                    await test.RunAsync(parameters);
                     CaseTearDown();
                 }
                 catch (Exception exception)
@@ -134,7 +134,6 @@ namespace Fixie.Tests
         static void TestSetUp() => WhereAmI();
         static void CaseSetUp() => WhereAmI();
         static void CaseTearDown() => WhereAmI();
-        static void InspectFailure() => WhereAmI();
         static void TestTearDown() => WhereAmI();
         static void ClassTearDown() => WhereAmI();
 
@@ -242,7 +241,7 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(
                 "ClassSetUp",
                 "TestSetUp",
-                "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown",
+                "CaseSetUp", "Fail", "CaseTearDown",
                 "TestTearDown",
                 "TestSetUp",
                 "CaseSetUp", "Pass(1)", "CaseTearDown",
@@ -262,7 +261,7 @@ namespace Fixie.Tests
 
             output.ShouldHaveLifecycle(
                 "ClassSetUp",
-                "TestSetUp", "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown", "TestTearDown",
+                "TestSetUp", "CaseSetUp", "Fail", "CaseTearDown", "TestTearDown",
                 "TestSetUp", "CaseSetUp", "Pass", "CaseTearDown", "TestTearDown",
                 "ClassTearDown");
         }
@@ -300,7 +299,7 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(
                 "ClassSetUp",
                 "TestSetUp",
-                "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown",
+                "CaseSetUp", "Fail", "CaseTearDown",
                 "TestTearDown",
                 "TestSetUp",
                 "ClassTearDown");
@@ -320,7 +319,7 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(
                 "ClassSetUp",
                 "TestSetUp",
-                "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown",
+                "CaseSetUp", "Fail", "CaseTearDown",
                 "TestTearDown",
                 "TestSetUp",
                 "ClassTearDown");
@@ -341,35 +340,10 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(
                 "ClassSetUp",
                 "TestSetUp",
-                "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown",
+                "CaseSetUp", "Fail", "CaseTearDown",
                 "TestTearDown",
                 "TestSetUp",
                 "CaseSetUp",
-                "CaseSetUp", "Pass(2)", "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown");
-        }
-
-        public async Task ShouldFailCaseWithoutHidingPrimaryFailuresWhenFailureInspectionThrows()
-        {
-            FailDuring("InspectFailure");
-
-            var output = await RunAsync<SampleTestClass, InstrumentedExecution>();
-
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail failed: 'Fail' failed!",
-                "SampleTestClass.Fail failed: 'InspectFailure' failed!",
-                "SampleTestClass.Pass(1) passed",
-                "SampleTestClass.Pass(2) passed",
-                "SampleTestClass.Skip skipped: This test did not run.");
-
-            output.ShouldHaveLifecycle(
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown",
-                "TestTearDown",
-                "TestSetUp",
-                "CaseSetUp", "Pass(1)", "CaseTearDown",
                 "CaseSetUp", "Pass(2)", "CaseTearDown",
                 "TestTearDown",
                 "ClassTearDown");
@@ -393,7 +367,7 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(
                 "ClassSetUp",
                 "TestSetUp",
-                "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown",
+                "CaseSetUp", "Fail", "CaseTearDown",
                 "TestTearDown",
                 "TestSetUp",
                 "CaseSetUp", "Pass(1)", "CaseTearDown",
@@ -421,7 +395,7 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(
                 "ClassSetUp",
                 "TestSetUp",
-                "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown",
+                "CaseSetUp", "Fail", "CaseTearDown",
                 "TestTearDown",
                 "TestSetUp",
                 "CaseSetUp", "Pass(1)", "CaseTearDown",
@@ -449,7 +423,7 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(
                 "ClassSetUp",
                 "TestSetUp",
-                "CaseSetUp", "Fail", "InspectFailure", "CaseTearDown",
+                "CaseSetUp", "Fail", "CaseTearDown",
                 "TestTearDown",
                 "TestSetUp",
                 "CaseSetUp", "Pass(1)", "CaseTearDown",

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -59,7 +59,7 @@
         /// <summary>
         /// Indicate the test case was skipped for the given reason.
         /// </summary>
-        public void Skip(string? reason)
+        internal void Skip(string? reason)
         {
             State = CaseState.Skipped;
             Exception = null;

--- a/src/Fixie/Case.cs
+++ b/src/Fixie/Case.cs
@@ -9,11 +9,11 @@
     /// <summary>
     /// A test case being executed, representing a single call to a test method.
     /// </summary>
-    public class Case
+    class Case
     {
         readonly object?[] parameters;
 
-        internal Case(MethodInfo testMethod, object?[] parameters)
+        public Case(MethodInfo testMethod, object?[] parameters)
         {
             this.parameters = parameters;
             Test = new Test(testMethod);
@@ -21,7 +21,7 @@
             Name = CaseNameBuilder.GetName(Method, parameters);
         }
 
-        internal Case(Case originalCase, Exception secondaryFailureReason)
+        public Case(Case originalCase, Exception secondaryFailureReason)
         {
             parameters = originalCase.parameters;
             Test = originalCase.Test;
@@ -59,7 +59,7 @@
         /// <summary>
         /// Indicate the test case was skipped for the given reason.
         /// </summary>
-        internal void Skip(string? reason)
+        public void Skip(string? reason)
         {
             State = CaseState.Skipped;
             Exception = null;
@@ -79,7 +79,7 @@
         /// <summary>
         /// Indicate the test case failed for the given reason.
         /// </summary>
-        internal void Fail(Exception reason)
+        public void Fail(Exception reason)
         {
             if (reason is PreservedException preservedException)
                 reason = preservedException.OriginalException;
@@ -91,14 +91,14 @@
             SkipReason = null;
         }
 
-        internal string? SkipReason { get; private set; }
-        internal CaseState State { get; private set; }
+        public string? SkipReason { get; private set; }
+        public CaseState State { get; private set; }
 
         /// <summary>
         /// Run the test case against the given instance of the test class,
         /// causing the case state to become either passing or failing.
         /// </summary>
-        internal async Task RunAsync(object? instance)
+        public async Task RunAsync(object? instance)
         {
             try
             {

--- a/src/Fixie/Internal/Case.cs
+++ b/src/Fixie/Internal/Case.cs
@@ -1,10 +1,9 @@
-﻿namespace Fixie
+﻿namespace Fixie.Internal
 {
     using System;
     using System.Collections.Generic;
     using System.Reflection;
     using System.Threading.Tasks;
-    using Internal;
 
     /// <summary>
     /// A test case being executed, representing a single call to a test method.

--- a/src/Fixie/Internal/CaseCompleted.cs
+++ b/src/Fixie/Internal/CaseCompleted.cs
@@ -4,7 +4,7 @@ namespace Fixie.Internal
 
     public abstract class CaseCompleted : Message
     {
-        protected CaseCompleted(Case @case, TimeSpan duration, string output)
+        internal CaseCompleted(Case @case, TimeSpan duration, string output)
         {
             Test = @case.Test;
             Name = @case.Name;

--- a/src/Fixie/Internal/CaseFailed.cs
+++ b/src/Fixie/Internal/CaseFailed.cs
@@ -4,7 +4,7 @@
 
     public class CaseFailed : CaseCompleted
     {
-        public CaseFailed(Case @case, TimeSpan duration, string output) : base(@case, duration, output)
+        internal CaseFailed(Case @case, TimeSpan duration, string output) : base(@case, duration, output)
             => Exception = @case.Exception!;
 
         public Exception Exception { get; }

--- a/src/Fixie/Internal/CasePassed.cs
+++ b/src/Fixie/Internal/CasePassed.cs
@@ -4,7 +4,7 @@
 
     public class CasePassed : CaseCompleted
     {
-        public CasePassed(Case @case, TimeSpan duration, string output)
+        internal CasePassed(Case @case, TimeSpan duration, string output)
             : base(@case, duration, output)
         {
         }

--- a/src/Fixie/Internal/CaseSkipped.cs
+++ b/src/Fixie/Internal/CaseSkipped.cs
@@ -4,7 +4,7 @@
 
     public class CaseSkipped : CaseCompleted
     {
-        public CaseSkipped(Case @case, TimeSpan duration, string output)
+        internal CaseSkipped(Case @case, TimeSpan duration, string output)
             : base(@case, duration, output)
         {
             Reason = @case.SkipReason;

--- a/src/Fixie/Internal/CaseStarted.cs
+++ b/src/Fixie/Internal/CaseStarted.cs
@@ -2,7 +2,7 @@
 {
     public class CaseStarted : Message
     {
-        public CaseStarted(Case @case)
+        internal CaseStarted(Case @case)
         {
             Test = @case.Test;
             Name = @case.Name;

--- a/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
+++ b/src/Fixie/Internal/Listeners/ExceptionExtensions.cs
@@ -44,7 +44,7 @@
             if (lines.Length >= 2)
             {
                 if (lines[^2].Contains(" Fixie.MethodInfoExtensions.RunTestMethodAsync(MethodInfo method, Object instance, Object[] parameters)") &&
-                    lines[^1].Contains(" Fixie.Case.RunAsync(Object instance)"))
+                    lines[^1].Contains(" Fixie.Internal.Case.RunAsync(Object instance)"))
 
                     return string.Join(NewLine, lines[..^2]);
             }

--- a/src/Fixie/TestMethod.cs
+++ b/src/Fixie/TestMethod.cs
@@ -34,7 +34,7 @@
         public bool Has<TAttribute>([NotNullWhen(true)] out TAttribute? matchingAttribute) where TAttribute : Attribute
             => Method.Has(out matchingAttribute);
 
-        async Task RunCoreAsync(object?[] parameters, object? instance, Action<Case>? inspectFailure)
+        async Task<Exception?> RunCoreAsync(object?[] parameters, object? instance, Action<Case>? inspectFailure)
         {
             var @case = new Case(Method, parameters);
 
@@ -105,6 +105,8 @@
             }
 
             RecordedResult = true;
+
+            return @case.Exception;
         }
 
         static Task TryRunCaseAsync(Case @case, object? instance)
@@ -145,12 +147,12 @@
             return disposalFailure;
         }
 
-        public Task RunAsync(Action<Case>? inspectFailure = null)
+        public Task<Exception?> RunAsync(Action<Case>? inspectFailure = null)
         {
             return RunCoreAsync(EmptyParameters, instance: null, inspectFailure);
         }
 
-        public Task RunAsync(object?[] parameters, Action<Case>? inspectFailure = null)
+        public Task<Exception?> RunAsync(object?[] parameters, Action<Case>? inspectFailure = null)
         {
             return RunCoreAsync(parameters, instance: null, inspectFailure);
         }
@@ -168,12 +170,12 @@
             }
         }
 
-        public Task RunAsync(object? instance, Action<Case>? inspectFailure = null)
+        public Task<Exception?> RunAsync(object? instance, Action<Case>? inspectFailure = null)
         {
             return RunCoreAsync(EmptyParameters, instance, inspectFailure);
         }
 
-        public Task RunAsync(object?[] parameters, object? instance, Action<Case>? inspectFailure = null)
+        public Task<Exception?> RunAsync(object?[] parameters, object? instance, Action<Case>? inspectFailure = null)
         {
             return RunCoreAsync(parameters, instance, inspectFailure);
         }


### PR DESCRIPTION
This phases out the test case-level failure inspection hook as irrelevant. There were two reasons this existed:

1. So that conventions could detect and inspect exceptions for failed tests, such as to count failures as they happen.
2. To recharacterize a failure as a skip.

We improve the situation here for point 1 by providing that exception in the return value from `TestMethod.RunAsync(...)`.

We reject point 2 as anathema to Fixie v3's design intention. This ability is a workaround rather than a feature. If a user wants to interpret some exceptions as OK, it is free to do so within the test method body. If a user wanted this in order to set up a retry concept, it is free to do so idiomatically within the test method body and is free to use a library like Polly to do so cleanly. A test that is invoked either throws or not, passes or fails. It's not a completed test case that deserves a recharacterization or a retry, but the activity *under* test itself.