### PR TITLE
Update versioning to begin v4 development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        filter: tree:0
     - name: .NET SDK
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        filter: tree:0
     - name: .NET SDK
       uses: actions/setup-dotnet@v3
       with:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Nullable>enable</Nullable>
         <UseArtifactsOutput>true</UseArtifactsOutput>
-        <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
+        <MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>1591</NoWarn>
         <WarningsNotAsErrors>162,612,618</WarningsNotAsErrors>


### PR DESCRIPTION
This is a simple versioning bump marking the start of v4 development. We use MinVer to version assemblies and packages. To ensure that the alpha builds for upcoming commits start with major version `4.0` instead of simply adding height to the most recent `3.*` tag, we update an MSBuild property to the desired *Major.Minor* value `4.0`.

While doing this, a scan of the latest documentation from MinVer showed an opportunity to improve the performance of the clone performed in GitHub Actions. We still need the full set of commits to guarantee MinVer's calculation, but now we omit all excessive tree (folder) and blob (file) data from the historic commits.