### PR TITLE
DiffEngine reporting

### DIFF
--- a/src/Fixie.Tests/DiffToolReport.cs
+++ b/src/Fixie.Tests/DiffToolReport.cs
@@ -1,16 +1,13 @@
 ﻿namespace Fixie.Tests
 {
     using System;
-    using System.Diagnostics;
     using System.IO;
-    using System.Linq;
     using System.Threading.Tasks;
     using Assertions;
     using Fixie.Reports;
-    using static System.Environment;
-    using static Fixie.Internal.Maybe;
+    using DiffEngine;
 
-    public class DiffToolReport : IHandler<TestFailed>, IHandler<ExecutionCompleted>
+    class DiffToolReport : IHandler<TestFailed>, IHandler<ExecutionCompleted>
     {
         int failures;
         Exception? singleFailure;
@@ -24,48 +21,23 @@
             return Task.CompletedTask;
         }
 
-        public Task Handle(ExecutionCompleted message)
+        public async Task Handle(ExecutionCompleted message)
         {
             if (singleFailure is AssertException exception)
                 if (!exception.HasCompactRepresentations)
-                    LaunchDiffTool(exception);
-
-            return Task.CompletedTask;
+                    await LaunchDiffTool(exception);
         }
 
-        static void LaunchDiffTool(AssertException exception)
+        static async Task LaunchDiffTool(AssertException exception)
         {
             var tempPath = Path.GetTempPath();
             var expectedPath = Path.Combine(tempPath, "expected.txt");
             var actualPath = Path.Combine(tempPath, "actual.txt");
 
-            if (Try(() => DiffCommand(expectedPath, actualPath), out var diffCommand))
-            {
-                File.WriteAllText(expectedPath, exception.Expected);
-                File.WriteAllText(actualPath, exception.Actual);
+            File.WriteAllText(expectedPath, exception.Expected);
+            File.WriteAllText(actualPath, exception.Actual);
 
-                using (Process.Start("cmd", $"/c \"{diffCommand}\""))  {  }
-            }
-        }
-
-        static string? DiffCommand(string expectedPath, string actualPath)
-        {
-            var gitconfig = Path.Combine(GetFolderPath(SpecialFolder.UserProfile), ".gitconfig");
-
-            if (!File.Exists(gitconfig))
-                return null;
-
-            return File.ReadAllLines(gitconfig)
-                .SkipWhile(x => !x.StartsWith("[difftool "))
-                .Skip(1)
-                .TakeWhile(x => !x.StartsWith("["))
-                .Select(x => x.Split(new[] {'='}, 2))
-                .Where(x => x[0].Trim() == "cmd")
-                .Select(x => x[1].Trim()
-                    .Replace("\\\"", "\"")
-                    .Replace("$LOCAL", expectedPath)
-                    .Replace("$REMOTE", actualPath))
-                .SingleOrDefault();
+            await DiffRunner.LaunchAsync(expectedPath, actualPath);
         }
     }
 }

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+	  <PackageReference Include="DiffEngine" Version="10.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Fixie.Console\Fixie.Console.csproj" />
     <ProjectReference Include="..\Fixie.TestAdapter\Fixie.TestAdapter.csproj" />
     <ProjectReference Include="..\Fixie\Fixie.csproj" />


### PR DESCRIPTION
This does not affect end users, but does improve upon the recommended pattern of using diff tools for development-time test failure reporting.

Instead of relying on brittle inspection of git config in order to infer the developer's diff tool of choice, we now delegate to the superior DiffEngine library.