### PR TITLE
Remove target framework `net6.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          6.0
           7.0
           8.0
     - run: dotnet --info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          6.0
           7.0
           8.0
     - run: dotnet --info

--- a/src/Fixie.Console/Fixie.Console.csproj
+++ b/src/Fixie.Console/Fixie.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>fixie</ToolCommandName>
     <Description>`dotnet fixie` console test runner for the Fixie test framework.</Description>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -14,11 +14,6 @@
     <copyright>$copyright$</copyright>
     <repository url="https://github.com/fixie/fixie" />
     <dependencies>
-	  <group targetFramework="net6.0">
-	    <dependency id="Fixie" version="[$version$]" />
-	    <dependency id="Mono.Cecil" version="0.11.5" />
-	    <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
-	  </group>
       <group targetFramework="net7.0">
         <dependency id="Fixie" version="[$version$]" />
         <dependency id="Mono.Cecil" version="0.11.5" />
@@ -37,9 +32,6 @@
     <file target="icon.png" src="..\..\img\fixie_256.png" />
 
     <!-- Run-Time Assets -->
-    <file target="lib\net6.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net6.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net6.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net6.0\Fixie.TestAdapter.pdb" />
-    
     <file target="lib\net7.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net7.0\Fixie.TestAdapter.dll" />
     <file target="lib\net7.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net7.0\Fixie.TestAdapter.pdb" />
     

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Fixie.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -45,7 +45,7 @@
             //Ambiguous Match
             Action attemptAmbiguousAttributeLookup = () => typeof(AttributeSample).Has<AmbiguouslyMultipleAttribute>(out _);
             
-            #if NET6_0 || NET7_0
+            #if NET7_0
             var expectedExceptionMessage = "Multiple custom attributes of the same type found.";
             #else
             var expectedExceptionMessage = "Multiple custom attributes of the same type 'Fixie.Tests.ReflectionExtensionsTests+AmbiguouslyMultipleAttribute' found.";

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -24,9 +24,7 @@
         {
             get
             {
-#if NET6_0
-                return "6.0";
-#elif NET7_0
+#if NET7_0
                 return "7.0";
 #elif NET8_0
                 return "8.0";

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Description>Ergonomic Testing for .NET</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Fixie/Reports/ExceptionExtensions.cs
+++ b/src/Fixie/Reports/ExceptionExtensions.cs
@@ -53,7 +53,7 @@
                 const string subsequentInvoke = " InvokeStub_";
                 const string firstInvoke = " System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
                 
-                #if NET6_0 || NET7_0
+                #if NET7_0
                 const string methodInvoker = " System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)";
                 #else
                 const string methodInvoker = " System.Reflection.MethodBaseInvoker.Invoke";


### PR DESCRIPTION
This phases out deprecated target framework `net6.0`, which will not pass the end of it's own support window until November 12, 2024.

The rationale is that Fixie 4.0 is intended to be released sometime during 2024 and close enough to the end of the `net6.0` lifetime to warrant dropping it in favor of modern C# and .NET features. By that point most users who tend towards upgrading things will have done so to the latest LTS framework (`net8.0`), and those who don't tend towards upgrading things will continue to be served by Fixie 3.x, which will never drop an already-supported target framework.

This raises the "floor" for the solution from `net6.0` and `C# 10` to `net7.0` and `C# 11`.