### PR TITLE
Add target framework net7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         dotnet-version: |
           3.1
           6.0
+          7.0
     - run: dotnet --info
     - name: Build and Test
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         dotnet-version: |
           3.1
           6.0
+          7.0
     - run: dotnet --info
     - name: Build and Test
       env:

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <DebugType>embedded</DebugType>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -23,6 +23,11 @@
 	    <dependency id="Mono.Cecil" version="0.11.3" />
 	    <dependency id="Microsoft.NET.Test.Sdk" version="16.10.0" />
 	  </group>
+      <group targetFramework="net7.0">
+        <dependency id="Fixie" version="[$version$]" />
+        <dependency id="Mono.Cecil" version="0.11.3" />
+        <dependency id="Microsoft.NET.Test.Sdk" version="16.10.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -32,5 +37,6 @@
     <!-- Run-Time Assets -->
     <file target="lib\netcoreapp3.1" src="..\Fixie.TestAdapter\bin\Release\netcoreapp3.1\Fixie.TestAdapter.dll" />
     <file target="lib\net6.0" src="..\Fixie.TestAdapter\bin\Release\net6.0\Fixie.TestAdapter.dll" />
+    <file target="lib\net7.0" src="..\Fixie.TestAdapter\bin\Release\net7.0\Fixie.TestAdapter.dll" />
   </files>
 </package>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Fixie.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Threading.Tasks;
     using Assertions;
     using Fixie.Reports;
@@ -70,7 +71,14 @@
 
         public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestMethodInvocationFailures()
         {
-            (await Run<FailureTestClass, ExplicitExceptionHandling>())
+            var output = (await Run<FailureTestClass, ExplicitExceptionHandling>()).ToArray();
+
+            #if NET7_0_OR_GREATER
+            const string optimizedInvoker = "   at InvokeStub_FailureTestClass.Synchronous(Object, Object, IntPtr*)";
+            const string initialInvoker = "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
+            #endif
+
+            output
                 .ShouldBe(
                     "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
                     "",
@@ -88,6 +96,12 @@
                     "",
                     "Fixie.Tests.FailureException",
                     At<FailureTestClass>("Synchronous()"),
+                    #if NET7_0_OR_GREATER
+                    output.Contains(optimizedInvoker)
+                        ? optimizedInvoker
+                        : initialInvoker,
+                    "   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)",
+                    #endif
                     "--- End of stack trace from previous location where exception was thrown ---",
                     At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
                     At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -29,6 +29,8 @@
                 return "3.1";
 #elif NET6_0
                 return "6.0";
+#elif NET7_0
+                return "7.0";
 #endif
             }
         }

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <Description>Ergonomic Testing for .NET</Description>
     <DebugType>embedded</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This adds target framework `net7.0` where appropriate:

* Ensure that the GitHub Actions build environment includes the .NET 7 SDK.
* Add target framework `net7.0` to the `Fixie`, `Fixie.TestAdapter`, and `Fixie.Tests` projects.
* Mirror `Fixie.TestAdapter` csproj changes in the corresponding nuspec.
* Deliberately leave the `Fixie.Console` project targeting our support window lower bound of `netcoreapp3.1`. As a `dotnet ...` tool definition, we target low and already compensate for that with `RollForward` behavior.
* Address all test failures that appeared while running on `net7.0`.

The primary novel change accounted for here on `net7.0` runs comes in the method that cleans up a test failure stack trace for presentation. Here, we aim to present a stack trace where execution apparently begins in the test method itself, omitting surrounding test runner and method invocation noise leading up to the invocation of the test method. The implementation tends to need attention with each .NET release, and this time the change in .NET behavior comes in its new optimizations within `MethodBase.Invoke` as described here: https://devblogs.microsoft.com/dotnet/performance_improvements_in_net_7/#reflection .  In short, we can seek and omit a few additional stack trace lines which represent the new reflection emit logic.