### PR TITLE
Third Party Test Runner Resiliency

### DIFF
--- a/src/Fixie.TestAdapter/DebuggerAttachmentFailure.cs
+++ b/src/Fixie.TestAdapter/DebuggerAttachmentFailure.cs
@@ -1,0 +1,93 @@
+namespace Fixie.TestAdapter
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+
+    class DebuggerAttachmentFailure
+    {
+        public string Message { get; }
+        public Exception ThirdPartyTestHostException { get; }
+
+        public DebuggerAttachmentFailure(Exception thirdPartyTestHostException)
+        {
+            ThirdPartyTestHostException = thirdPartyTestHostException;
+            Message = UserGuidanceMessage(thirdPartyTestHostException);
+        }
+
+        static string UserGuidanceMessage(Exception thirdPartyTestHostException)
+        {
+            var host = TryGetTestHost(out var testHost)
+                ? $"{Environment.NewLine}{testHost}{Environment.NewLine}"
+                : "";
+
+            return $@"Fixie attempted to run your test assembly
+under the active debugger session, but the
+third-party test host {host}failed to honor the request to attach to the
+test assembly process. The run continued
+without the debugger so that this message
+could be reported.
+
+
+In order to debug your test, bypass your
+test runner's unimplemented ""Debug""
+option using one of the following two
+approaches.
+
+If your operating system supports
+Debugger.Launch():
+
+    1. Add the following line at the start
+       of your test:
+
+       System.Diagnostics.Debugger.Launch();
+
+    2. Use your test runner's ""Run"" option
+       to start the test instead of using
+       its unimplemented ""Debug"" option.
+
+    3. Make a selection in the resulting
+       debugger session dialog.
+
+
+If your operating system does not support
+Debugger.Launch():
+
+    1. Note that Fixie test projects are in
+       fact normal console applications that
+       run their own tests.
+
+    2. Instead of using your test runner,
+       run your test project under your
+       development environment's debugger
+       as a normal console application.
+
+
+When filing a bug report to your specific
+third-party test runner's organization,
+please include the following exception
+thrown by their implementation of the VSTest
+API. Test runners are meant to implement
+IFrameworkHandle.LaunchProcessWithDebuggerAttached
+since they have control over the active
+debugger session.
+
+
+{thirdPartyTestHostException.Message}";
+        }
+
+        static bool TryGetTestHost([NotNullWhen(true)] out string? testHost)
+        {
+            try
+            {
+                testHost = Environment.GetCommandLineArgs().First();
+            }
+            catch
+            {
+                testHost = null;
+            }
+
+            return testHost != null;
+        }
+    }
+}

--- a/src/Fixie.TestAdapter/LoggingExtensions.cs
+++ b/src/Fixie.TestAdapter/LoggingExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace Fixie.TestAdapter
 {
+    using System;
     using Internal;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -10,6 +11,9 @@
 
         public static void Error(this IMessageLogger logger, string message)
             => logger.SendMessage(TestMessageLevel.Error, message);
+
+        public static void Error(this IMessageLogger logger, Exception exception)
+            => logger.SendMessage(TestMessageLevel.Error, exception.ToString());
 
         public static void Version(this IMessageLogger logger)
             => logger.Info(Framework.Version);

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -87,14 +87,23 @@ namespace Fixie.TestAdapter
 
             var filePath = FindDotnet();
 
-            frameworkHandle
-                .LaunchProcessWithDebuggerAttached(
-                    filePath,
-                    WorkingDirectory(assemblyPath),
-                    Serialize(arguments),
-                    environmentVariables);
+            try
+            {
+                frameworkHandle
+                    .LaunchProcessWithDebuggerAttached(
+                        filePath,
+                        WorkingDirectory(assemblyPath),
+                        Serialize(arguments),
+                        environmentVariables);
 
-            return null;
+                return null;
+            }
+            catch (Exception exception)
+            {
+                frameworkHandle.Error(exception);
+
+                return Run(assemblyPath);
+            }
         }
 
         static string WorkingDirectory(string assemblyPath)

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -41,11 +41,11 @@ namespace Fixie.TestAdapter
             return Run(workingDirectory, assemblyPath);
         }
 
-        public static Process? StartExecution(string assemblyPath, IFrameworkHandle? frameworkHandle)
+        public static Process? StartExecution(string assemblyPath, IFrameworkHandle frameworkHandle)
         {
             var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
 
-            if (Debugger.IsAttached && frameworkHandle != null)
+            if (Debugger.IsAttached)
                 return Debug(workingDirectory, assemblyPath, frameworkHandle);
 
             return Run(workingDirectory, assemblyPath);

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -36,14 +36,14 @@ namespace Fixie.TestAdapter
 
         public static Process StartDiscovery(string assemblyPath)
         {
-            var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
+            var workingDirectory = WorkingDirectory(assemblyPath);
 
             return Run(workingDirectory, assemblyPath);
         }
 
         public static Process? StartExecution(string assemblyPath, IFrameworkHandle frameworkHandle)
         {
-            var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
+            var workingDirectory = WorkingDirectory(assemblyPath);
 
             if (Debugger.IsAttached)
                 return Debug(workingDirectory, assemblyPath, frameworkHandle);
@@ -99,6 +99,11 @@ namespace Fixie.TestAdapter
                     environmentVariables);
 
             return null;
+        }
+
+        static string WorkingDirectory(string assemblyPath)
+        {
+            return Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
         }
 
         static Process Start(ProcessStartInfo startInfo)

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -36,19 +36,15 @@ namespace Fixie.TestAdapter
 
         public static Process StartDiscovery(string assemblyPath)
         {
-            var workingDirectory = WorkingDirectory(assemblyPath);
-
-            return Run(workingDirectory, assemblyPath);
+            return Run(WorkingDirectory(assemblyPath), assemblyPath);
         }
 
         public static Process? StartExecution(string assemblyPath, IFrameworkHandle frameworkHandle)
         {
-            var workingDirectory = WorkingDirectory(assemblyPath);
-
             if (Debugger.IsAttached)
-                return Debug(workingDirectory, assemblyPath, frameworkHandle);
+                return Debug(WorkingDirectory(assemblyPath), assemblyPath, frameworkHandle);
 
-            return Run(workingDirectory, assemblyPath);
+            return Run(WorkingDirectory(assemblyPath), assemblyPath);
         }
 
         static Process Run(string workingDirectory, string assemblyPath)

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -34,12 +34,9 @@ namespace Fixie.TestAdapter
             return null;
         }
 
-        public static Process? StartDiscovery(string assemblyPath)
+        public static Process StartDiscovery(string assemblyPath)
         {
             var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
-
-            if (Debugger.IsAttached && null != null)
-                return Debug(workingDirectory, assemblyPath, null);
 
             return Run(workingDirectory, assemblyPath);
         }

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -38,7 +38,7 @@ namespace Fixie.TestAdapter
         {
             var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
 
-            if (Debugger.IsAttached)
+            if (Debugger.IsAttached && frameworkHandle != null)
                 return Debug(workingDirectory, assemblyPath, frameworkHandle);
 
             return Run(workingDirectory, assemblyPath);
@@ -61,7 +61,7 @@ namespace Fixie.TestAdapter
             return Start(startInfo);
         }
 
-        static Process? Debug(string workingDirectory, string assemblyPath, IFrameworkHandle? frameworkHandle)
+        static Process? Debug(string workingDirectory, string assemblyPath, IFrameworkHandle frameworkHandle)
         {
             // LaunchProcessWithDebuggerAttached sends a request back
             // to the third-party test runner process which started
@@ -84,7 +84,7 @@ namespace Fixie.TestAdapter
 
             var filePath = FindDotnet();
 
-            frameworkHandle?
+            frameworkHandle
                 .LaunchProcessWithDebuggerAttached(
                     filePath,
                     workingDirectory,

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -34,7 +34,12 @@ namespace Fixie.TestAdapter
             return null;
         }
 
-        public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle = null)
+        public static Process? Start(string assemblyPath)
+        {
+            return Start(assemblyPath, null);
+        }
+
+        public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle)
         {
             var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
 

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -36,7 +36,12 @@ namespace Fixie.TestAdapter
 
         public static Process? StartDiscovery(string assemblyPath)
         {
-            return StartExecution(assemblyPath, null);
+            var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
+
+            if (Debugger.IsAttached && null != null)
+                return Debug(workingDirectory, assemblyPath, null);
+
+            return Run(workingDirectory, assemblyPath);
         }
 
         public static Process? StartExecution(string assemblyPath, IFrameworkHandle? frameworkHandle)

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -38,9 +38,7 @@ namespace Fixie.TestAdapter
         {
             var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
 
-            var runningUnderVisualStudio = Environment.GetEnvironmentVariable("VisualStudioVersion") != null;
-
-            if (Debugger.IsAttached && runningUnderVisualStudio)
+            if (Debugger.IsAttached)
                 return Debug(workingDirectory, assemblyPath, frameworkHandle);
 
             return Run(workingDirectory, assemblyPath);

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -36,24 +36,24 @@ namespace Fixie.TestAdapter
 
         public static Process StartDiscovery(string assemblyPath)
         {
-            return Run(WorkingDirectory(assemblyPath), assemblyPath);
+            return Run(assemblyPath);
         }
 
         public static Process? StartExecution(string assemblyPath, IFrameworkHandle frameworkHandle)
         {
             if (Debugger.IsAttached)
-                return Debug(WorkingDirectory(assemblyPath), assemblyPath, frameworkHandle);
+                return Debug(assemblyPath, frameworkHandle);
 
-            return Run(WorkingDirectory(assemblyPath), assemblyPath);
+            return Run(assemblyPath);
         }
 
-        static Process Run(string workingDirectory, string assemblyPath)
+        static Process Run(string assemblyPath)
         {
             var arguments = new[] { assemblyPath };
 
             var startInfo = new ProcessStartInfo
             {
-                WorkingDirectory = workingDirectory,
+                WorkingDirectory = WorkingDirectory(assemblyPath),
                 FileName = "dotnet",
                 UseShellExecute = false
             };
@@ -64,7 +64,7 @@ namespace Fixie.TestAdapter
             return Start(startInfo);
         }
 
-        static Process? Debug(string workingDirectory, string assemblyPath, IFrameworkHandle frameworkHandle)
+        static Process? Debug(string assemblyPath, IFrameworkHandle frameworkHandle)
         {
             // LaunchProcessWithDebuggerAttached sends a request back
             // to the third-party test runner process which started
@@ -90,7 +90,7 @@ namespace Fixie.TestAdapter
             frameworkHandle
                 .LaunchProcessWithDebuggerAttached(
                     filePath,
-                    workingDirectory,
+                    WorkingDirectory(assemblyPath),
                     Serialize(arguments),
                     environmentVariables);
 

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -34,12 +34,12 @@ namespace Fixie.TestAdapter
             return null;
         }
 
-        public static Process? Start(string assemblyPath)
+        public static Process? StartDiscovery(string assemblyPath)
         {
-            return Start(assemblyPath, null);
+            return StartExecution(assemblyPath, null);
         }
 
-        public static Process? Start(string assemblyPath, IFrameworkHandle? frameworkHandle)
+        public static Process? StartExecution(string assemblyPath, IFrameworkHandle? frameworkHandle)
         {
             var workingDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
 

--- a/src/Fixie.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.TestAdapter/VsTestDiscoverer.cs
@@ -44,7 +44,7 @@
 
             using (var pipeStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
             using (var pipe = new TestAdapterPipe(pipeStream))
-            using (var process = Start(assemblyPath))
+            using (var process = StartDiscovery(assemblyPath))
             {
                 pipeStream.WaitForConnection();
 

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -114,7 +114,7 @@
 
             using (var pipeStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
             using (var pipe = new TestAdapterPipe(pipeStream))
-            using (var process = StartExecution(assemblyPath, frameworkHandle))
+            using (var process = StartExecution(assemblyPath, frameworkHandle, out var attachmentFailure))
             {
                 pipeStream.WaitForConnection();
 
@@ -181,6 +181,30 @@
                         }
 
                         throw exception;
+                    }
+                }
+
+                if (attachmentFailure != null)
+                {
+                    var exception = attachmentFailure.ThirdPartyTestHostException;
+
+                    var reason = new PipeMessage.Exception
+                    {
+                        Type = exception.GetType().FullName!,
+                        Message = attachmentFailure.Message,
+                        StackTrace = exception.StackTrace!
+                    };
+
+                    foreach (var selectedTest in executeTests.Filter)
+                    {
+                        recorder.Record(new PipeMessage.TestFailed
+                        {
+                            Test = selectedTest,
+                            TestCase = selectedTest,
+                            Reason = reason,
+                            DurationInMilliseconds = 0,
+                            Output = ""
+                        });
                     }
                 }
             }

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -114,7 +114,7 @@
 
             using (var pipeStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
             using (var pipe = new TestAdapterPipe(pipeStream))
-            using (var process = Start(assemblyPath, frameworkHandle))
+            using (var process = StartExecution(assemblyPath, frameworkHandle))
             {
                 pipeStream.WaitForConnection();
 


### PR DESCRIPTION
This PR ensures Test Adapter resiliency in the face of faulty third party `LaunchProcessWithDebuggerAttached` implementations. It is a replacement for the earlier attempts at resiliency removed in #300 and #301.

In the past, I made the mistake of attempting to work around such debugger-attachment issues to the detriment of the project. I added workarounds intended to smooth over third party gaps, in fact dropping end users into bizarre assembly loading issues instead of driving them directly to success. I added workarounds intended to allow expected behavior for as many test runners as possible, only to find later that the Test Adapter was throwing exceptions that left their UX stuck spinning or reporting "inconclusive" results. In each case, in addition to creating false solutions, the complexity in the implementation grew.

#300, #301, and this code change mark a change in the Fixie project's stance on test runner integrations. When the world insists on taking the "move fast and break things" stance, automated testing proponents must meet that world with the opposing stance: "move slow and heal things". That goes for our tests as well as our test frameworks.

To follow my own advice, this repo will no longer be interested in workarounds, when I can instead give the user immediate guidance that unblocks *their* ability to move slow and heal things, and when I can give the user sufficient evidence to report their (now non-blocking, low-stakes) issue to the correct party.

# Background

Fixie provides a VSTest "Test Adapter" primarily in order to take part in the Visual Studio Test Explorer test runner. Any third party test runner can integrate by providing a "test host" process similar to the one provided by VSTest which calls into our Test Adapter to run tests and receive results.

For some test frameworks, that's enough to handle debugging. The test runner (such as an alternative IDE) launches their test host with the debugger attached to that process, loads the test framework's Test Adapter assembly, and calls into it with reflection (e.g. "Run All Tests Please"). If the test framework runs tests in-process, then test method breakpoints will be hit.

To ensure legitimate isolation, though, test frameworks can run the actual test assembly in a dedicated secondary process. For these cases, the Test Adapters need to call back to the test host (e.g. an IDE that just attached a debugger to the test host), asking them to start the process for them under the same debugging session. Doing so is not within the Test Adapter's control. (There are [yet more reasons](https://github.com/microsoft/vstest/blob/eb05f0dec14e85a87ce98d2cd8a92b64d92c99c1/docs/RFCs/0029-Debugging-External-Test-Processes.md) beyond environment and assembly loading isolation that a VSTest-integrated test framework might work with attaching debuggers to external processes, but they don't apply in this case.)

Specifically, any VSTest Test Adapter can make one pivotal request back to the test host: to launch a secondary process with the test host's debugger attached:

```
Namespace: Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
Interface: IFrameworkHandle
Member: LaunchProcessWithDebuggerAttached
```

```cs
int LaunchProcessWithDebuggerAttached(
      string filePath,
      string? workingDirectory,
      string? arguments,
      IDictionary<string, string?>? environmentVariables);
```

VSTest's own test host implements this method, and so debugging Fixie tests works in Test Explorer without user intervention. The secondary process is enlisted in the existing debugging session, and the user has no need to be aware of the process hops involved.

JetBrains' VSTest runner for ReSharper and Rider, unfortunately, throws NotSupportedException from this method.

Prior to this PR, this meant that the Test Adapter would encounter a highly-unanticipated exception at a pivotal moment: while the Test Adapter is establishing a named pipe connection to the test assembly process. Interrupting that communication would then fail with exceptions of its own around the far side of the pipe never connecting, and the JetBrains UI would have little to no information about what went wrong.

# Solution

This PR improves our error handling in these situations with the following goals:

1. First and foremost, the end user is already facing some blocking issue in their own project that they need to debug and resolve. They do not need to be further blocked by their choice of IDE. **The first feedback they receive must appear in their normal test runner UI where test results appear, and it must tell them exactly what to do next to debug their test, in their IDE, right now.**
2. Secondary to unblocking the user, attempt to prevent them from submitting their bug report to the wrong organization. **Provide actionable feedback about where to submit their feedback and what technical details to include in that feedback.**
3. Fixie's Test Adapter implementation should, ideally, not require any further change if the third party test runner fixes its implementation of the VSTest API. The user should be able to update their IDE once its own issue has been resolved, and the very next attempt to use the debugger on a test should just work. In other words, we'll **avoid detecting and making special cases for specific third party runners**, unless absolutely necessary, as these would need to be revisited over time and would risk needing to be reintroduced in the face of third party regressions, with Issues being submitted here at each step.