### PR TITLE
The GitHubReport provides a short color-coded "Job Summary"

### DIFF
--- a/src/Fixie.Tests/GitHubReport.cs
+++ b/src/Fixie.Tests/GitHubReport.cs
@@ -1,0 +1,69 @@
+﻿namespace Fixie.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Fixie.Reports;
+    using static System.Environment;
+
+    class GitHubReport :
+        IHandler<ExecutionStarted>,
+        IHandler<ExecutionCompleted>
+    {
+        readonly TestEnvironment environment;
+
+        public GitHubReport(TestEnvironment environment)
+            => this.environment = environment;
+
+        public async Task Handle(ExecutionStarted message)
+        {
+            var assembly = Path.GetFileNameWithoutExtension(environment.Assembly.Location);
+            var framework = environment.TargetFramework;
+
+            await AppendToJobSummary($"## {assembly} ({framework}){NewLine}{NewLine}");
+        }
+
+        public async Task Handle(ExecutionCompleted message)
+        {
+            string severity;
+            string detail;
+
+            if (message.Total == 0)
+            {
+                severity = "red";
+                detail = "No tests found.";
+            }
+            else
+            {
+                severity = "green";
+
+                var parts = new List<string>();
+
+                if (message.Passed > 0)
+                    parts.Add($"{message.Passed} passed");
+
+                if (message.Skipped > 0)
+                {
+                    severity = "yellow";
+                    parts.Add($"{message.Skipped} skipped");
+                }
+
+                if (message.Failed > 0)
+                {
+                    severity = "red";
+                    parts.Add($"{message.Failed} failed");
+                }
+
+                detail = string.Join(", ", parts);
+            }
+
+            await AppendToJobSummary($":{severity}_circle: {detail}{NewLine}{NewLine}");
+        }
+
+        static async Task AppendToJobSummary(string summary)
+        {
+            if (GetEnvironmentVariable("GITHUB_STEP_SUMMARY") is string summaryFile)
+                await File.AppendAllTextAsync(summaryFile, summary);
+        }
+    }
+}

--- a/src/Fixie.Tests/TestProject.cs
+++ b/src/Fixie.Tests/TestProject.cs
@@ -6,6 +6,8 @@
         {
             if (environment.IsDevelopment())
                 configuration.Reports.Add<DiffToolReport>();
+            else
+                configuration.Reports.Add(new GitHubReport(environment));
         }
     }
 }


### PR DESCRIPTION
The GitHubReport provides a short color-coded ["Job Summary"](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) so that developers can quickly inspect their completed job without having to look into the step logs.

Sample output for a solution mult-targeting different frameworks:



## Example.Tests (.NETCoreApp,Version=v7.0)
🔴 No tests found.

## Example.Tests (.NETCoreApp,Version=v6.0)
🟢 140 passed

## Example.Tests (.NETCoreApp,Version=v5.0)
🟡 139 passed, 1 skipped

## Example.Tests (.NETCoreApp,Version=v3.1)
🔴 138 passed, 1 skipped, 1 failed