### PR TITLE
Build with dotnet SDK 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.408'
+        dotnet-version: |
+          5.0.408
+          6.0.401
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to MyGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.408'
+        dotnet-version: |
+          5.0.408
+          6.0.401
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to NuGet

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-      "version": "5.0.408",
+      "version": "6.0.401",
       "rollForward": "latestMinor"
     }
 }

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>embedded</DebugType>
-    <RollForward>Major</RollForward>
+    <!-- <RollForward>Major</RollForward> -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updating the SDK version used to build the solution, as a precursor to actually targeting net6.0 and to avoid using the now out-of-support SDK 5.
- Precisely NOT updating TargetFramework(s) as that is a distinct concept, especially for Fixie, with much larger ramifications.