### PR TITLE
GitHub Actions workflows set up only the single necessary SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          3.1
           6.0
           7.0
           8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          3.1
           6.0
           7.0
           8.0


### PR DESCRIPTION
Experimental: stop ensuring netcoreapp3.1 is present on the build environment, to determine whether it needs to be present when targeting netcoreapp3.1.

