### PR TITLE
Add target framework net6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         dotnet-version: |
           3.1
+          6.0
     - run: dotnet --info
     - name: Build and Test
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       with:
         dotnet-version: |
           3.1
+          6.0
     - run: dotnet --info
     - name: Build and Test
       env:

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+	<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <DebugType>embedded</DebugType>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -18,6 +18,11 @@
         <dependency id="Mono.Cecil" version="0.11.3" />
         <dependency id="Microsoft.NET.Test.Sdk" version="16.10.0" />
       </group>
+	  <group targetFramework="net6.0">
+	    <dependency id="Fixie" version="[$version$]" />
+	    <dependency id="Mono.Cecil" version="0.11.3" />
+	    <dependency id="Microsoft.NET.Test.Sdk" version="16.10.0" />
+	  </group>
     </dependencies>
   </metadata>
   <files>
@@ -26,5 +31,6 @@
 
     <!-- Run-Time Assets -->
     <file target="lib\netcoreapp3.1" src="..\Fixie.TestAdapter\bin\Release\netcoreapp3.1\Fixie.TestAdapter.dll" />
+    <file target="lib\net6.0" src="..\Fixie.TestAdapter\bin\Release\net6.0\Fixie.TestAdapter.dll" />
   </files>
 </package>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Fixie.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -32,7 +32,7 @@
             foreach (var result in results)
             {
                 result.TestFramework.ShouldBe("Fixie");
-                result.FileName.ShouldBe("Fixie.Tests (.NETCoreApp,Version=v3.1)");
+                result.FileName.ShouldBe($"Fixie.Tests (.NETCoreApp,Version=v{TargetFrameworkVersion})");
             }
 
             var fail = results[0];

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -7,6 +7,7 @@
     using System.Threading.Tasks;
     using Assertions;
     using Fixie.Reports;
+    using static Utility;
     using static Fixie.Internal.Serialization;
 
     public class AzureReportTests : MessagingTests
@@ -77,7 +78,7 @@
             firstRequest.Uri.ShouldBe($"http://localhost:4567/{project}/_apis/test/runs?api-version=5.0");
 
             var createRun = firstRequest.Content;
-            createRun.name.ShouldBe("Fixie.Tests (.NETCoreApp,Version=v3.1)");
+            createRun.name.ShouldBe($"Fixie.Tests (.NETCoreApp,Version=v{TargetFrameworkVersion})");
             createRun.build.id.ShouldBe(buildId);
             createRun.isAutomated.ShouldBe(true);
 

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -40,6 +40,7 @@
                 actualHeader.MediaType.ShouldBe("application/json");
 
                 var actualAuthorization = client.DefaultRequestHeaders.Authorization;
+                actualAuthorization.ShouldNotBeNull();
                 actualAuthorization.Scheme.ShouldBe("Bearer");
                 actualAuthorization.Parameter.ShouldBe(accessToken);
             };

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -3,8 +3,6 @@
     using System;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
-    using System.Runtime.Versioning;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using System.Xml.Linq;
@@ -48,7 +46,7 @@
             cleaned = Regex.Replace(cleaned, @"run-time=""\d\d:\d\d:\d\d""", @"run-time=""HH:MM:SS""");
 
             //Avoid brittle assertion introduced by .NET version.
-            cleaned = cleaned.Replace($@"environment=""{IntPtr.Size * 8}-bit {TargetFramework}""", @"environment=""00-bit .NETCoreApp,Version=vX.Y""");
+            cleaned = cleaned.Replace($@"environment=""{IntPtr.Size * 8}-bit .NETCoreApp,Version=v{TargetFrameworkVersion}""", @"environment=""00-bit .NETCoreApp,Version=vX.Y""");
 
             //Avoid brittle assertion introduced by fixie version.
             cleaned = cleaned.Replace($@"test-framework=""{Fixie.Internal.Framework.Version}""", @"test-framework=""Fixie 1.2.3.4""");
@@ -75,8 +73,5 @@
                                 .Replace("[genericTestClassForStackTrace]", GenericTestClass.Replace("+", "."));
             }
         }
-
-        static string? TargetFramework
-            => typeof(XmlReportTests).Assembly.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
     }
 }

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -20,6 +20,9 @@
                     "",
                     "Fixie.Tests.FailureException",
                     At<ConstructionFailureTestClass>(".ctor()"),
+                    #if !NETCOREAPP3_1
+                    "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
+                    #endif
                     "",
                     "1 failed, took 1.23 seconds");
         }
@@ -34,6 +37,9 @@
                     "",
                     "Fixie.Tests.FailureException",
                     At<ConstructionFailureTestClass>(".ctor()"),
+                    #if !NETCOREAPP3_1
+                    "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
+                    #endif
                     "--- End of stack trace from previous location where exception was thrown ---",
                     At(typeof(TestClass), "Construct(Object[] parameters)", Path.Join("...", "src", "Fixie", "TestClass.cs")),
                     At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -354,10 +354,18 @@ namespace Fixie.Tests
         {
             var output = await Run<CannotInvokeConstructorTestClass, DefaultExecution>();
 
+#if NETCOREAPP3_1
             output.ShouldHaveResults(
                 "CannotInvokeConstructorTestClass.UnreachableCase failed: " +
                 "No parameterless constructor defined " +
                 $"for type '{FullName<CannotInvokeConstructorTestClass>()}'.");
+#else
+            output.ShouldHaveResults(
+                "CannotInvokeConstructorTestClass.UnreachableCase failed: " +
+                "Cannot dynamically create an instance " +
+                $"of type '{FullName<CannotInvokeConstructorTestClass>()}'. " +
+                "Reason: No parameterless constructor defined.");
+#endif
 
             output.ShouldHaveLifecycle();
         }

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -21,6 +21,18 @@
                 Directory.GetCurrentDirectory());
         }
 
+        public static string TargetFrameworkVersion
+        {
+            get
+            {
+#if NETCOREAPP3_1
+                return "3.1";
+#elif NET6_0
+                return "6.0";
+#endif
+            }
+        }
+
         public static string FullName<T>()
         {
             return typeof(T).FullName ??

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Description>Ergonomic Testing for .NET</Description>
     <DebugType>embedded</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Fixie/Internal/Serialization.cs
+++ b/src/Fixie/Internal/Serialization.cs
@@ -16,6 +16,6 @@
             => Deserialize<TMessage>(Encoding.UTF8.GetBytes(message));
 
         public static TMessage Deserialize<TMessage>(byte[] bytes)
-            => JsonSerializer.Deserialize<TMessage>(new ReadOnlySpan<byte>(bytes));
+            => JsonSerializer.Deserialize<TMessage>(new ReadOnlySpan<byte>(bytes))!;
     }
 }


### PR DESCRIPTION
As follow-up to #287 (Build with dotnet SDK 6), this officially includes target framework net6.0.

Prior to this, Fixie did already *work* with net6.0 consumer solutions, but adding the target does ensure that we're fully leveraging net6.0 when possible, and ensures that our own test coverage truly reveals any behavior changes between netcoreapp3.1 and net6.0.

Note that we did miss ever explicitly targeting net5.0. That was less than ideal in hindsight, but since it has already left the Microsoft support window we're skipping it intentionally.

This PR was kept focused to the minimal and ordered steps necessary to add a target framework, so that when we soon add net7.0 we'll have a clear model to follow. The lessons learned are now also documented at [Contributing to Fixie](https://github.com/fixie/fixie/wiki/Contributing-to-Fixie) since there are several gotchas to work through.
