### PR TITLE
Reduce warnings for XML comments

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,11 +12,13 @@
         <Nullable>enable</Nullable>
         <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <WarningsNotAsErrors>162,612,618,1591</WarningsNotAsErrors>
+        <NoWarn>1591</NoWarn>
+        <WarningsNotAsErrors>162,612,618</WarningsNotAsErrors>
         <!--
             CS0162: Unreachable code detected
             CS0612: '...' is obsolete
             CS0618: '...' is obsolete: "..."
+            CS1591: Missing XML comment for publicly visible type or member '...'
         -->
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Although most warnings are treated as errors, never warn for CS1591 ("Missing XML comment..."). XML comments are included where applicable, but we simply do not require them everywhere this warning would be enforced, and can reduce noise in the build output so that other warnings stand out.