### PR TITLE
JetBrains ReSharper/Rider Integration

### DIFF
--- a/build/Fixie.props
+++ b/build/Fixie.props
@@ -2,6 +2,7 @@
 <Project>
 
   <PropertyGroup>
+    <TestProject>true</TestProject>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/build/Fixie.targets
+++ b/build/Fixie.targets
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <Target Name="_Fixie_GetTargetFrameworks">

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.3" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="MinVer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -15,6 +15,7 @@
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <DebugType>embedded</DebugType>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -16,7 +16,7 @@
       <group targetFramework="netcoreapp3.1">
         <dependency id="Fixie" version="[$version$]" />
         <dependency id="Mono.Cecil" version="0.11.3" />
-        <dependency id="Microsoft.TestPlatform.TestHost" version="16.10.0" />
+        <dependency id="Microsoft.NET.Test.Sdk" version="16.10.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Our understanding is that the reason JetBrains hasn't detected our VSTest Test Adapter in the past is that we have until now deliberately avoided the Microsoft.NET.Test.Sdk nuget package.

That package introduces an empty `Main()` method into your test project. The Fixie.TestAdapter itself injects a *non-empty* `Main()` method to actually run the test project.

Since we are introducing a dependency on Microsoft.NET.Test.Sdk, we wind up with two Main() methods. This PR then compensates for that by attempting to disable the Microsoft.NET.Test.Sdk's own code generation step before it has a chance to happen.

Microsoft.NET.Test.Sdk also has the undesirable effect of incorrectly treating the Fixie.TestAdapter project as unpackable (a reasonable impact on test projects that are rarely packed, but Fixie.TestAdapter is not a test project itself!). We compensate by explicitly marking Fixie.TestAdapter as packable.