### PR TITLE
Fix `--tests` pattern matching semantics

### DIFF
--- a/src/Fixie.Tests/Internal/TestPatternTests.cs
+++ b/src/Fixie.Tests/Internal/TestPatternTests.cs
@@ -22,87 +22,180 @@
                 // Perfect match on full name.
                 new TestPattern(test).Matches(test).ShouldBe(true);
                 
-                // Substring match on full name.
-                new TestPattern("Fixie.Tests.TestTests+").Matches(test).ShouldBe(true);
-                new TestPattern("Class.MethodDefinedWithin").Matches(test).ShouldBe(true);
+                // Substring match on full name: implicit leading *, explicit closing *.
+                new TestPattern("Fixie.Tests.TestTests+").Matches(test).ShouldBe(false);
+                new TestPattern("Fixie.Tests.TestTests+*").Matches(test).ShouldBe(true);
+                new TestPattern("Class.MethodDefinedWithin").Matches(test).ShouldBe(false);
+                new TestPattern("Class.MethodDefinedWithin*").Matches(test).ShouldBe(true);
 
                 // Explicit wildcard matches everything.
                 new TestPattern("*").Matches(test).ShouldBe(true);
-                new TestPattern("F*Tests+").Matches(test).ShouldBe(true);
-                new TestPattern("Cla*hodDef*thin").Matches(test).ShouldBe(true);
+                new TestPattern("F*Tests+*").Matches(test).ShouldBe(true);
+                new TestPattern("Cla*hodDef*thin*").Matches(test).ShouldBe(true);
 
-                // Implicit [a-z]* between upper-case and non-lower-case characters.
-                new TestPattern("T+").Matches(test).ShouldBe(true);
-                new TestPattern("F.T.TT+").Matches(test).ShouldBe(true);
-                new TestPattern("C.MDW").Matches(test).ShouldBe(true);
+                // Implicit [a-z]* after upper-case characters that are not followed by lower-case characters.
+                new TestPattern("T+*").Matches(test).ShouldBe(true);
+                new TestPattern("F.T.TT+*").Matches(test).ShouldBe(true);
+                new TestPattern("C.MDW").Matches(test).ShouldBe(false);
+                new TestPattern("C.MDW*").Matches(test).ShouldBe(true);
+                new TestPattern("C.MDW*C").Matches(test).ShouldBe(true);
 
                 // Explicit lower-case can prevent the implied wildcard.
-                new TestPattern("Te+").Matches(test).ShouldBe(false);
-                new TestPattern("F.T.TTe+").Matches(test).ShouldBe(false);
-                new TestPattern("Cl.MDW").Matches(test).ShouldBe(false);
+                new TestPattern("Te+*").Matches(test).ShouldBe(false);
+                new TestPattern("Te*+*").Matches(test).ShouldBe(true);
+                new TestPattern("Fi.T.TT+*").Matches(test).ShouldBe(false);
+                new TestPattern("Fi*.T.TT+*").Matches(test).ShouldBe(true);
+                new TestPattern("Cl.MDW*").Matches(test).ShouldBe(false);
+                new TestPattern("Cl*.MDW*").Matches(test).ShouldBe(true);
+                new TestPattern("C.MDW*Cl").Matches(test).ShouldBe(false);
+                new TestPattern("C.MDW*Cl*").Matches(test).ShouldBe(true);
             }
 
             var testPattern = new TestPattern("C");
             testPattern.Matches(childClassChildMethod).ShouldBe(true);
             testPattern.Matches(parentClassParentMethod).ShouldBe(true);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
+            testPattern =new TestPattern("T");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("T*");
+            testPattern.Matches(childClassChildMethod).ShouldBe(true);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+            
             testPattern = new TestPattern("CC");
+            testPattern.Matches(childClassChildMethod).ShouldBe(true);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("CC*");
             testPattern.Matches(childClassChildMethod).ShouldBe(true);
             testPattern.Matches(parentClassParentMethod).ShouldBe(false);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
 
             testPattern = new TestPattern("CC.MDW");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("CC.MDW*");
             testPattern.Matches(childClassChildMethod).ShouldBe(true);
             testPattern.Matches(parentClassParentMethod).ShouldBe(false);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
 
             testPattern = new TestPattern("C.MDW");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("C.MDW*");
             testPattern.Matches(childClassChildMethod).ShouldBe(true);
             testPattern.Matches(parentClassParentMethod).ShouldBe(true);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
 
             testPattern = new TestPattern("C.MDWC");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("C.MDWC*");
+            testPattern.Matches(childClassChildMethod).ShouldBe(true);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("C.MDWCC");
+            testPattern.Matches(childClassChildMethod).ShouldBe(true);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("C.MDWCCl");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("C.MDWCClass");
             testPattern.Matches(childClassChildMethod).ShouldBe(true);
             testPattern.Matches(parentClassParentMethod).ShouldBe(false);
             testPattern.Matches(childClassParentMethod).ShouldBe(false);
 
             testPattern = new TestPattern("C.MDWP");
             testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("C.MDWP*");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
             testPattern.Matches(parentClassParentMethod).ShouldBe(true);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
-            
+            testPattern = new TestPattern("C.MDWPC");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+            testPattern = new TestPattern("C.MDWPCl");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("C.MDWPClass");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
             testPattern = new TestPattern("ChildClass");
             testPattern.Matches(childClassChildMethod).ShouldBe(true);
             testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("ChildClass.MethodDefinedWithin");
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("ChildClass*");
             testPattern.Matches(childClassChildMethod).ShouldBe(true);
             testPattern.Matches(parentClassParentMethod).ShouldBe(false);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
+            testPattern = new TestPattern("ParentClass");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+            testPattern = new TestPattern("ChildClass.MethodDefinedWithin");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("ChildClass.MethodDefinedWithin*");
+            testPattern.Matches(childClassChildMethod).ShouldBe(true);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+            testPattern = new TestPattern("ChildClass.MethodDefinedWithinC");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("ChildClass.MethodDefinedWithinCC");
+            testPattern.Matches(childClassChildMethod).ShouldBe(true);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
 
             testPattern = new TestPattern("ChildClass.MethodDefinedWithinP");
             testPattern.Matches(childClassChildMethod).ShouldBe(false);
             testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("ChildClass.Met*odDefinedWithin");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("ChildClass.MethodDefinedWithinP*");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
             testPattern.Matches(parentClassParentMethod).ShouldBe(false);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("ChildClass.Met*odDefinedWithinP");
+            testPattern = new TestPattern("ChildClass.MethodDefinedWithinPC");
             testPattern.Matches(childClassChildMethod).ShouldBe(false);
             testPattern.Matches(parentClassParentMethod).ShouldBe(false);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
 
-            testPattern = new TestPattern("*M*e*t*h*o*d*D*e*f*i*n*e*d*W*i*t*h*i*n*P");
+            testPattern = new TestPattern("ChildClass.Met*odDefinedWithin*");
+            testPattern.Matches(childClassChildMethod).ShouldBe(true);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+            testPattern = new TestPattern("ChildClass.Met*odDefinedWithinP*");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+            testPattern = new TestPattern("*M*e*t*h*o*d*D*e*f*i*n*e*d*W*i*t*h*i*n*P*");
             testPattern.Matches(childClassChildMethod).ShouldBe(false);
             testPattern.Matches(parentClassParentMethod).ShouldBe(true);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
 
             testPattern = new TestPattern("C*.M*D*W*P");
+            testPattern.Matches(childClassChildMethod).ShouldBe(false);
+            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+            testPattern.Matches(childClassParentMethod).ShouldBe(false);
+            testPattern = new TestPattern("C*.M*D*W*PC");
             testPattern.Matches(childClassChildMethod).ShouldBe(false);
             testPattern.Matches(parentClassParentMethod).ShouldBe(true);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);

--- a/src/Fixie/Internal/TestPattern.cs
+++ b/src/Fixie/Internal/TestPattern.cs
@@ -29,6 +29,9 @@ namespace Fixie.Internal
                 }
             }
 
+            if (previousWasUpperCase)
+                patternWithWildcards += "[a-z]*";
+
             regex = new Regex(patternWithWildcards + "$");
         }
 

--- a/src/Fixie/Internal/TestPattern.cs
+++ b/src/Fixie/Internal/TestPattern.cs
@@ -29,7 +29,7 @@ namespace Fixie.Internal
                 }
             }
 
-            regex = new Regex(patternWithWildcards);
+            regex = new Regex(patternWithWildcards + "$");
         }
 
         public bool Matches(string test)


### PR DESCRIPTION
The `dotnet fixie` filtering argument `--tests` was introduced in https://github.com/fixie/fixie/pull/238. Although it behaved well in many cases, it had an implicit wildcard at the end of the given pattern, and *when* that didn't match the user's expectations they had no recourse. Here, we fix the semantics of this argument so that all users can achieve their desired filter:

* Users who want to precisely match a test, even if there are similar tests nearby with varying suffixes, can now do so simply by stating the name of the test they are filtering to.
* Users who instead wanted to include nearby tests with varying suffixes are free to include an explicit wildcard.

I debated whether this should be treated as a breaking change or not, which could push the fix into the future 4.x line. However, the original description of the behavior in that PR itself is not internally consistent. It always claimed that "a full test name match will run that single test", which was simply not true in the implementation due to the implicit always-on ending wildcard. Since the feature wasn't even following the stated behavior, I'm considering this simply a bug fix for the 3.x line.

I've updated the docs with a better sequence of illustrative examples, copied below...

----

The optional argument `--tests` (abbreviated `-t`) lets you specify which tests to run.

A full test name will run that single test:

    dotnet fixie MyTestProject --tests Full.Namespace.MyTestClass.MyTestMethod

To avoid having to type the full name, since most test name prefixes are similar, there is an implicit wildcard at the start of the pattern:

    dotnet fixie MyTestProject --tests MyTestClass.MyTestMethod

An explicit `*` wildcard will match any sequence of zero or more characters:

    dotnet fixie MyTestProject --tests MyTest*.*estMetho*

Here we run an entire test class:

    dotnet fixie MyTestProject --tests MyTestClass.*

Leveraging the *PascalCase* naming convention of .NET namespaces, classes, and methods, there is an implicit lowercase letters wildcard whenever a capital letter is not followed by a lowercase letter. In other words, you can type "MTC" to match "MyTestClass". Here we run a select few related tests within that class:

    dotnet fixie MyTestProject --tests MTC.ShouldValidateThat*

Or even more succinctly:

    dotnet fixie MyTestProject --tests MTC.SVT*

Here we run a single test, where the method name alone was unique in the assembly:

    dotnet fixie MyTestProject --tests ShouldValidatePhoneNumber

Or even more succinctly:

    dotnet fixie MyTestProject --tests SVPN

When a pattern matches zero tests, the run fails with a nonzero exit code:

    dotnet fixie MyTestProject --tests NonMatchingPattern

    No tests match the specified pattern: NonMatchingPattern

When all tests are run by omitting the `--tests` argument, passing tests are omitted for brevity. However, because a `--tests` pattern may in fact be more inclusive than the developer intended, the console output will include *passing* test names in addition to other test results as feedback whenever this argument is used.
