### PR TITLE
Add target framework net8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           3.1
           6.0
           7.0
+          8.0
     - run: dotnet --info
     - name: Build and Test
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           3.1
           6.0
           7.0
+          8.0
     - run: dotnet --info
     - name: Build and Test
       env:

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <DebugType>embedded</DebugType>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -29,6 +29,11 @@
         <dependency id="Mono.Cecil" version="0.11.4" />
         <dependency id="Microsoft.NET.Test.Sdk" version="17.4.0" />
       </group>
+      <group targetFramework="net8.0">
+        <dependency id="Fixie" version="[$version$]" />
+        <dependency id="Mono.Cecil" version="0.11.4" />
+        <dependency id="Microsoft.NET.Test.Sdk" version="17.4.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -40,5 +45,6 @@
     <file target="lib\netcoreapp3.1" src="..\Fixie.TestAdapter\bin\Release\netcoreapp3.1\Fixie.TestAdapter.dll" />
     <file target="lib\net6.0" src="..\Fixie.TestAdapter\bin\Release\net6.0\Fixie.TestAdapter.dll" />
     <file target="lib\net7.0" src="..\Fixie.TestAdapter\bin\Release\net7.0\Fixie.TestAdapter.dll" />
+    <file target="lib\net8.0" src="..\Fixie.TestAdapter\bin\Release\net8.0\Fixie.TestAdapter.dll" />
   </files>
 </package>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Fixie.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -44,7 +44,14 @@
 
             //Ambiguous Match
             Action attemptAmbiguousAttributeLookup = () => typeof(AttributeSample).Has<AmbiguouslyMultipleAttribute>(out _);
-            attemptAmbiguousAttributeLookup.ShouldThrow<AmbiguousMatchException>("Multiple custom attributes of the same type found.");
+            
+            #if NETCOREAPP3_1 || NET6_0 || NET7_0
+            var expectedExceptionMessage = "Multiple custom attributes of the same type found.";
+            #else
+            var expectedExceptionMessage = "Multiple custom attributes of the same type 'Fixie.Tests.ReflectionExtensionsTests+AmbiguouslyMultipleAttribute' found.";
+            #endif
+
+            attemptAmbiguousAttributeLookup.ShouldThrow<AmbiguousMatchException>(expectedExceptionMessage);
         }
 
         void ReturnsVoid() { }

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -96,11 +96,17 @@
                     "",
                     "Fixie.Tests.FailureException",
                     At<FailureTestClass>("Synchronous()"),
-                    #if NET7_0_OR_GREATER
+                    #if NET7_0
                     output.Contains(optimizedInvoker)
                         ? optimizedInvoker
                         : initialInvoker,
                     "   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)",
+                    #endif
+                    #if NET8_0_OR_GREATER
+                    output.Contains(optimizedInvoker)
+                        ? optimizedInvoker
+                        : initialInvoker,
+                    "   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)",
                     #endif
                     "--- End of stack trace from previous location where exception was thrown ---",
                     At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -30,6 +30,8 @@
                 return "6.0";
 #elif NET7_0
                 return "7.0";
+#elif NET8_0
+                return "8.0";
 #endif
             }
         }

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Ergonomic Testing for .NET</Description>
     <DebugType>embedded</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Fixie/Reports/ExceptionExtensions.cs
+++ b/src/Fixie/Reports/ExceptionExtensions.cs
@@ -52,7 +52,13 @@
             {
                 const string subsequentInvoke = " InvokeStub_";
                 const string firstInvoke = " System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
+                
+                #if NETCOREAPP3_1 || NET6_0 || NET7_0
                 const string methodInvoker = " System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)";
+                #else
+                const string methodInvoker = " System.Reflection.MethodBaseInvoker.Invoke";
+                #endif                
+
                 const string synchronousRethrowMarker = "--- End of stack trace from previous location";
                 const string callResolvedMethod = " Fixie.MethodInfoExtensions.CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)";
                 const string constructTestClass = " Fixie.Test.Construct(Type testClass)";


### PR DESCRIPTION
This adds target framework `net8.0` where appropriate:

* Ensure that the GitHub Actions build environment includes the .NET 8 SDK.
* Add target framework `net8.0` to the `Fixie`, `Fixie.TestAdapter`, and `Fixie.Tests` projects.
* Mirror `Fixie.TestAdapter` csproj changes in the corresponding nuspec.
* Deliberately leave the `Fixie.Console` project targeting our support window lower bound of `netcoreapp3.1`. As a `dotnet ...` tool definition, we target low and already compensate for that with `RollForward` behavior.
* Address all test failures that appeared while running on `net8.0`.

The primary novel change accounted for here on `net8.0` runs comes in the method that cleans up a test failure stack trace for presentation. Here, we aim to present a stack trace where execution apparently begins in the test method itself, omitting surrounding test runner and method invocation noise leading up to the invocation of the test method. The implementation tends to need attention with each .NET release, and this time the change in .NET behavior comes in its new optimizations within `MethodBase.Invoke` as described here: https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/#reflection .  In short, there are several code paths that vary based on the optimization strategy selected by the framework, but thankfully we can detect them all by checking for a common substring `"System.Reflection.MethodBaseInvoker.Invoke"`.