### PR TITLE
Remove target framework `net7.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          7.0
           8.0
     - run: dotnet --info
     - name: Build and Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          7.0
           8.0
     - run: dotnet --info
     - name: Build and Test

--- a/src/Fixie.Console/Fixie.Console.csproj
+++ b/src/Fixie.Console/Fixie.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>fixie</ToolCommandName>
     <Description>`dotnet fixie` console test runner for the Fixie test framework.</Description>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -14,11 +14,6 @@
     <copyright>$copyright$</copyright>
     <repository url="https://github.com/fixie/fixie" />
     <dependencies>
-      <group targetFramework="net7.0">
-        <dependency id="Fixie" version="[$version$]" />
-        <dependency id="Mono.Cecil" version="0.11.5" />
-        <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
-      </group>
       <group targetFramework="net8.0">
         <dependency id="Fixie" version="[$version$]" />
         <dependency id="Mono.Cecil" version="0.11.5" />
@@ -32,10 +27,7 @@
     <file target="icon.png" src="..\..\img\fixie_256.png" />
 
     <!-- Run-Time Assets -->
-    <file target="lib\net7.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net7.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net7.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net7.0\Fixie.TestAdapter.pdb" />
-    
-    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net8.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net8.0\Fixie.TestAdapter.pdb" />
+    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release\Fixie.TestAdapter.dll" />
+    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release\Fixie.TestAdapter.pdb" />
   </files>
 </package>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Fixie.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -45,11 +45,7 @@
             //Ambiguous Match
             Action attemptAmbiguousAttributeLookup = () => typeof(AttributeSample).Has<AmbiguouslyMultipleAttribute>(out _);
             
-            #if NET7_0
-            var expectedExceptionMessage = "Multiple custom attributes of the same type found.";
-            #else
             var expectedExceptionMessage = "Multiple custom attributes of the same type 'Fixie.Tests.ReflectionExtensionsTests+AmbiguouslyMultipleAttribute' found.";
-            #endif
 
             attemptAmbiguousAttributeLookup.ShouldThrow<AmbiguousMatchException>(expectedExceptionMessage);
         }

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -69,10 +69,8 @@
         {
             var output = (await Run<FailureTestClass, ExplicitExceptionHandling>()).ToArray();
 
-            #if NET7_0_OR_GREATER
             const string optimizedInvoker = "   at InvokeStub_FailureTestClass.Synchronous(Object, Object, IntPtr*)";
             const string initialInvoker = "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
-            #endif
 
             output
                 .ShouldBe(
@@ -92,18 +90,10 @@
                     "",
                     "Fixie.Tests.FailureException",
                     At<FailureTestClass>("Synchronous()"),
-                    #if NET7_0
-                    output.Contains(optimizedInvoker)
-                        ? optimizedInvoker
-                        : initialInvoker,
-                    "   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)",
-                    #endif
-                    #if NET8_0_OR_GREATER
                     output.Contains(optimizedInvoker)
                         ? optimizedInvoker
                         : initialInvoker,
                     "   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)",
-                    #endif
                     "--- End of stack trace from previous location where exception was thrown ---",
                     At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
                     At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -20,17 +20,7 @@
                 Directory.GetCurrentDirectory());
         }
 
-        public static string TargetFrameworkVersion
-        {
-            get
-            {
-#if NET7_0
-                return "7.0";
-#elif NET8_0
-                return "8.0";
-#endif
-            }
-        }
+        public static string TargetFrameworkVersion => "8.0";
 
         public static string FullName<T>()
         {

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>Ergonomic Testing for .NET</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Fixie/Reports/ExceptionExtensions.cs
+++ b/src/Fixie/Reports/ExceptionExtensions.cs
@@ -52,13 +52,7 @@
             {
                 const string subsequentInvoke = " InvokeStub_";
                 const string firstInvoke = " System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
-                
-                #if NET7_0
-                const string methodInvoker = " System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)";
-                #else
                 const string methodInvoker = " System.Reflection.MethodBaseInvoker.Invoke";
-                #endif                
-
                 const string synchronousRethrowMarker = "--- End of stack trace from previous location";
                 const string callResolvedMethod = " Fixie.MethodInfoExtensions.CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)";
                 const string constructTestClass = " Fixie.Test.Construct(Type testClass)";


### PR DESCRIPTION
This phases out deprecated target framework `net7.0`, which will not pass the end of it's own support window until May 14, 2024.

The rationale is that Fixie 4.0 is intended to be released sometime during 2024 and either close to or beyond the end of the `net7.0` lifetime, warranting dropping it in favor of modern C# and .NET features.

This raises the "floor" for the solution from `net7.0` and `C# 11` to `net8.0` and `C# 12`.