### PR TITLE
Upgrade MinVer in preparation for including target framework net6.0

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -19,8 +19,5 @@ step { dotnet $fixie *.Tests -c Release --no-build }
 if ($pack) {
     step { dotnet pack src/Fixie -o artifacts -c Release --no-build --nologo }
     step { dotnet pack src/Fixie.Console -o artifacts -c Release --no-build --nologo }
-
-    # While Fixie.TestAdapter packs with a nuspec file, we cannot include --no-build here.
-    # If we did, the MinVer-calculated version would fail to apply to the package.
-    step { dotnet pack src/Fixie.TestAdapter -o artifacts -c Release --nologo }
+    step { dotnet pack src/Fixie.TestAdapter -o artifacts -c Release --no-build --nologo }
 }

--- a/src/Fixie.Console/Fixie.Console.csproj
+++ b/src/Fixie.Console/Fixie.Console.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.3.0">
+    <PackageReference Include="MinVer" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <DebugType>embedded</DebugType>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -21,9 +21,9 @@
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MinVer" Version="2.3.0">
+    <PackageReference Include="MinVer" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.3.0">
+    <PackageReference Include="MinVer" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
While experimenting with mult-targeting the Fixie.TestAdapter project, a bug in our old MinVer reference appeared which prevented that package from getting an appropriate version number. Thankfully a simple upgrade of MinVer addresses the issue. Additionally, the newer version of MinVer no longer requires an additional workaround in our build script, so we can simplify all `dotnet pack` lines to be alike.

Steps Taken:

1. Reveal a bug in version numbering by pluralizing `TargetFramework` to `TargetFrameworks` within Fixie.TestAdapter:

   Unlike typical projects, Fixie.TestAdapter is packaged with the combination of `dotnet pack` and a manual `*.nuspec` file. Although that is generally supported, the moment we pluralize to `TargetFrameworks` MinVer fails to pick up on the intended version and we end up with the incorrect package `Fixie.TestAdapter.1.0.0.nupkg`.

2. Fix the ability to version the Fixie.TestAdapter package, by upgrading MinVer:

   Changes to `IncludeAssets` come from following the https://www.nuget.org/packages/MinVer/ installation guidance exactly.

3. Simplify build script now that MinVer can successfully infer the `Fixie.TestAdapter` version number correctly during a `dotnet pack` with `--no-build` specified.