### PR TITLE
Build with dotnet SDK 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: .NET SDK
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           3.1
           6.0
     - name: Build and Test
+      env:
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 'true'
+        TERM: 'xterm'
       run: pwsh ./build.ps1 --pack
     - name: Release to MyGet
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         dotnet-version: |
           3.1
-          5.0
+          6.0
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to MyGet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.408'
+        dotnet-version: |
+          3.1.423
+          5.0.408
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to MyGet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-          3.1.423
-          5.0.408
+          3.1
+          5.0
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to MyGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ jobs:
     - name: .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.408'
+        dotnet-version: |
+          3.1.423
+          5.0.408
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to NuGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: .NET SDK
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         dotnet-version: |
           3.1
-          5.0
+          6.0
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to NuGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-          3.1.423
-          5.0.408
+          3.1
+          5.0
     - name: Build and Test
       run: pwsh ./build.ps1 --pack
     - name: Release to NuGet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
           3.1
           6.0
     - name: Build and Test
+      env:
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 'true'
+        TERM: 'xterm'
       run: pwsh ./build.ps1 --pack
     - name: Release to NuGet
       env:

--- a/build.ps1
+++ b/build.ps1
@@ -12,6 +12,7 @@ $fixie = "src/Fixie.Console/bin/Release/netcoreapp3.1/Fixie.Console.dll"
 
 if (test-path artifacts) { remove-item artifacts -Recurse }
 
+step { dotnet --version }
 step { dotnet clean src -c Release --nologo -v minimal }
 step { dotnet build src -c Release --nologo }
 step { dotnet $fixie *.Tests -c Release --no-build }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-﻿{
-    "sdk": {
-      "version": "5.0.408",
-      "rollForward": "latestMinor"
-    }
-}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,6 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/fixie/fixie</RepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
-        <LangVersion>8.0</LangVersion>
         <Nullable>enable</Nullable>
         <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>embedded</DebugType>
-    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This revises the handling of SDK versions used at development time as well as the TargetFramework behavior at self-testing execution time.

This uses the latest net6.0 SDK for builds, but precisely does NOT update any TargetFramework to use net6.0 at runtime as that is a distinct concept especially for Fixie, with much larger ramifications in the implementation, nuget packaging, supported targets for consumers, and the roadmap in general.

In short, this dramatically improves the CI/CD approach so that we have fewer places to update as we adopt and drop TargetFrameworks over time.

Details:

1. Avoid specifying LangVersion explicitly, as the default behavior ensures using the latest language version compatible with each target framework indicated in csproj files, so that we no longer need to update the language version when we update target frameworks.
2. The build script outputs the `dotnet --version` in effect, useful when troubleshooting unexpected behavior across build environments.
3. Remove global.json, so that we no longer pin the dotnet SDK for development-time concerns. This pinning capability is meant to be used only as-needed, and avoiding it is encouraged so that developers can leverage the latest development tools available. The SDK is meant to be backward compatible with older target frameworks. Note that the solution's TargetFramework selections do still strictly dictate versions pertaining to execution-time concerns.
4. The Fixie.Tests project no longer incorrectly uses the RollForward capability. This was included by mistake at the same time that RollForward was applied to Fixie.Console. It is appropriate to Fixie.Console because that defines a `dotnet` global tool, which needs to balance having a single build against the lowest supported target framework while also being "polite" in environments that lack that minimum supported version of the SDK. Fixie.Console deliberately uses a minimal and stable subset of the framework, so is considered safe enough to leverage RollForward. For Fixie.Tests, though, RollForward was hiding potential behavior differences across possible supported target frameworks, and could provoke surprising differences in behavior from one development environment to the next (e.g. local vs GitHub Actions).
5. The GitHub Actions build environment includes SDK 3.1 because we have netcoreapp3.1 as a TargetFramework and any supported TargetFramework should be present at run time. This does conceal proof that Fixie.Console's RollForward behavior works, but that should be confirmed separately in a controlled consumer environment.
6. The GitHub Actions build environment uses the latest patch version of each listed SDK Major.Minor version, ensuring that new builds leverage the latest available fixes.
7. Update actions/checkout and actions/setup-dotnet to v3.
8. Replace dotnet SDK 5.0 with 6.0 in the GitHub Actions build environment, since 5.0 is no longer supported by Microsoft and because the Fixie solution does not explicitly target it.
9. Allow `dotnet fixie` console colors to render in GitHub Actions logs (such colors can only pass through when executing on TargetFramework net6.0 or higher).