### PR TITLE
Simplify Test Adapter Prior to Resiliency Updates

### DIFF
--- a/src/Fixie.TestAdapter/ArgumentNullExceptionShim.cs
+++ b/src/Fixie.TestAdapter/ArgumentNullExceptionShim.cs
@@ -1,0 +1,16 @@
+﻿#if NETCOREAPP3_1
+namespace Fixie.TestAdapter
+{
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.CompilerServices;
+    
+    static class ArgumentNullException
+    {
+        public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        {
+            if (argument is null)
+                throw new System.ArgumentNullException(paramName);
+        }
+    }
+}
+#endif

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -40,7 +40,6 @@ namespace Fixie.TestAdapter
             var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath)!;
 
             var workingDirectory = assemblyDirectory;
-            var executable = "dotnet";
             var arguments = new[] { assemblyPath };
 
             var runningUnderVisualStudio = Environment.GetEnvironmentVariable("VisualStudioVersion") != null;
@@ -62,7 +61,7 @@ namespace Fixie.TestAdapter
                     ["FIXIE_NAMED_PIPE"] = Environment.GetEnvironmentVariable("FIXIE_NAMED_PIPE")
                 };
 
-                var filePath = executable == "dotnet" ? FindDotnet() : executable;
+                var filePath = FindDotnet();
 
                 var serializedArguments = Serialize(arguments);
                 
@@ -79,7 +78,7 @@ namespace Fixie.TestAdapter
             var startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = workingDirectory,
-                FileName = executable,
+                FileName = "dotnet",
                 UseShellExecute = false
             };
 

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -39,10 +39,14 @@ namespace Fixie.TestAdapter
             var assemblyFullPath = Path.GetFullPath(assemblyPath);
             var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath)!;
 
-            return Start(frameworkHandle, assemblyDirectory, "dotnet", assemblyPath);
+            var workingDirectory = assemblyDirectory;
+            var executable = "dotnet";
+            var arguments = new[] { assemblyPath };
+
+            return Start(frameworkHandle, workingDirectory, executable, arguments);
         }
 
-        static Process? Start(IFrameworkHandle? frameworkHandle, string workingDirectory, string executable, params string[] arguments)
+        static Process? Start(IFrameworkHandle? frameworkHandle, string workingDirectory, string executable, string[] arguments)
         {
             var serializedArguments = Serialize(arguments);
 

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -26,20 +26,20 @@ namespace Fixie.TestAdapter
             return File.Exists(Path.Combine(folderPath, "Fixie.dll"));
         }
 
-        public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle = null)
-        {
-            var assemblyFullPath = Path.GetFullPath(assemblyPath);
-            var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath)!;
-
-            return Start(frameworkHandle, assemblyDirectory, "dotnet", assemblyPath);
-        }
-
         public static int? TryGetExitCode(this Process? process)
         {
             if (process != null && process.WaitForExit(5000))
                 return process.ExitCode;
 
             return null;
+        }
+
+        public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle = null)
+        {
+            var assemblyFullPath = Path.GetFullPath(assemblyPath);
+            var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath)!;
+
+            return Start(frameworkHandle, assemblyDirectory, "dotnet", assemblyPath);
         }
 
         static Process? Start(IFrameworkHandle? frameworkHandle, string workingDirectory, string executable, params string[] arguments)

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -47,6 +47,11 @@ namespace Fixie.TestAdapter
             if (Debugger.IsAttached && runningUnderVisualStudio)
                 return Debug(workingDirectory, arguments, frameworkHandle);
 
+            return Run(workingDirectory, arguments);
+        }
+
+        static Process Run(string workingDirectory, string[] arguments)
+        {
             var startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = workingDirectory,

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -21,12 +21,9 @@ namespace Fixie.TestAdapter
             if (fixieAssemblies.Contains(Path.GetFileName(assemblyPath)))
                 return false;
 
-            return File.Exists(Path.Combine(FolderPath(assemblyPath), "Fixie.dll"));
-        }
+            var folderPath = new FileInfo(assemblyPath).Directory!.FullName;
 
-        public static string FolderPath(string assemblyPath)
-        {
-            return new FileInfo(assemblyPath).Directory!.FullName;
+            return File.Exists(Path.Combine(folderPath, "Fixie.dll"));
         }
 
         public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle = null)

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -43,8 +43,6 @@ namespace Fixie.TestAdapter
             var executable = "dotnet";
             var arguments = new[] { assemblyPath };
 
-            var serializedArguments = Serialize(arguments);
-
             var runningUnderVisualStudio = Environment.GetEnvironmentVariable("VisualStudioVersion") != null;
 
             if (Debugger.IsAttached && runningUnderVisualStudio)
@@ -66,6 +64,8 @@ namespace Fixie.TestAdapter
 
                 var filePath = executable == "dotnet" ? FindDotnet() : executable;
 
+                var serializedArguments = Serialize(arguments);
+                
                 frameworkHandle?
                     .LaunchProcessWithDebuggerAttached(
                         filePath,

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -36,10 +36,7 @@ namespace Fixie.TestAdapter
 
         public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle = null)
         {
-            var assemblyFullPath = Path.GetFullPath(assemblyPath);
-            var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath)!;
-
-            var workingDirectory = assemblyDirectory;
+            var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
 
             var runningUnderVisualStudio = Environment.GetEnvironmentVariable("VisualStudioVersion") != null;
 

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -43,11 +43,6 @@ namespace Fixie.TestAdapter
             var executable = "dotnet";
             var arguments = new[] { assemblyPath };
 
-            return Start(frameworkHandle, workingDirectory, executable, arguments);
-        }
-
-        static Process? Start(IFrameworkHandle? frameworkHandle, string workingDirectory, string executable, string[] arguments)
-        {
             var serializedArguments = Serialize(arguments);
 
             var runningUnderVisualStudio = Environment.GetEnvironmentVariable("VisualStudioVersion") != null;

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -40,18 +40,19 @@ namespace Fixie.TestAdapter
             var assemblyDirectory = Path.GetDirectoryName(assemblyFullPath)!;
 
             var workingDirectory = assemblyDirectory;
-            var arguments = new[] { assemblyPath };
 
             var runningUnderVisualStudio = Environment.GetEnvironmentVariable("VisualStudioVersion") != null;
 
             if (Debugger.IsAttached && runningUnderVisualStudio)
-                return Debug(workingDirectory, arguments, frameworkHandle);
+                return Debug(workingDirectory, assemblyPath, frameworkHandle);
 
-            return Run(workingDirectory, arguments);
+            return Run(workingDirectory, assemblyPath);
         }
 
-        static Process Run(string workingDirectory, string[] arguments)
+        static Process Run(string workingDirectory, string assemblyPath)
         {
+            var arguments = new[] { assemblyPath };
+
             var startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = workingDirectory,
@@ -65,7 +66,7 @@ namespace Fixie.TestAdapter
             return Start(startInfo);
         }
 
-        static Process? Debug(string workingDirectory, string[] arguments, IFrameworkHandle? frameworkHandle)
+        static Process? Debug(string workingDirectory, string assemblyPath, IFrameworkHandle? frameworkHandle)
         {
             // LaunchProcessWithDebuggerAttached sends a request back
             // to the third-party test runner process which started
@@ -78,6 +79,8 @@ namespace Fixie.TestAdapter
             // successfully honor the request, we must explicitly
             // pass along new environment variables and resolve the
             // full path for the `dotnet` executable.
+
+            var arguments = new[] { assemblyPath };
 
             var environmentVariables = new Dictionary<string, string?>
             {

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -43,13 +43,13 @@
 
                 HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
 
-                var message = new PipeMessage.ExecuteTests
+                var executeTests = new PipeMessage.ExecuteTests
                 {
                     Filter = new string[] { }
                 };
 
                 foreach (var assemblyPath in sources)
-                    RunTests(log, frameworkHandle, assemblyPath, pipe => pipe.Send(message));
+                    RunTests(log, frameworkHandle, assemblyPath, executeTests);
             }
             catch (Exception exception)
             {
@@ -89,12 +89,12 @@
                 {
                     var assemblyPath = assemblyGroup.Key;
 
-                    var message = new PipeMessage.ExecuteTests
+                    var executeTests = new PipeMessage.ExecuteTests
                     {
                         Filter = assemblyGroup.Select(x => x.FullyQualifiedName).ToArray()
                     };
 
-                    RunTests(log, frameworkHandle, assemblyPath, pipe => pipe.Send(message));
+                    RunTests(log, frameworkHandle, assemblyPath, executeTests);
                 }
             }
             catch (Exception exception)
@@ -105,7 +105,7 @@
 
         public void Cancel() { }
 
-        static void RunTests(IMessageLogger log, IFrameworkHandle frameworkHandle, string assemblyPath, Action<TestAdapterPipe> sendCommand)
+        static void RunTests(IMessageLogger log, IFrameworkHandle frameworkHandle, string assemblyPath, PipeMessage.ExecuteTests executeTests)
         {
             if (!IsTestAssembly(assemblyPath))
             {
@@ -124,7 +124,7 @@
             {
                 pipeStream.WaitForConnection();
 
-                sendCommand(pipe);
+                pipe.Send(executeTests);
 
                 var recorder = new VsExecutionRecorder(frameworkHandle, assemblyPath);
 

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -43,13 +43,13 @@
 
                 HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
 
-                var runAllTests = new PipeMessage.ExecuteTests
+                var message = new PipeMessage.ExecuteTests
                 {
                     Filter = new string[] { }
                 };
 
                 foreach (var assemblyPath in sources)
-                    RunTests(log, frameworkHandle, assemblyPath, pipe => pipe.Send(runAllTests));
+                    RunTests(log, frameworkHandle, assemblyPath, pipe => pipe.Send(message));
             }
             catch (Exception exception)
             {
@@ -89,13 +89,12 @@
                 {
                     var assemblyPath = assemblyGroup.Key;
 
-                    RunTests(log, frameworkHandle, assemblyPath, pipe =>
+                    var message = new PipeMessage.ExecuteTests
                     {
-                        pipe.Send(new PipeMessage.ExecuteTests
-                        {
-                            Filter = assemblyGroup.Select(x => x.FullyQualifiedName).ToArray()
-                        });
-                    });
+                        Filter = assemblyGroup.Select(x => x.FullyQualifiedName).ToArray()
+                    };
+
+                    RunTests(log, frameworkHandle, assemblyPath, pipe => pipe.Send(message));
                 }
             }
             catch (Exception exception)

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -29,14 +29,11 @@
         /// </summary>
         public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
         {
+            ArgumentNullException.ThrowIfNull(sources);
+            ArgumentNullException.ThrowIfNull(frameworkHandle);
+
             try
             {
-                if (sources == null)
-                    throw new ArgumentNullException(nameof(sources));
-
-                if (frameworkHandle == null)
-                    throw new ArgumentNullException(nameof(frameworkHandle));
-
                 IMessageLogger log = frameworkHandle;
 
                 log.Version();
@@ -69,14 +66,11 @@
         /// </summary>
         public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
         {
+            ArgumentNullException.ThrowIfNull(tests);
+            ArgumentNullException.ThrowIfNull(frameworkHandle);
+
             try
             {
-                if (tests == null)
-                    throw new ArgumentNullException(nameof(tests));
-
-                if (frameworkHandle == null)
-                    throw new ArgumentNullException(nameof(frameworkHandle));
-
                 IMessageLogger log = frameworkHandle;
 
                 log.Version();


### PR DESCRIPTION
As a step toward ensuring absolutely-reliable assembly loading during debugger-attached test runs, *even for incomplete third-party runners*, here we simplify the Test Adapter implementation in the area where those resiliency changes are planned.

This is a refactoring in the strict sense of the words. The purpose of doing this in a dedicated Pull Request is to get the behavior-sustaining cleanup reviewed in isolation and to make that upcoming behavior-changing work easier to understand and review independent of these "superficial" changes.