### PR TITLE
Enhance Fatal Error Communication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,11 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.408'
+        dotnet-version: '6.0.401'
     - name: Build and Test
+      env:
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
+        TERM: xterm
       run: pwsh ./build.ps1 --pack
     - name: Release to MyGet
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,8 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.401'
+        dotnet-version: '5.0.408'
     - name: Build and Test
-      env:
-        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: true
-        TERM: xterm
       run: pwsh ./build.ps1 --pack
     - name: Release to MyGet
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100'
+        dotnet-version: '5.0.408'
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to MyGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.100'
+        dotnet-version: '5.0.408'
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to NuGet

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-      "version": "5.0.100",
+      "version": "5.0.408",
       "rollForward": "latestMinor"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-      "version": "5.0.408",
+      "version": "6.0.401",
       "rollForward": "latestMinor"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-      "version": "6.0.401",
+      "version": "5.0.408",
       "rollForward": "latestMinor"
     }
 }

--- a/src/Fixie.Tests/TestProject.cs
+++ b/src/Fixie.Tests/TestProject.cs
@@ -1,27 +1,11 @@
 ﻿namespace Fixie.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-
-    class BrokenDiscovery : IDiscovery
-    {
-        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-            => concreteClasses.Where(x => false);
-
-        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-            => publicMethods.Where(x => false);
-    }
-
     class TestProject : ITestProject
     {
         public void Configure(TestConfiguration configuration, TestEnvironment environment)
         {
             if (environment.IsDevelopment())
                 configuration.Reports.Add<DiffToolReport>();
-
-            configuration.Conventions.Add<BrokenDiscovery, DefaultExecution>();
         }
     }
 }

--- a/src/Fixie.Tests/TestProject.cs
+++ b/src/Fixie.Tests/TestProject.cs
@@ -1,11 +1,27 @@
 ﻿namespace Fixie.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    class BrokenDiscovery : IDiscovery
+    {
+        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
+            => concreteClasses.Where(x => false);
+
+        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => publicMethods.Where(x => false);
+    }
+
     class TestProject : ITestProject
     {
         public void Configure(TestConfiguration configuration, TestEnvironment environment)
         {
             if (environment.IsDevelopment())
                 configuration.Reports.Add<DiffToolReport>();
+
+            configuration.Conventions.Add<BrokenDiscovery, DefaultExecution>();
         }
     }
 }

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -99,6 +99,11 @@
             if (message.Total == 0)
                 return "No tests found.";
 
+            return Summarize(message);
+        }
+
+        static string Summarize(ExecutionCompleted message)
+        {
             var parts = new List<string>();
 
             if (message.Passed > 0)

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -88,13 +88,13 @@
 
         public Task Handle(ExecutionCompleted message)
         {
-            console.WriteLine(Summarize(message));
+            console.WriteLine(DeprecatedSummarize(message));
             console.WriteLine();
 
             return Task.CompletedTask;
         }
 
-        static string Summarize(ExecutionCompleted message)
+        static string DeprecatedSummarize(ExecutionCompleted message)
         {
             if (message.Total == 0)
                 return "No tests found.";

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -88,18 +88,21 @@
 
         public Task Handle(ExecutionCompleted message)
         {
-            console.WriteLine(DeprecatedSummarize(message));
+            string? summary;
+            
+            if (message.Total == 0)
+            {
+                summary = "No tests found.";
+            }
+            else
+            {
+                summary = Summarize(message);
+            }
+
+            console.WriteLine(summary);
             console.WriteLine();
 
             return Task.CompletedTask;
-        }
-
-        static string DeprecatedSummarize(ExecutionCompleted message)
-        {
-            if (message.Total == 0)
-                return "No tests found.";
-
-            return Summarize(message);
         }
 
         static string Summarize(ExecutionCompleted message)

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -88,18 +88,23 @@
 
         public Task Handle(ExecutionCompleted message)
         {
-            string? summary;
-            
             if (message.Total == 0)
             {
+                string? summary;
+
                 summary = "No tests found.";
+                
+                console.WriteLine(summary);
             }
             else
             {
+                string? summary;
+
                 summary = Summarize(message);
+
+                console.WriteLine(summary);
             }
 
-            console.WriteLine(summary);
             console.WriteLine();
 
             return Task.CompletedTask;

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -90,7 +90,8 @@
         {
             if (message.Total == 0)
             {
-                console.WriteLine("No tests found.");
+                using (Foreground.Red)
+                    console.WriteLine("No tests found.");
             }
             else
             {

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -90,19 +90,11 @@
         {
             if (message.Total == 0)
             {
-                string? summary;
-
-                summary = "No tests found.";
-                
-                console.WriteLine(summary);
+                console.WriteLine("No tests found.");
             }
             else
             {
-                string? summary;
-
-                summary = Summarize(message);
-
-                console.WriteLine(summary);
+                console.WriteLine(Summarize(message));
             }
 
             console.WriteLine();


### PR DESCRIPTION
In the event that no tests are found, either by failing to meet the Discovery convention in effect, or by poorly implementing a custom Discovery convention such that no tests are found, Fixie already outputs a clear explanation and returns a fatal exit code so that the build will fail. This PR improves the user's ability to scan and diagnose that problem when looking at their build output.