### PR TITLE
Enable "Artifacts Output Layout".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /src/.vs/
 /src/artifacts/
-/artifacts/
+/packages/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /src/.vs/
-/src/**/bin/
-/src/**/obj/
+/src/artifacts/
 /artifacts/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Fixie.Tests/bin/Debug/netcoreapp3.1/Fixie.Tests.dll",
+            "program": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug_netcoreapp3.1/Fixie.Tests.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/src/Fixie.Tests",
+            "cwd": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug_netcoreapp3.1",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
             "stopAtEntry": false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,7 +27,7 @@
             "command": "dotnet",
             "type": "process",
             "args": [
-                "${workspaceFolder}/src/Fixie.Console/bin/Release/netcoreapp3.1/Fixie.Console.dll",
+                "${workspaceFolder}/src/artifacts/bin/Fixie.Console/release/Fixie.Console.dll",
                 "*.Tests",
                 "--no-build"
             ],
@@ -52,7 +52,7 @@
                 "--project",
                 "${workspaceFolder}/src/Fixie.Tests/Fixie.Tests.csproj",
 
-                "${workspaceFolder}/src/Fixie.Console/bin/Release/netcoreapp3.1/Fixie.Console.dll",
+                "${workspaceFolder}/src/artifacts/bin/Fixie.Console/release/Fixie.Console.dll",
                 "*.Tests"
             ],
             "isBackground": true,

--- a/build.ps1
+++ b/build.ps1
@@ -10,14 +10,14 @@ function step($command) {
 
 $fixie = "src/artifacts/bin/Fixie.Console/release/Fixie.Console.dll"
 
-if (test-path artifacts) { remove-item artifacts -Recurse }
+if (test-path packages) { remove-item packages -Recurse }
 
 step { dotnet clean src -c Release --nologo -v minimal }
 step { dotnet build src -c Release --nologo }
 step { dotnet $fixie *.Tests -c Release --no-build }
 
 if ($pack) {
-    step { dotnet pack src/Fixie -o artifacts -c Release --no-build --nologo }
-    step { dotnet pack src/Fixie.Console -o artifacts -c Release --no-build --nologo }
-    step { dotnet pack src/Fixie.TestAdapter -o artifacts -c Release --no-build --nologo }
+    step { dotnet pack src/Fixie -o packages -c Release --no-build --nologo }
+    step { dotnet pack src/Fixie.Console -o packages -c Release --no-build --nologo }
+    step { dotnet pack src/Fixie.TestAdapter -o packages -c Release --no-build --nologo }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,7 @@ function step($command) {
     if ($lastexitcode -ne 0) { throw $lastexitcode }
 }
 
-$fixie = "src/Fixie.Console/bin/Release/netcoreapp3.1/Fixie.Console.dll"
+$fixie = "src/artifacts/bin/Fixie.Console/release/Fixie.Console.dll"
 
 if (test-path artifacts) { remove-item artifacts -Recurse }
 

--- a/release.ps1
+++ b/release.ps1
@@ -1,4 +1,4 @@
-﻿$packages = get-childitem artifacts/*.nupkg | where-object {!$_.Name.EndsWith(".symbols.nupkg")}
+﻿$packages = get-childitem packages/*.nupkg | where-object {!$_.Name.EndsWith(".symbols.nupkg")}
 
 foreach ($package in $packages) {
     dotnet nuget push $package --source $env:PACKAGE_URL --api-key $env:PACKAGE_API_KEY

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
         <RepositoryUrl>https://github.com/fixie/fixie</RepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <Nullable>enable</Nullable>
+        <UseArtifactsOutput>true</UseArtifactsOutput>
         <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>1591</NoWarn>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -42,9 +42,9 @@
     <file target="icon.png" src="..\..\img\fixie_256.png" />
 
     <!-- Run-Time Assets -->
-    <file target="lib\netcoreapp3.1" src="..\Fixie.TestAdapter\bin\Release\netcoreapp3.1\Fixie.TestAdapter.dll" />
-    <file target="lib\net6.0" src="..\Fixie.TestAdapter\bin\Release\net6.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net7.0" src="..\Fixie.TestAdapter\bin\Release\net7.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net8.0" src="..\Fixie.TestAdapter\bin\Release\net8.0\Fixie.TestAdapter.dll" />
+    <file target="lib\netcoreapp3.1" src="..\artifacts\bin\Fixie.TestAdapter\release_netcoreapp3.1\Fixie.TestAdapter.dll" />
+    <file target="lib\net6.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net6.0\Fixie.TestAdapter.dll" />
+    <file target="lib\net7.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net7.0\Fixie.TestAdapter.dll" />
+    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net8.0\Fixie.TestAdapter.dll" />
   </files>
 </package>


### PR DESCRIPTION
The .NET 8 SDK adds support for "Artifacts Output Layout", which moves the per-project support folders like `bin/` and `obj/` to a common location outside of the project folders, as well as adjusting naming conventions around Configuration (Release, Debug...) and Target Framework Monikers (net8.0, ...).

Although the feature arrives in the .NET 8 SDK, it works for projects that target older frameworks, so this is appropriate even before the upcoming phasing-out of old frameworks.

We enable the feature, simplify `.gitignore`, and visit all hardcoded paths affected by the move.

Additionally, since this creates some ambiguity of purpose between the new `src/artifacts/` folder and our root `artifacts` folder where packages are output during CI builds, we rename that root folder to the more accurate name `packages`.

There was some risk that this feature would thwart old naive assumptions about build output paths with respect to their associated project code folder, but after testing console and IDE runs it appears we were already being defensive about the possibilities of custom OutputPath in any end user solution.