### PR TITLE
Add rollFoward option to global.json with value "latestMinor"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 ﻿{
     "sdk": {
-      "version": "5.0.100"
+      "version": "5.0.100",
+      "rollForward": "latestMinor"
     }
 }


### PR DESCRIPTION
Allows to use a most recent SDK 5.x version.

Fix #265 