### PR TITLE
Apply File-Scoped Namespaces

### DIFF
--- a/build/Fixie.Main.cs
+++ b/build/Fixie.Main.cs
@@ -1,15 +1,14 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Threading.Tasks;
+
+// The 'Fixie' package includes this file in test projects so
+// that their tests can be executed. Do not modify this file.
+
+class TestProjectEntryPoint
 {
-    using System;
-    using System.Threading.Tasks;
-
-    // The 'Fixie' package includes this file in test projects so
-    // that their tests can be executed. Do not modify this file.
-
-    class TestProjectEntryPoint
-    {
-        [STAThread]
-        static async Task<int> Main(string[] customArguments)
-            => await EntryPoint.Main(typeof(TestProjectEntryPoint).Assembly, customArguments);
-    }
+    [STAThread]
+    static async Task<int> Main(string[] customArguments)
+        => await EntryPoint.Main(typeof(TestProjectEntryPoint).Assembly, customArguments);
 }

--- a/src/Fixie.Console/CommandLine.cs
+++ b/src/Fixie.Console/CommandLine.cs
@@ -1,34 +1,33 @@
-﻿namespace Fixie.Console
+﻿namespace Fixie.Console;
+
+using System.Collections.Generic;
+
+public class CommandLine
 {
-    using System.Collections.Generic;
+    public static T Parse<T>(string[] arguments) where T : class
+        => new Parser<T>(arguments).Model;
 
-    public class CommandLine
+    public static void Partition(string[] arguments, out string[] runnerArguments, out string[] customArguments)
     {
-        public static T Parse<T>(string[] arguments) where T : class
-            => new Parser<T>(arguments).Model;
+        var runnerArgumentsList = new List<string>();
+        var customArgumentsList = new List<string>();
 
-        public static void Partition(string[] arguments, out string[] runnerArguments, out string[] customArguments)
+        bool separatorFound = false;
+        foreach (var arg in arguments)
         {
-            var runnerArgumentsList = new List<string>();
-            var customArgumentsList = new List<string>();
-
-            bool separatorFound = false;
-            foreach (var arg in arguments)
+            if (arg == "--")
             {
-                if (arg == "--")
-                {
-                    separatorFound = true;
-                    continue;
-                }
-
-                if (separatorFound)
-                    customArgumentsList.Add(arg);
-                else
-                    runnerArgumentsList.Add(arg);
+                separatorFound = true;
+                continue;
             }
 
-            runnerArguments = runnerArgumentsList.ToArray();
-            customArguments = customArgumentsList.ToArray();
+            if (separatorFound)
+                customArgumentsList.Add(arg);
+            else
+                runnerArgumentsList.Add(arg);
         }
+
+        runnerArguments = runnerArgumentsList.ToArray();
+        customArguments = customArgumentsList.ToArray();
     }
 }

--- a/src/Fixie.Console/CommandLineException.cs
+++ b/src/Fixie.Console/CommandLineException.cs
@@ -1,13 +1,12 @@
-﻿namespace Fixie.Console
+﻿namespace Fixie.Console;
+
+using System;
+
+public class CommandLineException : Exception
 {
-    using System;
+    public CommandLineException(string message, Exception innerException)
+        : base(message, innerException) { }
 
-    public class CommandLineException : Exception
-    {
-        public CommandLineException(string message, Exception innerException)
-            : base(message, innerException) { }
-
-        public CommandLineException(string message)
-            : base(message) { }
-    }
+    public CommandLineException(string message)
+        : base(message) { }
 }

--- a/src/Fixie.Console/Foreground.cs
+++ b/src/Fixie.Console/Foreground.cs
@@ -1,23 +1,22 @@
-﻿namespace Fixie.Console
+﻿namespace Fixie.Console;
+
+using System;
+
+class Foreground : IDisposable
 {
-    using System;
+    readonly ConsoleColor before;
 
-    class Foreground : IDisposable
+    public Foreground(ConsoleColor color)
     {
-        readonly ConsoleColor before;
-
-        public Foreground(ConsoleColor color)
-        {
-            before = Console.ForegroundColor;
-            Console.ForegroundColor = color;
-        }
-
-        public void Dispose() => Console.ForegroundColor = before;
-
-        public static Foreground Red => new Foreground(ConsoleColor.Red);
-
-        public static Foreground Yellow => new Foreground(ConsoleColor.Yellow);
-
-        public static Foreground Green => new Foreground(ConsoleColor.Green);
+        before = Console.ForegroundColor;
+        Console.ForegroundColor = color;
     }
+
+    public void Dispose() => Console.ForegroundColor = before;
+
+    public static Foreground Red => new Foreground(ConsoleColor.Red);
+
+    public static Foreground Yellow => new Foreground(ConsoleColor.Yellow);
+
+    public static Foreground Green => new Foreground(ConsoleColor.Green);
 }

--- a/src/Fixie.Console/NamedArgument.cs
+++ b/src/Fixie.Console/NamedArgument.cs
@@ -1,30 +1,29 @@
-namespace Fixie.Console
+namespace Fixie.Console;
+
+using System;
+using System.Collections.Generic;
+
+class NamedArgument
 {
-    using System;
-    using System.Collections.Generic;
-
-    class NamedArgument
+    public NamedArgument(Type type, string identifier)
     {
-        public NamedArgument(Type type, string identifier)
-        {
-            IsArray = type.IsArray;
+        IsArray = type.IsArray;
 
-            ItemType = IsArray
-                ? type.GetElementType()!
-                : type;
+        ItemType = IsArray
+            ? type.GetElementType()!
+            : type;
 
-            Identifier = identifier;
-            Name = Normalize(Identifier);
-            Values = new List<object?>();
-        }
-
-        public bool IsArray { get; }
-        public Type ItemType { get; }
-        public string Identifier { get; }
-        public string Name { get; }
-        public List<object?> Values { get; }
-
-        public static string Normalize(string namedArgumentKey)
-            => namedArgumentKey.ToLower().Replace("-", "");
+        Identifier = identifier;
+        Name = Normalize(Identifier);
+        Values = new List<object?>();
     }
+
+    public bool IsArray { get; }
+    public Type ItemType { get; }
+    public string Identifier { get; }
+    public string Name { get; }
+    public List<object?> Values { get; }
+
+    public static string Normalize(string namedArgumentKey)
+        => namedArgumentKey.ToLower().Replace("-", "");
 }

--- a/src/Fixie.Console/Options.cs
+++ b/src/Fixie.Console/Options.cs
@@ -1,26 +1,25 @@
-﻿namespace Fixie.Console
-{
-    public class Options
-    {
-        public Options(
-            string? configuration,
-            bool noBuild,
-            string? framework,
-            string? tests,
-            params string[] projectPatterns)
-        {
-            ProjectPatterns = projectPatterns;
-            Configuration = configuration ?? "Debug";
-            NoBuild = noBuild;
-            Framework = framework;
-            Tests = tests;
-        }
+﻿namespace Fixie.Console;
 
-        public string[] ProjectPatterns { get; }
-        public string Configuration { get; }
-        public bool NoBuild { get; }
-        public bool ShouldBuild => !NoBuild;
-        public string? Framework { get; }
-        public string? Tests { get; }
+public class Options
+{
+    public Options(
+        string? configuration,
+        bool noBuild,
+        string? framework,
+        string? tests,
+        params string[] projectPatterns)
+    {
+        ProjectPatterns = projectPatterns;
+        Configuration = configuration ?? "Debug";
+        NoBuild = noBuild;
+        Framework = framework;
+        Tests = tests;
     }
+
+    public string[] ProjectPatterns { get; }
+    public string Configuration { get; }
+    public bool NoBuild { get; }
+    public bool ShouldBuild => !NoBuild;
+    public string? Framework { get; }
+    public string? Tests { get; }
 }

--- a/src/Fixie.Console/PositionalArgument.cs
+++ b/src/Fixie.Console/PositionalArgument.cs
@@ -1,18 +1,17 @@
-﻿namespace Fixie.Console
+﻿namespace Fixie.Console;
+
+using System;
+using System.Reflection;
+
+class PositionalArgument
 {
-    using System;
-    using System.Reflection;
-
-    class PositionalArgument
+    public PositionalArgument(ParameterInfo parameter)
     {
-        public PositionalArgument(ParameterInfo parameter)
-        {
-            Type = parameter.ParameterType;
-            Name = parameter.Name!;
-        }
-
-        public Type Type { get; }
-        public string Name { get; }
-        public object? Value { get; set; }
+        Type = parameter.ParameterType;
+        Name = parameter.Name!;
     }
+
+    public Type Type { get; }
+    public string Name { get; }
+    public object? Value { get; set; }
 }

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -1,211 +1,210 @@
-﻿namespace Fixie.Console
+﻿namespace Fixie.Console;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using static System.Console;
+using static System.IO.Directory;
+using static Shell;
+
+class Program
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using static System.Console;
-    using static System.IO.Directory;
-    using static Shell;
+    const int Success = 0;
+    const int Failure = 1;
+    const int FatalError = 2;
 
-    class Program
+    [STAThread]
+    static int Main(string[] arguments)
     {
-        const int Success = 0;
-        const int Failure = 1;
-        const int FatalError = 2;
-
-        [STAThread]
-        static int Main(string[] arguments)
+        try
         {
-            try
+            CommandLine.Partition(arguments, out var runnerArguments, out var customArguments);
+
+            var options = CommandLine.Parse<Options>(runnerArguments);
+
+            var overallExitCode = Success;
+
+            foreach(var testProject in TestProjects(options).ToArray())
             {
-                CommandLine.Partition(arguments, out var runnerArguments, out var customArguments);
-
-                var options = CommandLine.Parse<Options>(runnerArguments);
-
-                var overallExitCode = Success;
-
-                foreach(var testProject in TestProjects(options).ToArray())
+                if (options.ShouldBuild)
                 {
-                    if (options.ShouldBuild)
+                    WriteLine($"Building {Path.GetFileNameWithoutExtension(testProject)}...");
+                    
+                    var exitCode = RunTarget(testProject, "Build", options.Configuration);
+                    
+                    if (exitCode != 0)
                     {
-                        WriteLine($"Building {Path.GetFileNameWithoutExtension(testProject)}...");
-                    
-                        var exitCode = RunTarget(testProject, "Build", options.Configuration);
-                    
-                        if (exitCode != 0)
-                        {
-                            Error("Build failed!");
-                            return FatalError;
-                        }
-                    }
-                    
-                    var targetFrameworks = GetTargetFrameworks(options, testProject);
-                    
-                    bool runningForMultipleFrameworks = targetFrameworks.Length > 1;
-                    foreach (var targetFramework in targetFrameworks)
-                    {
-                        int exitCode = RunTests(options, testProject, targetFramework, customArguments, runningForMultipleFrameworks);
-                    
-                        if (exitCode != Success && exitCode != Failure)
-                            Error("Unexpected exit code: " + exitCode);
-                    
-                        if (exitCode != Success)
-                            overallExitCode = Failure;
+                        Error("Build failed!");
+                        return FatalError;
                     }
                 }
-
-                return overallExitCode;
+                    
+                var targetFrameworks = GetTargetFrameworks(options, testProject);
+                    
+                bool runningForMultipleFrameworks = targetFrameworks.Length > 1;
+                foreach (var targetFramework in targetFrameworks)
+                {
+                    int exitCode = RunTests(options, testProject, targetFramework, customArguments, runningForMultipleFrameworks);
+                    
+                    if (exitCode != Success && exitCode != Failure)
+                        Error("Unexpected exit code: " + exitCode);
+                    
+                    if (exitCode != Success)
+                        overallExitCode = Failure;
+                }
             }
-            catch (CommandLineException exception)
-            {
-                Error(exception.Message);
-                Help();
 
-                return FatalError;
-            }
-            catch (Exception exception)
-            {
-                Error($"Fatal Error: {exception}");
-
-                return FatalError;
-            }
+            return overallExitCode;
         }
-
-        static IEnumerable<string> TestProjects(Options options)
+        catch (CommandLineException exception)
         {
-            if (options.ProjectPatterns.Any())
-            {
-                foreach (var pattern in options.ProjectPatterns)
-                {
-                    var found = false;
+            Error(exception.Message);
+            Help();
 
-                    foreach (var project in EnumerateFiles(GetCurrentDirectory(), pattern + ".*proj", SearchOption.AllDirectories))
-                    {
-                        found = true;
-                        yield return project;
-                    }
+            return FatalError;
+        }
+        catch (Exception exception)
+        {
+            Error($"Fatal Error: {exception}");
 
-                    if (!found)
-                        throw new CommandLineException($"There are no projects matching the pattern '{pattern}'.");
-                }
-            }
-            else
+            return FatalError;
+        }
+    }
+
+    static IEnumerable<string> TestProjects(Options options)
+    {
+        if (options.ProjectPatterns.Any())
+        {
+            foreach (var pattern in options.ProjectPatterns)
             {
                 var found = false;
 
-                foreach (var project in EnumerateFiles(GetCurrentDirectory(), "*.*proj"))
+                foreach (var project in EnumerateFiles(GetCurrentDirectory(), pattern + ".*proj", SearchOption.AllDirectories))
                 {
                     found = true;
                     yield return project;
                 }
 
                 if (!found)
-                    throw new CommandLineException("There are no projects in the current directory.");
+                    throw new CommandLineException($"There are no projects matching the pattern '{pattern}'.");
             }
         }
-
-        static string[] GetTargetFrameworks(Options options, string testProject)
+        else
         {
-            var targetFrameworks =
-                QueryTarget(testProject, "_Fixie_GetTargetFrameworks")
-                    .SelectMany(line => line.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries))
-                    .ToArray();
+            var found = false;
 
-            if (options.Framework == null)
-                return targetFrameworks;
+            foreach (var project in EnumerateFiles(GetCurrentDirectory(), "*.*proj"))
+            {
+                found = true;
+                yield return project;
+            }
 
-            if (targetFrameworks.Contains(options.Framework))
-                return new[] {options.Framework};
-
-            var availableFrameworks = string.Join(", ", targetFrameworks.Select(x => $"'{x}'"));
-
-            throw new CommandLineException(
-                $"Cannot target framework '{options.Framework}'. " +
-                $"The test project targets the following framework(s): {availableFrameworks}");
+            if (!found)
+                throw new CommandLineException("There are no projects in the current directory.");
         }
+    }
 
-        static int RunTests(Options options, string testProject, string targetFramework, string[] customArguments, bool runningForMultipleFrameworks)
-        {
-            var assemblyMetadata = QueryTarget(testProject, "_Fixie_GetAssemblyMetadata", options.Configuration, targetFramework);
+    static string[] GetTargetFrameworks(Options options, string testProject)
+    {
+        var targetFrameworks =
+            QueryTarget(testProject, "_Fixie_GetTargetFrameworks")
+                .SelectMany(line => line.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries))
+                .ToArray();
 
-            var outputPath = assemblyMetadata[0];
-            var assemblyName = assemblyMetadata[1];
-            var targetFileName = assemblyMetadata[2];
+        if (options.Framework == null)
+            return targetFrameworks;
 
-            var context =
-                runningForMultipleFrameworks
-                    ? $" ({targetFramework})"
-                    : "";
+        if (targetFrameworks.Contains(options.Framework))
+            return new[] {options.Framework};
 
-            Heading($"Running {assemblyName}{context}");
-            WriteLine();
+        var availableFrameworks = string.Join(", ", targetFrameworks.Select(x => $"'{x}'"));
 
-            var arguments = new List<string> { targetFileName };
+        throw new CommandLineException(
+            $"Cannot target framework '{options.Framework}'. " +
+            $"The test project targets the following framework(s): {availableFrameworks}");
+    }
 
-            arguments.AddRange(customArguments);
+    static int RunTests(Options options, string testProject, string targetFramework, string[] customArguments, bool runningForMultipleFrameworks)
+    {
+        var assemblyMetadata = QueryTarget(testProject, "_Fixie_GetAssemblyMetadata", options.Configuration, targetFramework);
 
-            var workingDirectory = Path.Combine(
-                new FileInfo(testProject).Directory!.FullName,
-                outputPath);
+        var outputPath = assemblyMetadata[0];
+        var assemblyName = assemblyMetadata[1];
+        var targetFileName = assemblyMetadata[2];
 
-            var environmentVariables = new Dictionary<string, string>();
+        var context =
+            runningForMultipleFrameworks
+                ? $" ({targetFramework})"
+                : "";
 
-            if (options.Tests != null)
-                environmentVariables["FIXIE_TESTS_PATTERN"] = options.Tests;
+        Heading($"Running {assemblyName}{context}");
+        WriteLine();
 
-            return Run("dotnet", workingDirectory, arguments.ToArray(), environmentVariables);
-        }
+        var arguments = new List<string> { targetFileName };
 
-        static void Help()
-        {
-            WriteLine();
-            WriteLine("Usage: dotnet fixie [project]... [options] [-- [custom arguments]...]");
-            WriteLine();
-            WriteLine();
-            WriteLine("    project");
-            WriteLine("        The name of a test project to run. When this option");
-            WriteLine("        is omitted, the project in the current directory is");
-            WriteLine("        assumed. Specify multiple project names or use * wildcards");
-            WriteLine("        to run multiple test projects.");
-            WriteLine();
-            WriteLine("    -c <configuration>");
-            WriteLine("    --configuration <configuration>");
-            WriteLine("        The configuration under which to build. When this option");
-            WriteLine("        is omitted, the default configuration is `Debug`.");
-            WriteLine();
-            WriteLine("    -n");
-            WriteLine("    --no-build");
-            WriteLine("        Skip building the test project prior to running it.");
-            WriteLine();
-            WriteLine("    -f <framework>");
-            WriteLine("    --framework <framework>");
-            WriteLine("        Only run test assemblies targeting a specific framework.");
-            WriteLine();
-            WriteLine("    -t <pattern>");
-            WriteLine("    --tests <pattern>");
-            WriteLine("        Run only the tests whose full names match the given pattern.");
-            WriteLine();
-            WriteLine("    --");
-            WriteLine("        Signifies the end of built-in arguments and the beginning");
-            WriteLine("        of custom arguments.");
-            WriteLine();
-            WriteLine("    custom arguments");
-            WriteLine("        Arbitrary arguments made available to custom discovery/execution classes.");
-            WriteLine();
-        }
+        arguments.AddRange(customArguments);
 
-        static void Heading(string message)
-        {
-            using (Foreground.Green)
-                WriteLine(message);
-        }
+        var workingDirectory = Path.Combine(
+            new FileInfo(testProject).Directory!.FullName,
+            outputPath);
 
-        static void Error(string message)
-        {
-            WriteLine();
-            using (Foreground.Red)
-                WriteLine(message);
-        }
+        var environmentVariables = new Dictionary<string, string>();
+
+        if (options.Tests != null)
+            environmentVariables["FIXIE_TESTS_PATTERN"] = options.Tests;
+
+        return Run("dotnet", workingDirectory, arguments.ToArray(), environmentVariables);
+    }
+
+    static void Help()
+    {
+        WriteLine();
+        WriteLine("Usage: dotnet fixie [project]... [options] [-- [custom arguments]...]");
+        WriteLine();
+        WriteLine();
+        WriteLine("    project");
+        WriteLine("        The name of a test project to run. When this option");
+        WriteLine("        is omitted, the project in the current directory is");
+        WriteLine("        assumed. Specify multiple project names or use * wildcards");
+        WriteLine("        to run multiple test projects.");
+        WriteLine();
+        WriteLine("    -c <configuration>");
+        WriteLine("    --configuration <configuration>");
+        WriteLine("        The configuration under which to build. When this option");
+        WriteLine("        is omitted, the default configuration is `Debug`.");
+        WriteLine();
+        WriteLine("    -n");
+        WriteLine("    --no-build");
+        WriteLine("        Skip building the test project prior to running it.");
+        WriteLine();
+        WriteLine("    -f <framework>");
+        WriteLine("    --framework <framework>");
+        WriteLine("        Only run test assemblies targeting a specific framework.");
+        WriteLine();
+        WriteLine("    -t <pattern>");
+        WriteLine("    --tests <pattern>");
+        WriteLine("        Run only the tests whose full names match the given pattern.");
+        WriteLine();
+        WriteLine("    --");
+        WriteLine("        Signifies the end of built-in arguments and the beginning");
+        WriteLine("        of custom arguments.");
+        WriteLine();
+        WriteLine("    custom arguments");
+        WriteLine("        Arbitrary arguments made available to custom discovery/execution classes.");
+        WriteLine();
+    }
+
+    static void Heading(string message)
+    {
+        using (Foreground.Green)
+            WriteLine(message);
+    }
+
+    static void Error(string message)
+    {
+        WriteLine();
+        using (Foreground.Red)
+            WriteLine(message);
     }
 }

--- a/src/Fixie.Console/Shell.cs
+++ b/src/Fixie.Console/Shell.cs
@@ -1,100 +1,99 @@
-﻿namespace Fixie.Console
+﻿namespace Fixie.Console;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+static class Shell
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IO;
-
-    static class Shell
+    public static int Run(string executable, string workingDirectory, string[] arguments, IDictionary<string, string>? environmentVariables = null)
     {
-        public static int Run(string executable, string workingDirectory, string[] arguments, IDictionary<string, string>? environmentVariables = null)
+        var startInfo = new ProcessStartInfo
         {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = executable,
-                WorkingDirectory = workingDirectory,
-                UseShellExecute = false
-            };
+            FileName = executable,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false
+        };
 
-            foreach (var argument in arguments)
-                startInfo.ArgumentList.Add(argument);
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
 
-            if (environmentVariables != null)
-                foreach (var pair in environmentVariables)
-                    startInfo.Environment.Add(pair.Key, pair.Value);
+        if (environmentVariables != null)
+            foreach (var pair in environmentVariables)
+                startInfo.Environment.Add(pair.Key, pair.Value);
 
-            return Run(startInfo);
-        }
+        return Run(startInfo);
+    }
 
-        public static int RunTarget(string project, string target, string configuration)
-            => MsBuild(project, target, configuration);
+    public static int RunTarget(string project, string target, string configuration)
+        => MsBuild(project, target, configuration);
 
-        public static string[] QueryTarget(string project, string target)
-            => QueryTarget(project, target, outputPath => MsBuild(project, target, outputPath: outputPath));
+    public static string[] QueryTarget(string project, string target)
+        => QueryTarget(project, target, outputPath => MsBuild(project, target, outputPath: outputPath));
 
-        public static string[] QueryTarget(string project, string target, string configuration, string targetFramework)
-            => QueryTarget(project, target, outputPath => MsBuild(project, target, configuration, targetFramework, outputPath));
+    public static string[] QueryTarget(string project, string target, string configuration, string targetFramework)
+        => QueryTarget(project, target, outputPath => MsBuild(project, target, configuration, targetFramework, outputPath));
 
-        static string[] QueryTarget(string project, string target, Func<string, int> msbuild)
+    static string[] QueryTarget(string project, string target, Func<string, int> msbuild)
+    {
+        var outputPath = Path.GetTempFileName();
+
+        try
         {
-            var outputPath = Path.GetTempFileName();
+            var exitCode = msbuild(outputPath);
 
-            try
-            {
-                var exitCode = msbuild(outputPath);
+            if (exitCode != 0)
+                throw new Exception($"msbuild failed while trying to run target '{target}' in project '{project}'.");
 
-                if (exitCode != 0)
-                    throw new Exception($"msbuild failed while trying to run target '{target}' in project '{project}'.");
-
-                return File.ReadAllLines(outputPath);
-            }
-            finally
-            {
-                File.Delete(outputPath);
-            }
+            return File.ReadAllLines(outputPath);
         }
-
-        static int MsBuild(string project, string target, string? configuration = null, string? targetFramework = null, string? outputPath = null)
+        finally
         {
-            var arguments = new List<string>
-            {
-                "msbuild",
-                project,
-                "/nologo",
-                "/verbosity:minimal",
-                "/t:" + target
-            };
-
-            if (configuration != null)
-                arguments.Add($"/p:Configuration={configuration}");
-
-            if (targetFramework != null)
-                arguments.Add($"/p:TargetFramework={targetFramework}");
-
-            if (outputPath != null)
-                arguments.Add($"/p:_Fixie_OutputFile={outputPath}");
-
-            return Run("dotnet", workingDirectory: "", arguments.ToArray());
+            File.Delete(outputPath);
         }
+    }
 
-        static int Run(ProcessStartInfo startInfo)
+    static int MsBuild(string project, string target, string? configuration = null, string? targetFramework = null, string? outputPath = null)
+    {
+        var arguments = new List<string>
         {
-            using var process = Start(startInfo);
-            process.WaitForExit();
-            return process.ExitCode;
-        }
+            "msbuild",
+            project,
+            "/nologo",
+            "/verbosity:minimal",
+            "/t:" + target
+        };
 
-        static Process Start(ProcessStartInfo startInfo)
+        if (configuration != null)
+            arguments.Add($"/p:Configuration={configuration}");
+
+        if (targetFramework != null)
+            arguments.Add($"/p:TargetFramework={targetFramework}");
+
+        if (outputPath != null)
+            arguments.Add($"/p:_Fixie_OutputFile={outputPath}");
+
+        return Run("dotnet", workingDirectory: "", arguments.ToArray());
+    }
+
+    static int Run(ProcessStartInfo startInfo)
+    {
+        using var process = Start(startInfo);
+        process.WaitForExit();
+        return process.ExitCode;
+    }
+
+    static Process Start(ProcessStartInfo startInfo)
+    {
+        var process = new Process
         {
-            var process = new Process
-            {
-                StartInfo = startInfo
-            };
+            StartInfo = startInfo
+        };
 
-            if (process.Start())
-                return process;
+        if (process.Start())
+            return process;
 
-            throw new Exception("Failed to start process: " + startInfo.FileName);
-        }
+        throw new Exception("Failed to start process: " + startInfo.FileName);
     }
 }

--- a/src/Fixie.TestAdapter/DebuggerAttachmentFailure.cs
+++ b/src/Fixie.TestAdapter/DebuggerAttachmentFailure.cs
@@ -1,27 +1,27 @@
-namespace Fixie.TestAdapter
+namespace Fixie.TestAdapter;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+class DebuggerAttachmentFailure
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
+    public string Message { get; }
+    public Exception ThirdPartyTestHostException { get; }
 
-    class DebuggerAttachmentFailure
+    public DebuggerAttachmentFailure(Exception thirdPartyTestHostException)
     {
-        public string Message { get; }
-        public Exception ThirdPartyTestHostException { get; }
+        ThirdPartyTestHostException = thirdPartyTestHostException;
+        Message = UserGuidanceMessage(thirdPartyTestHostException);
+    }
 
-        public DebuggerAttachmentFailure(Exception thirdPartyTestHostException)
-        {
-            ThirdPartyTestHostException = thirdPartyTestHostException;
-            Message = UserGuidanceMessage(thirdPartyTestHostException);
-        }
+    static string UserGuidanceMessage(Exception thirdPartyTestHostException)
+    {
+        var host = TryGetTestHost(out var testHost)
+            ? $"{Environment.NewLine}{testHost}{Environment.NewLine}"
+            : "";
 
-        static string UserGuidanceMessage(Exception thirdPartyTestHostException)
-        {
-            var host = TryGetTestHost(out var testHost)
-                ? $"{Environment.NewLine}{testHost}{Environment.NewLine}"
-                : "";
-
-            return $@"Fixie attempted to run your test assembly
+        return $@"Fixie attempted to run your test assembly
 under the active debugger session, but the
 third-party test host {host}failed to honor the request to attach to the
 test assembly process. The run continued
@@ -74,20 +74,19 @@ debugger session.
 
 
 {thirdPartyTestHostException.Message}";
-        }
+    }
 
-        static bool TryGetTestHost([NotNullWhen(true)] out string? testHost)
+    static bool TryGetTestHost([NotNullWhen(true)] out string? testHost)
+    {
+        try
         {
-            try
-            {
-                testHost = Environment.GetCommandLineArgs().First();
-            }
-            catch
-            {
-                testHost = null;
-            }
-
-            return testHost != null;
+            testHost = Environment.GetCommandLineArgs().First();
         }
+        catch
+        {
+            testHost = null;
+        }
+
+        return testHost != null;
     }
 }

--- a/src/Fixie.TestAdapter/LoggingExtensions.cs
+++ b/src/Fixie.TestAdapter/LoggingExtensions.cs
@@ -1,21 +1,20 @@
-﻿namespace Fixie.TestAdapter
+﻿namespace Fixie.TestAdapter;
+
+using System;
+using Internal;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+static class LoggingExtensions
 {
-    using System;
-    using Internal;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+    public static void Info(this IMessageLogger logger, string message)
+        => logger.SendMessage(TestMessageLevel.Informational, message);
 
-    static class LoggingExtensions
-    {
-        public static void Info(this IMessageLogger logger, string message)
-            => logger.SendMessage(TestMessageLevel.Informational, message);
+    public static void Error(this IMessageLogger logger, string message)
+        => logger.SendMessage(TestMessageLevel.Error, message);
 
-        public static void Error(this IMessageLogger logger, string message)
-            => logger.SendMessage(TestMessageLevel.Error, message);
+    public static void Error(this IMessageLogger logger, Exception exception)
+        => logger.SendMessage(TestMessageLevel.Error, exception.ToString());
 
-        public static void Error(this IMessageLogger logger, Exception exception)
-            => logger.SendMessage(TestMessageLevel.Error, exception.ToString());
-
-        public static void Version(this IMessageLogger logger)
-            => logger.Info(Framework.Version);
-    }
+    public static void Version(this IMessageLogger logger)
+        => logger.Info(Framework.Version);
 }

--- a/src/Fixie.TestAdapter/RunnerException.cs
+++ b/src/Fixie.TestAdapter/RunnerException.cs
@@ -1,26 +1,25 @@
-﻿namespace Fixie.TestAdapter
+﻿namespace Fixie.TestAdapter;
+
+using System;
+using System.Text;
+using Internal;
+
+class RunnerException : Exception
 {
-    using System;
-    using System.Text;
-    using Internal;
-
-    class RunnerException : Exception
+    public RunnerException(Exception exception)
+        : base(exception.ToString())
     {
-        public RunnerException(Exception exception)
-            : base(exception.ToString())
-        {
-        }
+    }
 
-        public RunnerException(PipeMessage.Exception exception)
-            : base(new StringBuilder()
-                .AppendLine()
-                .AppendLine()
-                .AppendLine(exception.Message)
-                .AppendLine()
-                .AppendLine(exception.Type)
-                .AppendLine(exception.StackTrace)
-                .ToString())
-        {
-        }
+    public RunnerException(PipeMessage.Exception exception)
+        : base(new StringBuilder()
+            .AppendLine()
+            .AppendLine()
+            .AppendLine(exception.Message)
+            .AppendLine()
+            .AppendLine(exception.Type)
+            .AppendLine(exception.StackTrace)
+            .ToString())
+    {
     }
 }

--- a/src/Fixie.TestAdapter/SourceLocation.cs
+++ b/src/Fixie.TestAdapter/SourceLocation.cs
@@ -1,14 +1,13 @@
-﻿namespace Fixie.TestAdapter
-{
-    class SourceLocation
-    {
-        public SourceLocation(string codeFilePath, int lineNumber)
-        {
-            CodeFilePath = codeFilePath;
-            LineNumber = lineNumber;
-        }
+﻿namespace Fixie.TestAdapter;
 
-        public string CodeFilePath { get; }
-        public int LineNumber { get; }
+class SourceLocation
+{
+    public SourceLocation(string codeFilePath, int lineNumber)
+    {
+        CodeFilePath = codeFilePath;
+        LineNumber = lineNumber;
     }
+
+    public string CodeFilePath { get; }
+    public int LineNumber { get; }
 }

--- a/src/Fixie.TestAdapter/SourceLocationProvider.cs
+++ b/src/Fixie.TestAdapter/SourceLocationProvider.cs
@@ -1,141 +1,140 @@
-namespace Fixie.TestAdapter
+namespace Fixie.TestAdapter;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
+
+class SourceLocationProvider
 {
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
-    using System.Runtime.CompilerServices;
-    using Mono.Cecil;
-    using Mono.Cecil.Cil;
-    using Mono.Cecil.Rocks;
+    readonly string assemblyPath;
+    Dictionary<string, Dictionary<string, SourceLocation>>? sourceLocations;
 
-    class SourceLocationProvider
+    public SourceLocationProvider(string assemblyPath)
     {
-        readonly string assemblyPath;
-        Dictionary<string, Dictionary<string, SourceLocation>>? sourceLocations;
+        this.assemblyPath = assemblyPath;
+    }
 
-        public SourceLocationProvider(string assemblyPath)
+    public bool TryGetSourceLocation(string test, [NotNullWhen(true)] out SourceLocation? sourceLocation)
+    {
+        if (sourceLocations == null)
+            sourceLocations = CacheLocations(assemblyPath);
+
+        sourceLocation = null;
+
+        if (TryParse(test, out var className, out var methodName))
+            if (sourceLocations.TryGetValue(StandardizeTypeName(className), out var type))
+                if (type.TryGetValue(methodName, out var firstOverloadLocation))
+                    sourceLocation = firstOverloadLocation;
+
+        return sourceLocation != null;
+    }
+
+    static bool TryParse(string fullyQualifiedMethodName, [NotNullWhen(true)] out string? className, [NotNullWhen(true)] out string? methodName)
+    {
+        var indexOfMemberSeparator = fullyQualifiedMethodName.LastIndexOf(".");
+
+        if (indexOfMemberSeparator >= 0)
         {
-            this.assemblyPath = assemblyPath;
+            className = fullyQualifiedMethodName.Substring(0, indexOfMemberSeparator);
+            methodName = fullyQualifiedMethodName.Substring(indexOfMemberSeparator + 1);
+
+            if (className.Length > 0 && methodName.Length > 0)
+                return true;
         }
 
-        public bool TryGetSourceLocation(string test, [NotNullWhen(true)] out SourceLocation? sourceLocation)
+        className = null;
+        methodName = null;
+        return false;
+    }
+
+    static Dictionary<string, Dictionary<string, SourceLocation>> CacheLocations(string assemblyPath)
+    {
+        var readerParameters = new ReaderParameters { ReadSymbols = true };
+        using var module = ModuleDefinition.ReadModule(assemblyPath, readerParameters);
+
+        return module.GetTypes().Where(type => type.IsClass).ToDictionary(type => type.FullName, MethodLocations);
+    }
+
+    static Dictionary<string, SourceLocation> MethodLocations(TypeDefinition type)
+    {
+        var methodLocations = new Dictionary<string, SourceLocation>();
+
+        foreach (var method in type.GetMethods())
         {
-            if (sourceLocations == null)
-                sourceLocations = CacheLocations(assemblyPath);
-
-            sourceLocation = null;
-
-            if (TryParse(test, out var className, out var methodName))
-                if (sourceLocations.TryGetValue(StandardizeTypeName(className), out var type))
-                    if (type.TryGetValue(methodName, out var firstOverloadLocation))
-                        sourceLocation = firstOverloadLocation;
-
-            return sourceLocation != null;
-        }
-
-        static bool TryParse(string fullyQualifiedMethodName, [NotNullWhen(true)] out string? className, [NotNullWhen(true)] out string? methodName)
-        {
-            var indexOfMemberSeparator = fullyQualifiedMethodName.LastIndexOf(".");
-
-            if (indexOfMemberSeparator >= 0)
+            if (!method.IsAbstract)
             {
-                className = fullyQualifiedMethodName.Substring(0, indexOfMemberSeparator);
-                methodName = fullyQualifiedMethodName.Substring(indexOfMemberSeparator + 1);
+                var location = FirstOrDefaultSourceLocation(method);
 
-                if (className.Length > 0 && methodName.Length > 0)
-                    return true;
+                if (location != null && !methodLocations.ContainsKey(method.Name))
+                    methodLocations[method.Name] = location;
             }
-
-            className = null;
-            methodName = null;
-            return false;
         }
 
-        static Dictionary<string, Dictionary<string, SourceLocation>> CacheLocations(string assemblyPath)
-        {
-            var readerParameters = new ReaderParameters { ReadSymbols = true };
-            using var module = ModuleDefinition.ReadModule(assemblyPath, readerParameters);
+        return methodLocations;
+    }
 
-            return module.GetTypes().Where(type => type.IsClass).ToDictionary(type => type.FullName, MethodLocations);
-        }
+    static SourceLocation? FirstOrDefaultSourceLocation(MethodDefinition method)
+    {
+        var sequencePoint = FirstOrDefaultSequencePoint(method);
 
-        static Dictionary<string, SourceLocation> MethodLocations(TypeDefinition type)
-        {
-            var methodLocations = new Dictionary<string, SourceLocation>();
-
-            foreach (var method in type.GetMethods())
-            {
-                if (!method.IsAbstract)
-                {
-                    var location = FirstOrDefaultSourceLocation(method);
-
-                    if (location != null && !methodLocations.ContainsKey(method.Name))
-                        methodLocations[method.Name] = location;
-                }
-            }
-
-            return methodLocations;
-        }
-
-        static SourceLocation? FirstOrDefaultSourceLocation(MethodDefinition method)
-        {
-            var sequencePoint = FirstOrDefaultSequencePoint(method);
-
-            if (sequencePoint != null)
-                return new SourceLocation(sequencePoint.Document.Url, sequencePoint.StartLine);
+        if (sequencePoint != null)
+            return new SourceLocation(sequencePoint.Document.Url, sequencePoint.StartLine);
             
-            return null;
-        }
+        return null;
+    }
 
-        static SequencePoint? FirstOrDefaultSequencePoint(MethodDefinition testMethod)
+    static SequencePoint? FirstOrDefaultSequencePoint(MethodDefinition testMethod)
+    {
+        if (TryGetAsyncStateMachineAttribute(testMethod, out var asyncStateMachineAttribute))
+            testMethod = GetStateMachineMoveNextMethod(asyncStateMachineAttribute);
+
+        return FirstOrDefaultUnhiddenSequencePoint(testMethod.Body);
+    }
+
+    static bool TryGetAsyncStateMachineAttribute(MethodDefinition method, [NotNullWhen(true)] out CustomAttribute? attribute)
+    {
+        attribute = method.CustomAttributes.FirstOrDefault(c => c.AttributeType.Name == nameof(AsyncStateMachineAttribute));
+        return attribute != null;
+    }
+
+    static MethodDefinition GetStateMachineMoveNextMethod(CustomAttribute asyncStateMachineAttribute)
+    {
+        var stateMachineType = (TypeDefinition)asyncStateMachineAttribute.ConstructorArguments[0].Value;
+        var stateMachineMoveNextMethod = stateMachineType.GetMethods().First(m => m.Name == "MoveNext");
+        return stateMachineMoveNextMethod;
+    }
+
+    static SequencePoint? FirstOrDefaultUnhiddenSequencePoint(MethodBody? body)
+    {
+        const int lineNumberIndicatingHiddenLine = 16707566; //0xfeefee
+
+        if (body != null)
         {
-            if (TryGetAsyncStateMachineAttribute(testMethod, out var asyncStateMachineAttribute))
-                testMethod = GetStateMachineMoveNextMethod(asyncStateMachineAttribute);
-
-            return FirstOrDefaultUnhiddenSequencePoint(testMethod.Body);
-        }
-
-        static bool TryGetAsyncStateMachineAttribute(MethodDefinition method, [NotNullWhen(true)] out CustomAttribute? attribute)
-        {
-            attribute = method.CustomAttributes.FirstOrDefault(c => c.AttributeType.Name == nameof(AsyncStateMachineAttribute));
-            return attribute != null;
-        }
-
-        static MethodDefinition GetStateMachineMoveNextMethod(CustomAttribute asyncStateMachineAttribute)
-        {
-            var stateMachineType = (TypeDefinition)asyncStateMachineAttribute.ConstructorArguments[0].Value;
-            var stateMachineMoveNextMethod = stateMachineType.GetMethods().First(m => m.Name == "MoveNext");
-            return stateMachineMoveNextMethod;
-        }
-
-        static SequencePoint? FirstOrDefaultUnhiddenSequencePoint(MethodBody? body)
-        {
-            const int lineNumberIndicatingHiddenLine = 16707566; //0xfeefee
-
-            if (body != null)
+            foreach (var instruction in body.Instructions)
             {
-                foreach (var instruction in body.Instructions)
+                var sequencePoint = body.Method.DebugInformation.GetSequencePoint(instruction);
+                if (sequencePoint != null && sequencePoint.StartLine != lineNumberIndicatingHiddenLine)
                 {
-                    var sequencePoint = body.Method.DebugInformation.GetSequencePoint(instruction);
-                    if (sequencePoint != null && sequencePoint.StartLine != lineNumberIndicatingHiddenLine)
-                    {
-                        return sequencePoint;
-                    }
+                    return sequencePoint;
                 }
             }
-
-            return null;
         }
 
-        static string StandardizeTypeName(string className)
-        {
-            //Mono.Cecil respects ECMA-335 for the FullName of a type, which can differ from Type.FullName.
-            //In order to make reliable comparisons between the class part of a test name, the class part
-            //must be standardized to the ECMA-335 format.
-            //
-            //ECMA-335 specifies "/" instead of "+" to indicate a nested type.
+        return null;
+    }
 
-            return className.Replace("+", "/");
-        }
+    static string StandardizeTypeName(string className)
+    {
+        //Mono.Cecil respects ECMA-335 for the FullName of a type, which can differ from Type.FullName.
+        //In order to make reliable comparisons between the class part of a test name, the class part
+        //must be standardized to the ECMA-335 format.
+        //
+        //ECMA-335 specifies "/" instead of "+" to indicate a nested type.
+
+        return className.Replace("+", "/");
     }
 }

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -1,18 +1,18 @@
-namespace Fixie.TestAdapter
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Linq;
-    using System.Runtime.InteropServices;
-    using System.Text.RegularExpressions;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+namespace Fixie.TestAdapter;
 
-    static class TestAssembly
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+static class TestAssembly
+{
+    public static bool IsTestAssembly(string assemblyPath)
     {
-        public static bool IsTestAssembly(string assemblyPath)
-        {
             var fixieAssemblies = new[]
             {
                 "Fixie.dll", "Fixie.TestAdapter.dll"
@@ -26,22 +26,22 @@ namespace Fixie.TestAdapter
             return File.Exists(Path.Combine(folderPath, "Fixie.dll"));
         }
 
-        public static int? TryGetExitCode(this Process? process)
-        {
+    public static int? TryGetExitCode(this Process? process)
+    {
             if (process != null && process.WaitForExit(5000))
                 return process.ExitCode;
 
             return null;
         }
 
-        public static Process StartDiscovery(string assemblyPath)
-        {
+    public static Process StartDiscovery(string assemblyPath)
+    {
             return Run(assemblyPath);
         }
 
-        public static Process? StartExecution(string assemblyPath, IFrameworkHandle frameworkHandle,
-            out DebuggerAttachmentFailure? attachmentFailure)
-        {
+    public static Process? StartExecution(string assemblyPath, IFrameworkHandle frameworkHandle,
+        out DebuggerAttachmentFailure? attachmentFailure)
+    {
             attachmentFailure = null;
 
             if (Debugger.IsAttached)
@@ -50,8 +50,8 @@ namespace Fixie.TestAdapter
             return Run(assemblyPath);
         }
 
-        static Process Run(string assemblyPath)
-        {
+    static Process Run(string assemblyPath)
+    {
             var arguments = new[] { assemblyPath };
 
             var startInfo = new ProcessStartInfo
@@ -67,9 +67,9 @@ namespace Fixie.TestAdapter
             return Start(startInfo);
         }
 
-        static Process? RunAttemptingDebuggerAttachment(string assemblyPath, IFrameworkHandle frameworkHandle,
-            out DebuggerAttachmentFailure? attachmentFailure)
-        {
+    static Process? RunAttemptingDebuggerAttachment(string assemblyPath, IFrameworkHandle frameworkHandle,
+        out DebuggerAttachmentFailure? attachmentFailure)
+    {
             attachmentFailure = null;
 
             // LaunchProcessWithDebuggerAttached sends a request back
@@ -114,13 +114,13 @@ namespace Fixie.TestAdapter
             }
         }
 
-        static string WorkingDirectory(string assemblyPath)
-        {
+    static string WorkingDirectory(string assemblyPath)
+    {
             return Path.GetDirectoryName(Path.GetFullPath(assemblyPath))!;
         }
 
-        static Process Start(ProcessStartInfo startInfo)
-        {
+    static Process Start(ProcessStartInfo startInfo)
+    {
             var process = new Process
             {
                 StartInfo = startInfo
@@ -132,8 +132,8 @@ namespace Fixie.TestAdapter
             throw new Exception("Failed to start process: " + startInfo.FileName);
         }
 
-        static string FindDotnet()
-        {
+    static string FindDotnet()
+    {
             var fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
 
             var folderPath = Environment
@@ -149,18 +149,18 @@ namespace Fixie.TestAdapter
             return Path.Combine(folderPath.Trim(), fileName);
         }
 
-        /// <summary>
-        /// Serialize the given string[] to a single string, so that when used as a ProcessStartInfo.Arguments
-        /// value, the process's Main method will receive the original string[].
-        /// 
-        /// See https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
-        /// See https://stackoverflow.com/a/6040946 for the regex approach used here.
-        /// </summary>
-        public static string Serialize(string[] arguments)
-            => string.Join(" ", arguments.Select(Quote));
+    /// <summary>
+    /// Serialize the given string[] to a single string, so that when used as a ProcessStartInfo.Arguments
+    /// value, the process's Main method will receive the original string[].
+    /// 
+    /// See https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+    /// See https://stackoverflow.com/a/6040946 for the regex approach used here.
+    /// </summary>
+    public static string Serialize(string[] arguments)
+        => string.Join(" ", arguments.Select(Quote));
 
-        static string Quote(string argument)
-        {
+    static string Quote(string argument)
+    {
             //For each substring of zero or more \ followed by "
             //replace it with twice as many \ followed by \"
             var s = Regex.Replace(argument, @"(\\*)" + '"', @"$1$1\" + '"');
@@ -171,5 +171,4 @@ namespace Fixie.TestAdapter
             //Now that the content has been escaped, surround the value in quotes.
             return '"' + s + '"';
         }
-    }
 }

--- a/src/Fixie.TestAdapter/TestProcessExitException.cs
+++ b/src/Fixie.TestAdapter/TestProcessExitException.cs
@@ -1,30 +1,29 @@
-﻿namespace Fixie.TestAdapter
+﻿namespace Fixie.TestAdapter;
+
+using System;
+
+public class TestProcessExitException : Exception
 {
-    using System;
+    const int StackOverflowExitCode = -1073741571;
 
-    public class TestProcessExitException : Exception
+    public TestProcessExitException(int? exitCode)
+        : base(GetMessage(exitCode))
     {
-        const int StackOverflowExitCode = -1073741571;
+    }
 
-        public TestProcessExitException(int? exitCode)
-            : base(GetMessage(exitCode))
+    static string GetMessage(int? exitCode)
+    {
+        const string exitedUnexpectedly = "The test assembly process exited unexpectedly";
+
+        if (exitCode != null)
         {
+            var withExitCode = $"with exit code {exitCode}";
+
+            return exitCode == StackOverflowExitCode
+                ? $"{exitedUnexpectedly} {withExitCode}, indicating the test threw a StackOverflowException."
+                : $"{exitedUnexpectedly} {withExitCode}.";
         }
 
-        static string GetMessage(int? exitCode)
-        {
-            const string exitedUnexpectedly = "The test assembly process exited unexpectedly";
-
-            if (exitCode != null)
-            {
-                var withExitCode = $"with exit code {exitCode}";
-
-                return exitCode == StackOverflowExitCode
-                    ? $"{exitedUnexpectedly} {withExitCode}, indicating the test threw a StackOverflowException."
-                    : $"{exitedUnexpectedly} {withExitCode}.";
-            }
-
-            return $"{exitedUnexpectedly}.";
-        }
+        return $"{exitedUnexpectedly}.";
     }
 }

--- a/src/Fixie.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.TestAdapter/VsTestDiscoverer.cs
@@ -1,85 +1,84 @@
-﻿namespace Fixie.TestAdapter
+﻿namespace Fixie.TestAdapter;
+
+using System;
+using System.Collections.Generic;
+using System.IO.Pipes;
+using Internal;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using static TestAssembly;
+
+[DefaultExecutorUri(VsTestExecutor.Id)]
+[FileExtension(".exe")]
+[FileExtension(".dll")]
+class VsTestDiscoverer : ITestDiscoverer
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO.Pipes;
-    using Internal;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-    using static TestAssembly;
-
-    [DefaultExecutorUri(VsTestExecutor.Id)]
-    [FileExtension(".exe")]
-    [FileExtension(".dll")]
-    class VsTestDiscoverer : ITestDiscoverer
+    public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger log, ITestCaseDiscoverySink discoverySink)
     {
-        public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger log, ITestCaseDiscoverySink discoverySink)
+        try
         {
-            try
-            {
-                log.Version();
+            log.Version();
 
-                foreach (var assemblyPath in sources)
-                    DiscoverTests(log, discoverySink, assemblyPath);
-            }
-            catch (Exception exception)
-            {
-                throw new RunnerException(exception);
-            }
+            foreach (var assemblyPath in sources)
+                DiscoverTests(log, discoverySink, assemblyPath);
+        }
+        catch (Exception exception)
+        {
+            throw new RunnerException(exception);
+        }
+    }
+
+    static void DiscoverTests(IMessageLogger log, ITestCaseDiscoverySink discoverySink, string assemblyPath)
+    {
+        if (!IsTestAssembly(assemblyPath))
+        {
+            log.Info("Skipping " + assemblyPath + " because it is not a test assembly.");
+            return;
         }
 
-        static void DiscoverTests(IMessageLogger log, ITestCaseDiscoverySink discoverySink, string assemblyPath)
+        log.Info("Processing " + assemblyPath);
+
+        var pipeName = Guid.NewGuid().ToString();
+        Environment.SetEnvironmentVariable("FIXIE_NAMED_PIPE", pipeName);
+
+        using (var pipeStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
+        using (var pipe = new TestAdapterPipe(pipeStream))
+        using (var process = StartDiscovery(assemblyPath))
         {
-            if (!IsTestAssembly(assemblyPath))
+            pipeStream.WaitForConnection();
+
+            pipe.Send<PipeMessage.DiscoverTests>();
+
+            var recorder = new VsDiscoveryRecorder(log, discoverySink, assemblyPath);
+
+            while (true)
             {
-                log.Info("Skipping " + assemblyPath + " because it is not a test assembly.");
-                return;
-            }
+                var messageType = pipe.ReceiveMessageType();
 
-            log.Info("Processing " + assemblyPath);
-
-            var pipeName = Guid.NewGuid().ToString();
-            Environment.SetEnvironmentVariable("FIXIE_NAMED_PIPE", pipeName);
-
-            using (var pipeStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
-            using (var pipe = new TestAdapterPipe(pipeStream))
-            using (var process = StartDiscovery(assemblyPath))
-            {
-                pipeStream.WaitForConnection();
-
-                pipe.Send<PipeMessage.DiscoverTests>();
-
-                var recorder = new VsDiscoveryRecorder(log, discoverySink, assemblyPath);
-
-                while (true)
+                if (messageType == typeof(PipeMessage.TestDiscovered).FullName)
                 {
-                    var messageType = pipe.ReceiveMessageType();
-
-                    if (messageType == typeof(PipeMessage.TestDiscovered).FullName)
-                    {
-                        var testDiscovered = pipe.Receive<PipeMessage.TestDiscovered>();
-                        recorder.Record(testDiscovered);
-                    }
-                    else if (messageType == typeof(PipeMessage.Exception).FullName)
-                    {
-                        var exception = pipe.Receive<PipeMessage.Exception>();
-                        throw new RunnerException(exception);
-                    }
-                    else if (messageType == typeof(PipeMessage.EndOfPipe).FullName)
-                    {
-                        var endOfPipe = pipe.Receive<PipeMessage.EndOfPipe>();
-                        break;
-                    }
-                    else if (!string.IsNullOrEmpty(messageType))
-                    {
-                        var body = pipe.ReceiveMessageBody();
-                        log.Error($"The test runner received an unexpected message of type {messageType}: {body}");
-                    }
-                    else
-                    {
-                        throw new TestProcessExitException(process.TryGetExitCode());
-                    }
+                    var testDiscovered = pipe.Receive<PipeMessage.TestDiscovered>();
+                    recorder.Record(testDiscovered);
+                }
+                else if (messageType == typeof(PipeMessage.Exception).FullName)
+                {
+                    var exception = pipe.Receive<PipeMessage.Exception>();
+                    throw new RunnerException(exception);
+                }
+                else if (messageType == typeof(PipeMessage.EndOfPipe).FullName)
+                {
+                    var endOfPipe = pipe.Receive<PipeMessage.EndOfPipe>();
+                    break;
+                }
+                else if (!string.IsNullOrEmpty(messageType))
+                {
+                    var body = pipe.ReceiveMessageBody();
+                    log.Error($"The test runner received an unexpected message of type {messageType}: {body}");
+                }
+                else
+                {
+                    throw new TestProcessExitException(process.TryGetExitCode());
                 }
             }
         }

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -1,219 +1,218 @@
-﻿namespace Fixie.TestAdapter
+﻿namespace Fixie.TestAdapter;
+
+using System;
+using System.Collections.Generic;
+using System.IO.Pipes;
+using System.Linq;
+using Internal;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using static TestAssembly;
+
+[ExtensionUri(Id)]
+public class VsTestExecutor : ITestExecutor
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO.Pipes;
-    using System.Linq;
-    using Internal;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-    using static TestAssembly;
+    public const string Id = "executor://fixie.testadapter/";
+    public static readonly Uri Uri = new Uri(Id);
 
-    [ExtensionUri(Id)]
-    public class VsTestExecutor : ITestExecutor
+    /// <summary>
+    /// This method was originally intended to be called by VsTest when running
+    /// all tests. However, VsTest no longer appears to call this method, instead
+    /// favoring its overload with all individual tests specified as if they were
+    /// all selected by the user. The stated reason is for performance, but in
+    /// fact requires far larger messages to be passed between processes and far
+    /// more cross-referencing of test names within each specific test framework
+    /// at execution time. This overload is maintained optimistically and for
+    /// protection in the event that VsTest changes back to the more efficient
+    /// approach.
+    /// </summary>
+    public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
     {
-        public const string Id = "executor://fixie.testadapter/";
-        public static readonly Uri Uri = new Uri(Id);
+        ArgumentNullException.ThrowIfNull(sources);
+        ArgumentNullException.ThrowIfNull(frameworkHandle);
 
-        /// <summary>
-        /// This method was originally intended to be called by VsTest when running
-        /// all tests. However, VsTest no longer appears to call this method, instead
-        /// favoring its overload with all individual tests specified as if they were
-        /// all selected by the user. The stated reason is for performance, but in
-        /// fact requires far larger messages to be passed between processes and far
-        /// more cross-referencing of test names within each specific test framework
-        /// at execution time. This overload is maintained optimistically and for
-        /// protection in the event that VsTest changes back to the more efficient
-        /// approach.
-        /// </summary>
-        public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+        try
         {
-            ArgumentNullException.ThrowIfNull(sources);
-            ArgumentNullException.ThrowIfNull(frameworkHandle);
+            IMessageLogger log = frameworkHandle;
 
-            try
+            log.Version();
+
+            HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
+
+            var executeTests = new PipeMessage.ExecuteTests
             {
-                IMessageLogger log = frameworkHandle;
+                Filter = new string[] { }
+            };
 
-                log.Version();
+            foreach (var assemblyPath in sources)
+                RunTests(log, frameworkHandle, assemblyPath, executeTests);
+        }
+        catch (Exception exception)
+        {
+            throw new RunnerException(exception);
+        }
+    }
 
-                HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
+    /// <summary>
+    /// This method was originally intended to be called by VsTest only when running
+    /// a selected subset of previously discovered tests. However, VsTest appears to
+    /// call this method even in the event the user is running *all* tests, with all
+    /// individual tests specified in the input as if all were individually selected
+    /// by the user. The stated reason is for performance, but in fact requires far
+    /// larger messages to be passed between processes and far more cross-referencing
+    /// of test names within each specific test framework at execution time. Still,
+    /// this overload is functionally correct even when all tests are passed to it.
+    /// </summary>
+    public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+    {
+        ArgumentNullException.ThrowIfNull(tests);
+        ArgumentNullException.ThrowIfNull(frameworkHandle);
+
+        try
+        {
+            IMessageLogger log = frameworkHandle;
+
+            log.Version();
+
+            HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
+
+            var assemblyGroups = tests.GroupBy(tc => tc.Source);
+
+            foreach (var assemblyGroup in assemblyGroups)
+            {
+                var assemblyPath = assemblyGroup.Key;
 
                 var executeTests = new PipeMessage.ExecuteTests
                 {
-                    Filter = new string[] { }
+                    Filter = assemblyGroup.Select(x => x.FullyQualifiedName).ToArray()
                 };
 
-                foreach (var assemblyPath in sources)
-                    RunTests(log, frameworkHandle, assemblyPath, executeTests);
-            }
-            catch (Exception exception)
-            {
-                throw new RunnerException(exception);
+                RunTests(log, frameworkHandle, assemblyPath, executeTests);
             }
         }
-
-        /// <summary>
-        /// This method was originally intended to be called by VsTest only when running
-        /// a selected subset of previously discovered tests. However, VsTest appears to
-        /// call this method even in the event the user is running *all* tests, with all
-        /// individual tests specified in the input as if all were individually selected
-        /// by the user. The stated reason is for performance, but in fact requires far
-        /// larger messages to be passed between processes and far more cross-referencing
-        /// of test names within each specific test framework at execution time. Still,
-        /// this overload is functionally correct even when all tests are passed to it.
-        /// </summary>
-        public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+        catch (Exception exception)
         {
-            ArgumentNullException.ThrowIfNull(tests);
-            ArgumentNullException.ThrowIfNull(frameworkHandle);
+            throw new RunnerException(exception);
+        }
+    }
 
-            try
-            {
-                IMessageLogger log = frameworkHandle;
+    public void Cancel() { }
 
-                log.Version();
-
-                HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
-
-                var assemblyGroups = tests.GroupBy(tc => tc.Source);
-
-                foreach (var assemblyGroup in assemblyGroups)
-                {
-                    var assemblyPath = assemblyGroup.Key;
-
-                    var executeTests = new PipeMessage.ExecuteTests
-                    {
-                        Filter = assemblyGroup.Select(x => x.FullyQualifiedName).ToArray()
-                    };
-
-                    RunTests(log, frameworkHandle, assemblyPath, executeTests);
-                }
-            }
-            catch (Exception exception)
-            {
-                throw new RunnerException(exception);
-            }
+    static void RunTests(IMessageLogger log, IFrameworkHandle frameworkHandle, string assemblyPath, PipeMessage.ExecuteTests executeTests)
+    {
+        if (!IsTestAssembly(assemblyPath))
+        {
+            log.Info("Skipping " + assemblyPath + " because it is not a test assembly.");
+            return;
         }
 
-        public void Cancel() { }
+        log.Info("Processing " + assemblyPath);
 
-        static void RunTests(IMessageLogger log, IFrameworkHandle frameworkHandle, string assemblyPath, PipeMessage.ExecuteTests executeTests)
+        var pipeName = Guid.NewGuid().ToString();
+        Environment.SetEnvironmentVariable("FIXIE_NAMED_PIPE", pipeName);
+
+        using (var pipeStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
+        using (var pipe = new TestAdapterPipe(pipeStream))
+        using (var process = StartExecution(assemblyPath, frameworkHandle, out var attachmentFailure))
         {
-            if (!IsTestAssembly(assemblyPath))
+            pipeStream.WaitForConnection();
+
+            pipe.Send(executeTests);
+
+            var recorder = new VsExecutionRecorder(frameworkHandle, assemblyPath);
+
+            PipeMessage.TestStarted? lastTestStarted = null;
+
+            while (true)
             {
-                log.Info("Skipping " + assemblyPath + " because it is not a test assembly.");
-                return;
-            }
+                var messageType = pipe.ReceiveMessageType();
 
-            log.Info("Processing " + assemblyPath);
-
-            var pipeName = Guid.NewGuid().ToString();
-            Environment.SetEnvironmentVariable("FIXIE_NAMED_PIPE", pipeName);
-
-            using (var pipeStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte))
-            using (var pipe = new TestAdapterPipe(pipeStream))
-            using (var process = StartExecution(assemblyPath, frameworkHandle, out var attachmentFailure))
-            {
-                pipeStream.WaitForConnection();
-
-                pipe.Send(executeTests);
-
-                var recorder = new VsExecutionRecorder(frameworkHandle, assemblyPath);
-
-                PipeMessage.TestStarted? lastTestStarted = null;
-
-                while (true)
+                if (messageType == typeof(PipeMessage.TestStarted).FullName)
                 {
-                    var messageType = pipe.ReceiveMessageType();
-
-                    if (messageType == typeof(PipeMessage.TestStarted).FullName)
-                    {
-                        var message = pipe.Receive<PipeMessage.TestStarted>();
-                        lastTestStarted = message;
-                        recorder.Record(message);
-                    }
-                    else if (messageType == typeof(PipeMessage.TestSkipped).FullName)
-                    {
-                        var testResult = pipe.Receive<PipeMessage.TestSkipped>();
-                        recorder.Record(testResult);
-                    }
-                    else if (messageType == typeof(PipeMessage.TestPassed).FullName)
-                    {
-                        var testResult = pipe.Receive<PipeMessage.TestPassed>();
-                        recorder.Record(testResult);
-                    }
-                    else if (messageType == typeof(PipeMessage.TestFailed).FullName)
-                    {
-                        var testResult = pipe.Receive<PipeMessage.TestFailed>();
-                        recorder.Record(testResult);
-                    }
-                    else if (messageType == typeof(PipeMessage.Exception).FullName)
-                    {
-                        var exception = pipe.Receive<PipeMessage.Exception>();
-                        throw new RunnerException(exception);
-                    }
-                    else if (messageType == typeof(PipeMessage.EndOfPipe).FullName)
-                    {
-                        var endOfPipe = pipe.Receive<PipeMessage.EndOfPipe>();
-                        break;
-                    }
-                    else if (!string.IsNullOrEmpty(messageType))
-                    {
-                        var body = pipe.ReceiveMessageBody();
-                        log.Error($"The test runner received an unexpected message of type {messageType}: {body}");
-                    }
-                    else
-                    {
-                        var exception = new TestProcessExitException(process.TryGetExitCode());
-
-                        if (lastTestStarted != null)
-                        {
-                            recorder.Record(new PipeMessage.TestFailed
-                            {
-                                Test = lastTestStarted.Test,
-                                TestCase = lastTestStarted.Test,
-                                Reason = new PipeMessage.Exception(exception),
-                                DurationInMilliseconds = 0,
-                                Output = ""
-                            });
-                        }
-
-                        throw exception;
-                    }
+                    var message = pipe.Receive<PipeMessage.TestStarted>();
+                    lastTestStarted = message;
+                    recorder.Record(message);
                 }
-
-                if (attachmentFailure != null)
+                else if (messageType == typeof(PipeMessage.TestSkipped).FullName)
                 {
-                    var exception = attachmentFailure.ThirdPartyTestHostException;
+                    var testResult = pipe.Receive<PipeMessage.TestSkipped>();
+                    recorder.Record(testResult);
+                }
+                else if (messageType == typeof(PipeMessage.TestPassed).FullName)
+                {
+                    var testResult = pipe.Receive<PipeMessage.TestPassed>();
+                    recorder.Record(testResult);
+                }
+                else if (messageType == typeof(PipeMessage.TestFailed).FullName)
+                {
+                    var testResult = pipe.Receive<PipeMessage.TestFailed>();
+                    recorder.Record(testResult);
+                }
+                else if (messageType == typeof(PipeMessage.Exception).FullName)
+                {
+                    var exception = pipe.Receive<PipeMessage.Exception>();
+                    throw new RunnerException(exception);
+                }
+                else if (messageType == typeof(PipeMessage.EndOfPipe).FullName)
+                {
+                    var endOfPipe = pipe.Receive<PipeMessage.EndOfPipe>();
+                    break;
+                }
+                else if (!string.IsNullOrEmpty(messageType))
+                {
+                    var body = pipe.ReceiveMessageBody();
+                    log.Error($"The test runner received an unexpected message of type {messageType}: {body}");
+                }
+                else
+                {
+                    var exception = new TestProcessExitException(process.TryGetExitCode());
 
-                    var reason = new PipeMessage.Exception
-                    {
-                        Type = exception.GetType().FullName!,
-                        Message = attachmentFailure.Message,
-                        StackTrace = exception.StackTrace!
-                    };
-
-                    foreach (var selectedTest in executeTests.Filter)
+                    if (lastTestStarted != null)
                     {
                         recorder.Record(new PipeMessage.TestFailed
                         {
-                            Test = selectedTest,
-                            TestCase = selectedTest,
-                            Reason = reason,
+                            Test = lastTestStarted.Test,
+                            TestCase = lastTestStarted.Test,
+                            Reason = new PipeMessage.Exception(exception),
                             DurationInMilliseconds = 0,
                             Output = ""
                         });
                     }
+
+                    throw exception;
+                }
+            }
+
+            if (attachmentFailure != null)
+            {
+                var exception = attachmentFailure.ThirdPartyTestHostException;
+
+                var reason = new PipeMessage.Exception
+                {
+                    Type = exception.GetType().FullName!,
+                    Message = attachmentFailure.Message,
+                    StackTrace = exception.StackTrace!
+                };
+
+                foreach (var selectedTest in executeTests.Filter)
+                {
+                    recorder.Record(new PipeMessage.TestFailed
+                    {
+                        Test = selectedTest,
+                        TestCase = selectedTest,
+                        Reason = reason,
+                        DurationInMilliseconds = 0,
+                        Output = ""
+                    });
                 }
             }
         }
+    }
 
-        static void HandlePoorVsTestImplementationDetails(IRunContext? runContext, IFrameworkHandle frameworkHandle)
-        {
-            if (runContext?.KeepAlive == true)
-                frameworkHandle.EnableShutdownAfterTestRun = true;
-        }
+    static void HandlePoorVsTestImplementationDetails(IRunContext? runContext, IFrameworkHandle frameworkHandle)
+    {
+        if (runContext?.KeepAlive == true)
+            frameworkHandle.EnableShutdownAfterTestRun = true;
     }
 }

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -1,161 +1,160 @@
-namespace Fixie.Tests.Assertions
+namespace Fixie.Tests.Assertions;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+public static class AssertionExtensions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
-    using System.Text.Json;
-    using System.Text.Json.Serialization;
-    using System.Threading.Tasks;
+    static readonly JsonSerializerOptions JsonSerializerOptions;
 
-    public static class AssertionExtensions
+    static AssertionExtensions()
     {
-        static readonly JsonSerializerOptions JsonSerializerOptions;
-
-        static AssertionExtensions()
+        JsonSerializerOptions = new JsonSerializerOptions
         {
-            JsonSerializerOptions = new JsonSerializerOptions
-            {
-                WriteIndented = true
-            };
+            WriteIndented = true
+        };
 
-            JsonSerializerOptions.Converters.Add(new StringRepresentation<Type>());
+        JsonSerializerOptions.Converters.Add(new StringRepresentation<Type>());
+    }
+
+    public static void ShouldBe(this string? actual, string? expected)
+    {
+        if (actual != expected)
+            throw new AssertException(expected, actual);
+    }
+
+    public static void ShouldBe<T>(this IEquatable<T> actual, IEquatable<T> expected)
+    {
+        if (!actual.Equals(expected))
+            throw new AssertException(expected.ToString(), actual.ToString());
+    }
+
+    public static void ShouldBe(this object? actual, object? expected)
+    {
+        if (!Equals(actual, expected))
+            throw new AssertException(expected?.ToString(), actual?.ToString());
+    }
+
+    public static void ShouldBe<T>(this IEnumerable<T> actual, params T[] expected)
+    {
+        actual.ToArray().ShouldMatch(expected);
+    }
+
+    public static T ShouldBe<T>(this object? actual)
+    {
+        if (actual is T typed)
+            return typed;
+
+        throw new AssertException(typeof(T).ToString(), actual?.GetType().ToString());
+    }
+
+    public static void ShouldBeEmpty<T>(this IEnumerable<T> collection)
+    {
+        collection.ShouldMatch(Array.Empty<T>());
+    }
+
+    public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage) where TException : Exception
+    {
+        try
+        {
+            shouldThrow();
+        }
+        catch (Exception actual)
+        {
+            actual
+                .ShouldBe<TException>()
+                .Message.ShouldBe(expectedMessage);
+            return (TException)actual;
         }
 
-        public static void ShouldBe(this string? actual, string? expected)
+        throw new AssertException(typeof(TException).FullName, "No exception was thrown.");
+    }
+
+    public static async Task<TException> ShouldThrowAsync<TException>(this Func<Task> shouldThrowAsync, string expectedMessage) where TException : Exception
+    {
+        try
         {
-            if (actual != expected)
-                throw new AssertException(expected, actual);
+            await shouldThrowAsync();
+        }
+        catch (Exception actual)
+        {
+            actual
+                .ShouldBe<TException>()
+                .Message.ShouldBe(expectedMessage);
+            return (TException)actual;
         }
 
-        public static void ShouldBe<T>(this IEquatable<T> actual, IEquatable<T> expected)
-        {
-            if (!actual.Equals(expected))
-                throw new AssertException(expected.ToString(), actual.ToString());
-        }
+        throw new AssertException(typeof(TException).FullName, "No exception was thrown.");
+    }
 
-        public static void ShouldBe(this object? actual, object? expected)
-        {
-            if (!Equals(actual, expected))
-                throw new AssertException(expected?.ToString(), actual?.ToString());
-        }
+    public static void ShouldBeGreaterThan<T>(this T actual, T minimum) where T: IComparable<T>
+    {
+        if (actual.CompareTo(minimum) <= 0)
+            throw new AssertException($"value > {minimum}", actual.ToString());
+    }
 
-        public static void ShouldBe<T>(this IEnumerable<T> actual, params T[] expected)
-        {
-            actual.ToArray().ShouldMatch(expected);
-        }
+    public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T minimum) where T: IComparable<T>
+    {
+        if (actual.CompareTo(minimum) < 0)
+            throw new AssertException($"value >= {minimum}", actual.ToString());
+    }
 
-        public static T ShouldBe<T>(this object? actual)
-        {
-            if (actual is T typed)
-                return typed;
-
-            throw new AssertException(typeof(T).ToString(), actual?.GetType().ToString());
-        }
-
-        public static void ShouldBeEmpty<T>(this IEnumerable<T> collection)
-        {
-            collection.ShouldMatch(Array.Empty<T>());
-        }
-
-        public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage) where TException : Exception
-        {
-            try
-            {
-                shouldThrow();
-            }
-            catch (Exception actual)
-            {
-                actual
-                    .ShouldBe<TException>()
-                    .Message.ShouldBe(expectedMessage);
-                return (TException)actual;
-            }
-
-            throw new AssertException(typeof(TException).FullName, "No exception was thrown.");
-        }
-
-        public static async Task<TException> ShouldThrowAsync<TException>(this Func<Task> shouldThrowAsync, string expectedMessage) where TException : Exception
-        {
-            try
-            {
-                await shouldThrowAsync();
-            }
-            catch (Exception actual)
-            {
-                actual
-                    .ShouldBe<TException>()
-                    .Message.ShouldBe(expectedMessage);
-                return (TException)actual;
-            }
-
-            throw new AssertException(typeof(TException).FullName, "No exception was thrown.");
-        }
-
-        public static void ShouldBeGreaterThan<T>(this T actual, T minimum) where T: IComparable<T>
-        {
-            if (actual.CompareTo(minimum) <= 0)
-                throw new AssertException($"value > {minimum}", actual.ToString());
-        }
-
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T minimum) where T: IComparable<T>
-        {
-            if (actual.CompareTo(minimum) < 0)
-                throw new AssertException($"value >= {minimum}", actual.ToString());
-        }
-
-        public static void ShouldMatch<T>(this T actual, T expected)
-        {
-            var actualJson = Json(actual);
-            var expectedJson = Json(expected);
+    public static void ShouldMatch<T>(this T actual, T expected)
+    {
+        var actualJson = Json(actual);
+        var expectedJson = Json(expected);
             
-            if (actualJson != expectedJson)
-                throw new AssertException(expectedJson, actualJson);
-        }
+        if (actualJson != expectedJson)
+            throw new AssertException(expectedJson, actualJson);
+    }
 
-        public static void ShouldSatisfy<T>(this IEnumerable<T> actual, params Action<T>[] itemExpectations)
+    public static void ShouldSatisfy<T>(this IEnumerable<T> actual, params Action<T>[] itemExpectations)
+    {
+        var actualItems = actual.ToArray();
+
+        if (actualItems.Length != itemExpectations.Length)
+            throw new AssertException(
+                $"{itemExpectations.Length} items",
+                $"{actualItems.Length} items");
+
+        for (var i = 0; i < actualItems.Length; i++)
+            itemExpectations[i](actualItems[i]);
+    }
+
+    public static void ShouldBeGenericTypeParameter(this Type actual, string expectedName)
+    {
+        actual.IsGenericParameter.ShouldBe(true);
+        actual.FullName.ShouldBe(null);
+        actual.Name.ShouldBe(expectedName);
+    }
+
+    public static void ShouldNotBeNull([NotNull] this object? actual)
+    {
+        if (actual == null)
+            throw new AssertException("not null", "null");
+    }
+
+    static string Json<T>(T @object)
+    {
+        return JsonSerializer.Serialize(@object, JsonSerializerOptions);
+    }
+
+    class StringRepresentation<T> : JsonConverter<T>
+    {
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => throw new NotImplementedException();
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
-            var actualItems = actual.ToArray();
-
-            if (actualItems.Length != itemExpectations.Length)
-                throw new AssertException(
-                    $"{itemExpectations.Length} items",
-                    $"{actualItems.Length} items");
-
-            for (var i = 0; i < actualItems.Length; i++)
-                itemExpectations[i](actualItems[i]);
-        }
-
-        public static void ShouldBeGenericTypeParameter(this Type actual, string expectedName)
-        {
-            actual.IsGenericParameter.ShouldBe(true);
-            actual.FullName.ShouldBe(null);
-            actual.Name.ShouldBe(expectedName);
-        }
-
-        public static void ShouldNotBeNull([NotNull] this object? actual)
-        {
-            if (actual == null)
-                throw new AssertException("not null", "null");
-        }
-
-        static string Json<T>(T @object)
-        {
-            return JsonSerializer.Serialize(@object, JsonSerializerOptions);
-        }
-
-        class StringRepresentation<T> : JsonConverter<T>
-        {
-            public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-                => throw new NotImplementedException();
-
-            public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
-            {
-                if (value is null)
-                    writer.WriteNullValue();
-                else
-                    writer.WriteStringValue(value.ToString());
-            }
+            if (value is null)
+                writer.WriteNullValue();
+            else
+                writer.WriteStringValue(value.ToString());
         }
     }
 }

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -1,15 +1,15 @@
-﻿namespace Fixie.Tests
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Assertions;
+﻿namespace Fixie.Tests;
 
-    public class CaseNameTests
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Assertions;
+
+public class CaseNameTests
+{
+    public async Task ShouldBeNamedAfterTheUnderlyingMethod()
     {
-        public async Task ShouldBeNamedAfterTheUnderlyingMethod()
-        {
             var output = await RunScript<NoParametersTestClass>(async test =>
             {
                 await Run(test);
@@ -18,8 +18,8 @@
             ShouldHaveNames(output, "NoParametersTestClass.NoParameters");
         }
 
-        public async Task ShouldIncludeParameterValuesInNameWhenTheUnderlyingMethodHasParameters()
-        {
+    public async Task ShouldIncludeParameterValuesInNameWhenTheUnderlyingMethodHasParameters()
+    {
             var output = await RunScript<ParameterizedTestClass>(async test =>
             {
                 await Run(test,
@@ -31,8 +31,8 @@
                 "ParameterizedTestClass.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseNameTests, Fixie.Tests.CaseNameTests+ObjectWithNullStringRepresentation)");
         }
 
-        public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()
-        {
+    public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()
+    {
             // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
             // Just like \r and \n, we escape these in order to present a readable string literal. All other unicode sequences pass through
             // with no additional special treatment.
@@ -103,8 +103,8 @@
             );
         }
 
-        public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasStringParameters()
-        {
+    public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasStringParameters()
+    {
             // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
             // Just like \r and \n, we escape these in order to present a readable string literal. All other unicode sequences pass through
             // with no additional special treatment.
@@ -135,8 +135,8 @@
             );
         }
 
-        public async Task ShouldIncludeResolvedGenericArgumentsInNameWhenTheUnderlyingMethodIsGeneric()
-        {
+    public async Task ShouldIncludeResolvedGenericArgumentsInNameWhenTheUnderlyingMethodIsGeneric()
+    {
             var output = await RunScript<GenericTestClass>(async test =>
             {
                 await Run(test, 123, true, "a", "b");
@@ -151,8 +151,8 @@
             );
         }
 
-        public async Task ShouldUseGenericTypeParametersInNameWhenGenericTypeParametersCannotBeResolved()
-        {
+    public async Task ShouldUseGenericTypeParametersInNameWhenGenericTypeParametersCannotBeResolved()
+    {
             var output = await RunScript<ConstrainedGenericTestClass>(async test =>
             {
                 await Run(test, 1);
@@ -167,8 +167,8 @@
             );
         }
 
-        public async Task ShouldInferAppropriateClassUnderInheritance()
-        {
+    public async Task ShouldInferAppropriateClassUnderInheritance()
+    {
             var parent = await RunScript<ParentTestClass>(async test =>
             {
                 await Run(test);
@@ -189,33 +189,33 @@
             );
         }
 
-        class ScriptedExecution : IExecution
+    class ScriptedExecution : IExecution
+    {
+        readonly Func<Test, Task> script;
+
+        public ScriptedExecution(Func<Test, Task> script)
+            => this.script = script;
+
+        public async Task Run(TestSuite testSuite)
         {
-            readonly Func<Test, Task> script;
-
-            public ScriptedExecution(Func<Test, Task> script)
-                => this.script = script;
-
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var test in testSuite.Tests)
                     await script(test);
             }
-        }
+    }
 
-        static Task<IEnumerable<string>> RunScript<TSampleTestClass>(Func<Test, Task> scriptAsync)
-            => Utility.Run(typeof(TSampleTestClass), new ScriptedExecution(scriptAsync));
+    static Task<IEnumerable<string>> RunScript<TSampleTestClass>(Func<Test, Task> scriptAsync)
+        => Utility.Run(typeof(TSampleTestClass), new ScriptedExecution(scriptAsync));
 
-        static async Task Run(Test test, params object?[] parameters)
-        {
+    static async Task Run(Test test, params object?[] parameters)
+    {
             await test.Run(parameters);
             await test.Pass(parameters);
             await test.Fail(parameters, new FailureException());
             await test.Skip(parameters, reason: "Exercising Skipped Case Names");
         }
 
-        void ShouldHaveNames(IEnumerable<string> actual, params string[] expected)
-        {
+    void ShouldHaveNames(IEnumerable<string> actual, params string[] expected)
+    {
             const int variants = 4;
 
             var actualArray = actual.ToArray();
@@ -237,53 +237,52 @@
                 first.ShouldBe(second);
         }
 
-        class ObjectWithNullStringRepresentation
-        {
-            public override string? ToString() => null;
-        }
+    class ObjectWithNullStringRepresentation
+    {
+        public override string? ToString() => null;
+    }
 
-        class NoParametersTestClass
-        {
-            public void NoParameters() { }
-        }
+    class NoParametersTestClass
+    {
+        public void NoParameters() { }
+    }
 
-        class ParameterizedTestClass
-        {
-            public void Parameterized(int i, bool b, char ch, string s1, string s2, object obj, CaseNameTests complex, ObjectWithNullStringRepresentation nullStringRepresentation) { }
-        }
+    class ParameterizedTestClass
+    {
+        public void Parameterized(int i, bool b, char ch, string s1, string s2, object obj, CaseNameTests complex, ObjectWithNullStringRepresentation nullStringRepresentation) { }
+    }
 
-        class CharParametersTestClass
-        {
-            public void Char(char c) { }
-        }
+    class CharParametersTestClass
+    {
+        public void Char(char c) { }
+    }
 
-        class StringParametersTestClass
-        {
-            public void String(string s) { }
-        }
+    class StringParametersTestClass
+    {
+        public void String(string s) { }
+    }
 
-        class GenericTestClass
-        {
-            public void Generic<T1, T2>(int i, T1 t1, T2 t2a, T2 t2b) { }
-        }
+    class GenericTestClass
+    {
+        public void Generic<T1, T2>(int i, T1 t1, T2 t2a, T2 t2b) { }
+    }
 
-        class ConstrainedGenericTestClass
-        {
-            public void ConstrainedGeneric<T>(T t) where T : struct { }
-        }
+    class ConstrainedGenericTestClass
+    {
+        public void ConstrainedGeneric<T>(T t) where T : struct { }
+    }
 
-        class ParentTestClass
+    class ParentTestClass
+    {
+        public void TestMethodDefinedWithinParentClass()
         {
-            public void TestMethodDefinedWithinParentClass()
-            {
             }
-        }
+    }
 
-        class ChildTestClass : ParentTestClass
+    class ChildTestClass : ParentTestClass
+    {
+        public void TestMethodDefinedWithinChildClass()
         {
-            public void TestMethodDefinedWithinChildClass()
-            {
             }
-        }
     }
 }

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -10,184 +10,184 @@ public class CaseNameTests
 {
     public async Task ShouldBeNamedAfterTheUnderlyingMethod()
     {
-            var output = await RunScript<NoParametersTestClass>(async test =>
-            {
-                await Run(test);
-            });
+        var output = await RunScript<NoParametersTestClass>(async test =>
+        {
+            await Run(test);
+        });
 
-            ShouldHaveNames(output, "NoParametersTestClass.NoParameters");
-        }
+        ShouldHaveNames(output, "NoParametersTestClass.NoParameters");
+    }
 
     public async Task ShouldIncludeParameterValuesInNameWhenTheUnderlyingMethodHasParameters()
     {
-            var output = await RunScript<ParameterizedTestClass>(async test =>
-            {
-                await Run(test,
-                    123, true, 'a', "with \"quotes\"", "long \"string\" gets truncated",
-                    null, this, new ObjectWithNullStringRepresentation());
-            });
+        var output = await RunScript<ParameterizedTestClass>(async test =>
+        {
+            await Run(test,
+                123, true, 'a', "with \"quotes\"", "long \"string\" gets truncated",
+                null, this, new ObjectWithNullStringRepresentation());
+        });
 
-            ShouldHaveNames(output,
-                "ParameterizedTestClass.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseNameTests, Fixie.Tests.CaseNameTests+ObjectWithNullStringRepresentation)");
-        }
+        ShouldHaveNames(output,
+            "ParameterizedTestClass.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseNameTests, Fixie.Tests.CaseNameTests+ObjectWithNullStringRepresentation)");
+    }
 
     public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()
     {
-            // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
-            // Just like \r and \n, we escape these in order to present a readable string literal. All other unicode sequences pass through
-            // with no additional special treatment.
+        // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
+        // Just like \r and \n, we escape these in order to present a readable string literal. All other unicode sequences pass through
+        // with no additional special treatment.
 
-            // \uxxxx - Unicode escape sequence for character with hex value xxxx.
-            // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
-            // \Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
+        // \uxxxx - Unicode escape sequence for character with hex value xxxx.
+        // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
+        // \Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
 
-            var output = await RunScript<CharParametersTestClass>(async test =>
-            {
-                foreach (var c in new[] {'\"', '"', '\''})
-                    await Run(test, c);
-                
-                foreach (var c in new[] {'\\', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v'})
-                    await Run(test, c);
-                
-                foreach (var c in new[] {'\u0000', '\u0085', '\u2028', '\u2029', '\u263A'})
-                    await Run(test, c);
-                
-                foreach (var c in new[] {'\x0000', '\x000', '\x00', '\x0'})
-                    await Run(test, c);
-                
-                foreach (var c in new[] {'\x0085', '\x085', '\x85', '\x2028', '\x2029', '\x263A'})
-                    await Run(test, c);
-                
-                foreach (var c in new[] {'\U00000000', '\U00000085', '\U00002028', '\U00002029', '\U0000263A'})
-                    await Run(test, c);
-            });
+        var output = await RunScript<CharParametersTestClass>(async test =>
+        {
+            foreach (var c in new[] {'\"', '"', '\''})
+                await Run(test, c);
+            
+            foreach (var c in new[] {'\\', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v'})
+                await Run(test, c);
+            
+            foreach (var c in new[] {'\u0000', '\u0085', '\u2028', '\u2029', '\u263A'})
+                await Run(test, c);
+            
+            foreach (var c in new[] {'\x0000', '\x000', '\x00', '\x0'})
+                await Run(test, c);
+            
+            foreach (var c in new[] {'\x0085', '\x085', '\x85', '\x2028', '\x2029', '\x263A'})
+                await Run(test, c);
+            
+            foreach (var c in new[] {'\U00000000', '\U00000085', '\U00002028', '\U00002029', '\U0000263A'})
+                await Run(test, c);
+        });
 
-            ShouldHaveNames(output,
-                "CharParametersTestClass.Char('\"')",
-                "CharParametersTestClass.Char('\"')",
-                "CharParametersTestClass.Char('\\'')",
+        ShouldHaveNames(output,
+            "CharParametersTestClass.Char('\"')",
+            "CharParametersTestClass.Char('\"')",
+            "CharParametersTestClass.Char('\\'')",
 
-                "CharParametersTestClass.Char('\\\\')",
-                "CharParametersTestClass.Char('\\0')",
-                "CharParametersTestClass.Char('\\a')",
-                "CharParametersTestClass.Char('\\b')",
-                "CharParametersTestClass.Char('\\f')",
-                "CharParametersTestClass.Char('\\n')",
-                "CharParametersTestClass.Char('\\r')",
-                "CharParametersTestClass.Char('\\t')",
-                "CharParametersTestClass.Char('\\v')",
-                
-                "CharParametersTestClass.Char('\\0')",
-                "CharParametersTestClass.Char('\\u0085')",
-                "CharParametersTestClass.Char('\\u2028')",
-                "CharParametersTestClass.Char('\\u2029')",
-                "CharParametersTestClass.Char('☺')",
+            "CharParametersTestClass.Char('\\\\')",
+            "CharParametersTestClass.Char('\\0')",
+            "CharParametersTestClass.Char('\\a')",
+            "CharParametersTestClass.Char('\\b')",
+            "CharParametersTestClass.Char('\\f')",
+            "CharParametersTestClass.Char('\\n')",
+            "CharParametersTestClass.Char('\\r')",
+            "CharParametersTestClass.Char('\\t')",
+            "CharParametersTestClass.Char('\\v')",
+            
+            "CharParametersTestClass.Char('\\0')",
+            "CharParametersTestClass.Char('\\u0085')",
+            "CharParametersTestClass.Char('\\u2028')",
+            "CharParametersTestClass.Char('\\u2029')",
+            "CharParametersTestClass.Char('☺')",
 
-                "CharParametersTestClass.Char('\\0')",
-                "CharParametersTestClass.Char('\\0')",
-                "CharParametersTestClass.Char('\\0')",
-                "CharParametersTestClass.Char('\\0')",
+            "CharParametersTestClass.Char('\\0')",
+            "CharParametersTestClass.Char('\\0')",
+            "CharParametersTestClass.Char('\\0')",
+            "CharParametersTestClass.Char('\\0')",
 
-                "CharParametersTestClass.Char('\\u0085')",
-                "CharParametersTestClass.Char('\\u0085')",
-                "CharParametersTestClass.Char('\\u0085')",
-                "CharParametersTestClass.Char('\\u2028')",
-                "CharParametersTestClass.Char('\\u2029')",
-                "CharParametersTestClass.Char('☺')",
+            "CharParametersTestClass.Char('\\u0085')",
+            "CharParametersTestClass.Char('\\u0085')",
+            "CharParametersTestClass.Char('\\u0085')",
+            "CharParametersTestClass.Char('\\u2028')",
+            "CharParametersTestClass.Char('\\u2029')",
+            "CharParametersTestClass.Char('☺')",
 
-                "CharParametersTestClass.Char('\\0')",
-                "CharParametersTestClass.Char('\\u0085')",
-                "CharParametersTestClass.Char('\\u2028')",
-                "CharParametersTestClass.Char('\\u2029')",
-                "CharParametersTestClass.Char('☺')"
-            );
-        }
+            "CharParametersTestClass.Char('\\0')",
+            "CharParametersTestClass.Char('\\u0085')",
+            "CharParametersTestClass.Char('\\u2028')",
+            "CharParametersTestClass.Char('\\u2029')",
+            "CharParametersTestClass.Char('☺')"
+        );
+    }
 
     public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasStringParameters()
     {
-            // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
-            // Just like \r and \n, we escape these in order to present a readable string literal. All other unicode sequences pass through
-            // with no additional special treatment.
+        // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
+        // Just like \r and \n, we escape these in order to present a readable string literal. All other unicode sequences pass through
+        // with no additional special treatment.
 
-            // \uxxxx - Unicode escape sequence for character with hex value xxxx.
-            // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
-            // \Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
+        // \uxxxx - Unicode escape sequence for character with hex value xxxx.
+        // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
+        // \Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
 
-            var output = await RunScript<StringParametersTestClass>(async test =>
-            {
-                await Run(test, " \' ' \" ");
-                await Run(test, " \\ \0 \a \b ");
-                await Run(test, " \f \n \r \t \v ");
-                await Run(test, " \u0000 \u0085 \u2028 \u2029 \u263A ");
-                await Run(test, " \x0000 \x000 \x00 \x0 ");
-                await Run(test, " \x0085 \x085 \x85 \x2028 \x2029 \x263A ");
-                await Run(test, " \U00000000 \U00000085 \U00002028 \U00002029 \U0000263A ");
-            });
+        var output = await RunScript<StringParametersTestClass>(async test =>
+        {
+            await Run(test, " \' ' \" ");
+            await Run(test, " \\ \0 \a \b ");
+            await Run(test, " \f \n \r \t \v ");
+            await Run(test, " \u0000 \u0085 \u2028 \u2029 \u263A ");
+            await Run(test, " \x0000 \x000 \x00 \x0 ");
+            await Run(test, " \x0085 \x085 \x85 \x2028 \x2029 \x263A ");
+            await Run(test, " \U00000000 \U00000085 \U00002028 \U00002029 \U0000263A ");
+        });
 
-            ShouldHaveNames(output,
-                "StringParametersTestClass.String(\" ' ' \\\" \")",
-                "StringParametersTestClass.String(\" \\\\ \\0 \\a \\b \")",
-                "StringParametersTestClass.String(\" \\f \\n \\r \\t \\v \")",
-                "StringParametersTestClass.String(\" \\0 \\u0085 \\u2028 \\u2029 ☺ \")",
-                "StringParametersTestClass.String(\" \\0 \\0 \\0 \\0 \")",
-                "StringParametersTestClass.String(\" \\u0085 \\u0085 \\u0085 \\u2028 \\u2029 ☺ \")",
-                "StringParametersTestClass.String(\" \\0 \\u0085 \\u2028 \\u2029 ☺ \")"
-            );
-        }
+        ShouldHaveNames(output,
+            "StringParametersTestClass.String(\" ' ' \\\" \")",
+            "StringParametersTestClass.String(\" \\\\ \\0 \\a \\b \")",
+            "StringParametersTestClass.String(\" \\f \\n \\r \\t \\v \")",
+            "StringParametersTestClass.String(\" \\0 \\u0085 \\u2028 \\u2029 ☺ \")",
+            "StringParametersTestClass.String(\" \\0 \\0 \\0 \\0 \")",
+            "StringParametersTestClass.String(\" \\u0085 \\u0085 \\u0085 \\u2028 \\u2029 ☺ \")",
+            "StringParametersTestClass.String(\" \\0 \\u0085 \\u2028 \\u2029 ☺ \")"
+        );
+    }
 
     public async Task ShouldIncludeResolvedGenericArgumentsInNameWhenTheUnderlyingMethodIsGeneric()
     {
-            var output = await RunScript<GenericTestClass>(async test =>
-            {
-                await Run(test, 123, true, "a", "b");
-                await Run(test, 123, true, 1, null);
-                await Run(test, 123, 1.23m, "a", null);
-            });
+        var output = await RunScript<GenericTestClass>(async test =>
+        {
+            await Run(test, 123, true, "a", "b");
+            await Run(test, 123, true, 1, null);
+            await Run(test, 123, 1.23m, "a", null);
+        });
 
-            ShouldHaveNames(output,
-                "GenericTestClass.Generic<System.Boolean, System.String>(123, True, \"a\", \"b\")",
-                "GenericTestClass.Generic<System.Boolean, System.Int32>(123, True, 1, null)",
-                "GenericTestClass.Generic<System.Decimal, System.String>(123, 1.23, \"a\", null)"
-            );
-        }
+        ShouldHaveNames(output,
+            "GenericTestClass.Generic<System.Boolean, System.String>(123, True, \"a\", \"b\")",
+            "GenericTestClass.Generic<System.Boolean, System.Int32>(123, True, 1, null)",
+            "GenericTestClass.Generic<System.Decimal, System.String>(123, 1.23, \"a\", null)"
+        );
+    }
 
     public async Task ShouldUseGenericTypeParametersInNameWhenGenericTypeParametersCannotBeResolved()
     {
-            var output = await RunScript<ConstrainedGenericTestClass>(async test =>
-            {
-                await Run(test, 1);
-                await Run(test, true);
-                await Run(test, "Incompatible");
-            });
+        var output = await RunScript<ConstrainedGenericTestClass>(async test =>
+        {
+            await Run(test, 1);
+            await Run(test, true);
+            await Run(test, "Incompatible");
+        });
 
-            ShouldHaveNames(output,
-                "ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(1)",
-                "ConstrainedGenericTestClass.ConstrainedGeneric<System.Boolean>(True)",
-                "ConstrainedGenericTestClass.ConstrainedGeneric<T>(\"Incompatible\")"
-            );
-        }
+        ShouldHaveNames(output,
+            "ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(1)",
+            "ConstrainedGenericTestClass.ConstrainedGeneric<System.Boolean>(True)",
+            "ConstrainedGenericTestClass.ConstrainedGeneric<T>(\"Incompatible\")"
+        );
+    }
 
     public async Task ShouldInferAppropriateClassUnderInheritance()
     {
-            var parent = await RunScript<ParentTestClass>(async test =>
-            {
-                await Run(test);
-            });
+        var parent = await RunScript<ParentTestClass>(async test =>
+        {
+            await Run(test);
+        });
 
-            ShouldHaveNames(parent,
-                "ParentTestClass.TestMethodDefinedWithinParentClass"
-            );
+        ShouldHaveNames(parent,
+            "ParentTestClass.TestMethodDefinedWithinParentClass"
+        );
 
-            var child = await RunScript<ChildTestClass>(async test =>
-            {
-                await Run(test);
-            });
+        var child = await RunScript<ChildTestClass>(async test =>
+        {
+            await Run(test);
+        });
 
-            ShouldHaveNames(child,
-                "ChildTestClass.TestMethodDefinedWithinChildClass",
-                "ChildTestClass.TestMethodDefinedWithinParentClass"
-            );
-        }
+        ShouldHaveNames(child,
+            "ChildTestClass.TestMethodDefinedWithinChildClass",
+            "ChildTestClass.TestMethodDefinedWithinParentClass"
+        );
+    }
 
     class ScriptedExecution : IExecution
     {
@@ -198,9 +198,9 @@ public class CaseNameTests
 
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var test in testSuite.Tests)
-                    await script(test);
-            }
+            foreach (var test in testSuite.Tests)
+                await script(test);
+        }
     }
 
     static Task<IEnumerable<string>> RunScript<TSampleTestClass>(Func<Test, Task> scriptAsync)
@@ -208,34 +208,34 @@ public class CaseNameTests
 
     static async Task Run(Test test, params object?[] parameters)
     {
-            await test.Run(parameters);
-            await test.Pass(parameters);
-            await test.Fail(parameters, new FailureException());
-            await test.Skip(parameters, reason: "Exercising Skipped Case Names");
-        }
+        await test.Run(parameters);
+        await test.Pass(parameters);
+        await test.Fail(parameters, new FailureException());
+        await test.Skip(parameters, reason: "Exercising Skipped Case Names");
+    }
 
     void ShouldHaveNames(IEnumerable<string> actual, params string[] expected)
     {
-            const int variants = 4;
+        const int variants = 4;
 
-            var actualArray = actual.ToArray();
-            actualArray.Length.ShouldBe(expected.Length * variants);
+        var actualArray = actual.ToArray();
+        actualArray.Length.ShouldBe(expected.Length * variants);
 
-            var expectedVariants = expected.Select(name => new[]
-            {
-                name.Contains("Incompatible")
-                    ? $"{name} failed: The type parameters for generic method ConstrainedGeneric could not be resolved."
-                    : $"{name} passed",
-                $"{name} passed",
-                $"{name} failed: 'Run' failed!",
-                $"{name} skipped: Exercising Skipped Case Names"
-            }).SelectMany(x => x);
+        var expectedVariants = expected.Select(name => new[]
+        {
+            name.Contains("Incompatible")
+                ? $"{name} failed: The type parameters for generic method ConstrainedGeneric could not be resolved."
+                : $"{name} passed",
+            $"{name} passed",
+            $"{name} failed: 'Run' failed!",
+            $"{name} skipped: Exercising Skipped Case Names"
+        }).SelectMany(x => x);
 
-            var fullyQualifiedExpectation = expectedVariants.Select(x => GetType().FullName + "+" + x).ToArray();
+        var fullyQualifiedExpectation = expectedVariants.Select(x => GetType().FullName + "+" + x).ToArray();
 
-            foreach (var (first, second) in actualArray.Zip(fullyQualifiedExpectation))
-                first.ShouldBe(second);
-        }
+        foreach (var (first, second) in actualArray.Zip(fullyQualifiedExpectation))
+            first.ShouldBe(second);
+    }
 
     class ObjectWithNullStringRepresentation
     {
@@ -276,13 +276,13 @@ public class CaseNameTests
     {
         public void TestMethodDefinedWithinParentClass()
         {
-            }
+        }
     }
 
     class ChildTestClass : ParentTestClass
     {
         public void TestMethodDefinedWithinChildClass()
         {
-            }
+        }
     }
 }

--- a/src/Fixie.Tests/Console/ParserTests.cs
+++ b/src/Fixie.Tests/Console/ParserTests.cs
@@ -12,8 +12,8 @@ public class ParserTests
 
     public void ShouldParseEmptyModels()
     {
-            Parse<Empty>().ShouldSucceed(new Empty());
-        }
+        Parse<Empty>().ShouldSucceed(new Empty());
+    }
 
     class TooManyConstructors
     {
@@ -23,10 +23,10 @@ public class ParserTests
 
     public void ShouldDemandExactlyOneConstructor()
     {
-            Parse<TooManyConstructors>()
-                .ShouldFail($"Could not construct an instance of type '{typeof(TooManyConstructors).FullName}'. " +
-                            "Expected to find exactly 1 public constructor, but found 2.");
-        }
+        Parse<TooManyConstructors>()
+            .ShouldFail($"Could not construct an instance of type '{typeof(TooManyConstructors).FullName}'. " +
+                        "Expected to find exactly 1 public constructor, but found 2.");
+    }
 
     class ModelWithConstructor<T>
     {
@@ -36,10 +36,10 @@ public class ParserTests
 
         public ModelWithConstructor(T first, T second, T third)
         {
-                First = first;
-                Second = second;
-                Third = third;
-            }
+            First = first;
+            Second = second;
+            Third = third;
+        }
     }
 
     class ModelWithParams<T>
@@ -51,268 +51,268 @@ public class ParserTests
 
         public ModelWithParams(T first, T second, T third, params T[] rest)
         {
-                First = first;
-                Second = second;
-                Third = third;
-                Rest = rest;
-            }
+            First = first;
+            Second = second;
+            Third = third;
+            Rest = rest;
+        }
     }
 
     public void ShouldParseArgumentsAsConstructorParameters()
     {
-            Parse<ModelWithConstructor<string>>("--first", "value1", "--second", "value2", "--third", "value3")
-                .ShouldSucceed(new ModelWithConstructor<string>("value1", "value2", "value3"));
+        Parse<ModelWithConstructor<string>>("--first", "value1", "--second", "value2", "--third", "value3")
+            .ShouldSucceed(new ModelWithConstructor<string>("value1", "value2", "value3"));
 
-            Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "--third", "3")
-                .ShouldSucceed(new ModelWithConstructor<int>(1, 2, 3));
+        Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "--third", "3")
+            .ShouldSucceed(new ModelWithConstructor<int>(1, 2, 3));
 
-            Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "--third", "abc")
-                .ShouldFail("--third was not in the correct format.");
+        Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "--third", "abc")
+            .ShouldFail("--third was not in the correct format.");
 
-            Parse<ModelWithConstructor<string>>("-f", "value1", "-s", "value2", "-t", "value3")
-                .ShouldSucceed(new ModelWithConstructor<string>("value1", "value2", "value3"));
+        Parse<ModelWithConstructor<string>>("-f", "value1", "-s", "value2", "-t", "value3")
+            .ShouldSucceed(new ModelWithConstructor<string>("value1", "value2", "value3"));
 
-            Parse<ModelWithConstructor<int>>("-f", "1", "-s", "2", "-t", "3")
-                .ShouldSucceed(new ModelWithConstructor<int>(1, 2, 3));
+        Parse<ModelWithConstructor<int>>("-f", "1", "-s", "2", "-t", "3")
+            .ShouldSucceed(new ModelWithConstructor<int>(1, 2, 3));
 
-            Parse<ModelWithConstructor<int>>("-f", "1", "-s", "2", "-t", "abc")
-                .ShouldFail("--third was not in the correct format.");
+        Parse<ModelWithConstructor<int>>("-f", "1", "-s", "2", "-t", "abc")
+            .ShouldFail("--third was not in the correct format.");
 
-            //Unspecified params[]
-            Parse<ModelWithParams<string>>("--first", "value1", "--second", "value2", "--third", "value3")
-                .ShouldSucceed(new ModelWithParams<string>("value1", "value2", "value3"));
+        //Unspecified params[]
+        Parse<ModelWithParams<string>>("--first", "value1", "--second", "value2", "--third", "value3")
+            .ShouldSucceed(new ModelWithParams<string>("value1", "value2", "value3"));
 
-            Parse<ModelWithParams<int>>("--first", "1", "--second", "2", "--third", "3")
-                .ShouldSucceed(new ModelWithParams<int>(1, 2, 3));
+        Parse<ModelWithParams<int>>("--first", "1", "--second", "2", "--third", "3")
+            .ShouldSucceed(new ModelWithParams<int>(1, 2, 3));
 
-            Parse<ModelWithParams<int>>("--first", "1", "--second", "2", "--third", "abc")
-                .ShouldFail("--third was not in the correct format.");
+        Parse<ModelWithParams<int>>("--first", "1", "--second", "2", "--third", "abc")
+            .ShouldFail("--third was not in the correct format.");
 
-            //Specified params[]
-            Parse<ModelWithParams<string>>("--first", "first", "--second", "second", "--third", "third", "fourth", "fifth")
-                .ShouldSucceed(new ModelWithParams<string>("first", "second", "third", "fourth", "fifth"));
+        //Specified params[]
+        Parse<ModelWithParams<string>>("--first", "first", "--second", "second", "--third", "third", "fourth", "fifth")
+            .ShouldSucceed(new ModelWithParams<string>("first", "second", "third", "fourth", "fifth"));
 
-            Parse<ModelWithParams<int>>("--first", "1", "--second", "2", "--third", "3", "4", "5")
-                .ShouldSucceed(new ModelWithParams<int>(1, 2, 3, 4, 5));
+        Parse<ModelWithParams<int>>("--first", "1", "--second", "2", "--third", "3", "4", "5")
+            .ShouldSucceed(new ModelWithParams<int>(1, 2, 3, 4, 5));
 
-            Parse<ModelWithParams<int>>("--first", "1", "--second", "2", "--third", "3", "4", "abc")
-                .ShouldFail("rest was not in the correct format.");
-        }
+        Parse<ModelWithParams<int>>("--first", "1", "--second", "2", "--third", "3", "4", "abc")
+            .ShouldFail("rest was not in the correct format.");
+    }
 
     public void ShouldFailWhenNamedArgumentsAreMissingTheirRequiredValues()
     {
-            Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "--third")
-                .ShouldFail("--third is missing its required value.");
-            
-            Parse<ModelWithConstructor<int>>("-f", "1", "-s", "2", "-t")
-                .ShouldFail("--third is missing its required value.");
+        Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "--third")
+            .ShouldFail("--third is missing its required value.");
+        
+        Parse<ModelWithConstructor<int>>("-f", "1", "-s", "2", "-t")
+            .ShouldFail("--third is missing its required value.");
 
-            Parse<ModelWithConstructor<int>>("--first", "1", "--second", "--third", "3")
-                .ShouldFail("--second is missing its required value.");
+        Parse<ModelWithConstructor<int>>("--first", "1", "--second", "--third", "3")
+            .ShouldFail("--second is missing its required value.");
 
-            Parse<ModelWithConstructor<int>>("-f", "1", "-s", "-t", "3")
-                .ShouldFail("--second is missing its required value.");
-        }
+        Parse<ModelWithConstructor<int>>("-f", "1", "-s", "-t", "3")
+            .ShouldFail("--second is missing its required value.");
+    }
 
     public void ShouldLeaveDefaultValuesForMissingNamedArguments()
     {
-            Parse<ModelWithConstructor<string?>>("--first", "value1", "--second", "value2")
-                .ShouldSucceed(new ModelWithConstructor<string?>("value1", "value2", null));
+        Parse<ModelWithConstructor<string?>>("--first", "value1", "--second", "value2")
+            .ShouldSucceed(new ModelWithConstructor<string?>("value1", "value2", null));
 
-            Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2")
-                .ShouldSucceed(new ModelWithConstructor<int>(1, 2, 0));
+        Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2")
+            .ShouldSucceed(new ModelWithConstructor<int>(1, 2, 0));
 
-            //Unspecified params[] default to an empty array.
-            Parse<ModelWithParams<string?>>("--first", "first", "--second", "second")
-                .ShouldSucceed(new ModelWithParams<string?>("first", "second", null));
+        //Unspecified params[] default to an empty array.
+        Parse<ModelWithParams<string?>>("--first", "first", "--second", "second")
+            .ShouldSucceed(new ModelWithParams<string?>("first", "second", null));
 
-            Parse<ModelWithParams<int>>("--first", "1", "--second", "2")
-                .ShouldSucceed(new ModelWithParams<int>(1, 2, 0));
-        }
+        Parse<ModelWithParams<int>>("--first", "1", "--second", "2")
+            .ShouldSucceed(new ModelWithParams<int>(1, 2, 0));
+    }
 
     public void ShouldParseNullableValueTypeArguments()
     {
-            Parse<ModelWithConstructor<int?>>("--first", "1", "--third", "3")
-                .ShouldSucceed(new ModelWithConstructor<int?>(1, null, 3));
+        Parse<ModelWithConstructor<int?>>("--first", "1", "--third", "3")
+            .ShouldSucceed(new ModelWithConstructor<int?>(1, null, 3));
 
-            Parse<ModelWithConstructor<char?>>("--first", "a", "--third", "c")
-                .ShouldSucceed(new ModelWithConstructor<char?>('a', null, 'c'));
+        Parse<ModelWithConstructor<char?>>("--first", "a", "--third", "c")
+            .ShouldSucceed(new ModelWithConstructor<char?>('a', null, 'c'));
 
-            //Unspecified params[]
-            Parse<ModelWithParams<int?>>("--first", "1", "--third", "3")
-                .ShouldSucceed(new ModelWithParams<int?>(1, null, 3));
+        //Unspecified params[]
+        Parse<ModelWithParams<int?>>("--first", "1", "--third", "3")
+            .ShouldSucceed(new ModelWithParams<int?>(1, null, 3));
 
-            Parse<ModelWithParams<char?>>("--first", "a", "--third", "c")
-                .ShouldSucceed(new ModelWithParams<char?>('a', null, 'c'));
+        Parse<ModelWithParams<char?>>("--first", "a", "--third", "c")
+            .ShouldSucceed(new ModelWithParams<char?>('a', null, 'c'));
 
-            //Specified params[]
-            Parse<ModelWithParams<int?>>("--first", "1", "--third", "3", "4", "5")
-                .ShouldSucceed(new ModelWithParams<int?>(1, null, 3, 4, 5));
+        //Specified params[]
+        Parse<ModelWithParams<int?>>("--first", "1", "--third", "3", "4", "5")
+            .ShouldSucceed(new ModelWithParams<int?>(1, null, 3, 4, 5));
 
-            Parse<ModelWithParams<char?>>("--first", "a", "--third", "c", "d", "e")
-                .ShouldSucceed(new ModelWithParams<char?>('a', null, 'c', 'd', 'e'));
-        }
+        Parse<ModelWithParams<char?>>("--first", "a", "--third", "c", "d", "e")
+            .ShouldSucceed(new ModelWithParams<char?>('a', null, 'c', 'd', 'e'));
+    }
 
     public void ShouldParseBoolArgumentsAsFlagsWithoutExplicitValues()
     {
-            Parse<ModelWithConstructor<bool>>("--first", "--third")
-                .ShouldSucceed(new ModelWithConstructor<bool>(true, false, true));
-            
-            Parse<ModelWithConstructor<bool>>("-f", "-t")
-                .ShouldSucceed(new ModelWithConstructor<bool>(true, false, true));
+        Parse<ModelWithConstructor<bool>>("--first", "--third")
+            .ShouldSucceed(new ModelWithConstructor<bool>(true, false, true));
+        
+        Parse<ModelWithConstructor<bool>>("-f", "-t")
+            .ShouldSucceed(new ModelWithConstructor<bool>(true, false, true));
 
-            //Unspecified params[]
-            Parse<ModelWithParams<bool>>("--first", "--third")
-                .ShouldSucceed(new ModelWithParams<bool>(true, false, true));
+        //Unspecified params[]
+        Parse<ModelWithParams<bool>>("--first", "--third")
+            .ShouldSucceed(new ModelWithParams<bool>(true, false, true));
 
-            //Specified params[]
-            Parse<ModelWithParams<bool>>("--first", "--third", "true", "false")
-                .ShouldSucceed(new ModelWithParams<bool>(true, false, true, true, false));
+        //Specified params[]
+        Parse<ModelWithParams<bool>>("--first", "--third", "true", "false")
+            .ShouldSucceed(new ModelWithParams<bool>(true, false, true, true, false));
 
-            Parse<ModelWithParams<bool>>("--first", "--third", "FALSE", "TRUE")
-                .ShouldSucceed(new ModelWithParams<bool>(true, false, true, false, true));
+        Parse<ModelWithParams<bool>>("--first", "--third", "FALSE", "TRUE")
+            .ShouldSucceed(new ModelWithParams<bool>(true, false, true, false, true));
 
-            Parse<ModelWithParams<bool>>("--first", "--third", "on", "off")
-                .ShouldSucceed(new ModelWithParams<bool>(true, false, true, true, false));
+        Parse<ModelWithParams<bool>>("--first", "--third", "on", "off")
+            .ShouldSucceed(new ModelWithParams<bool>(true, false, true, true, false));
 
-            Parse<ModelWithParams<bool>>("--first", "--third", "OFF", "ON")
-                .ShouldSucceed(new ModelWithParams<bool>(true, false, true, false, true));
+        Parse<ModelWithParams<bool>>("--first", "--third", "OFF", "ON")
+            .ShouldSucceed(new ModelWithParams<bool>(true, false, true, false, true));
 
-            Parse<ModelWithParams<bool>>("--first", "--third", "value")
-                .ShouldFail("rest was not in the correct format.");
-        }
+        Parse<ModelWithParams<bool>>("--first", "--third", "value")
+            .ShouldFail("rest was not in the correct format.");
+    }
 
     public void ShouldParseNullableBoolArgumentsAsFlagsWithExplicitValues()
     {
-            Parse<ModelWithConstructor<bool?>>("--first", "true", "--third", "false")
-                .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
+        Parse<ModelWithConstructor<bool?>>("--first", "true", "--third", "false")
+            .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
 
-            Parse<ModelWithConstructor<bool?>>("--first", "TRUE", "--third", "FALSE")
-                .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
+        Parse<ModelWithConstructor<bool?>>("--first", "TRUE", "--third", "FALSE")
+            .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
 
-            Parse<ModelWithConstructor<bool?>>("--first", "on", "--third", "off")
-                .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
+        Parse<ModelWithConstructor<bool?>>("--first", "on", "--third", "off")
+            .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
 
-            Parse<ModelWithConstructor<bool?>>("--first", "ON", "--third", "OFF")
-                .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
+        Parse<ModelWithConstructor<bool?>>("--first", "ON", "--third", "OFF")
+            .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
 
-            Parse<ModelWithConstructor<bool?>>("--first", "value1", "--third", "value2")
-                .ShouldFail("--first was not in the correct format.");
+        Parse<ModelWithConstructor<bool?>>("--first", "value1", "--third", "value2")
+            .ShouldFail("--first was not in the correct format.");
 
-            //Unspecified params[]
-            Parse<ModelWithParams<bool?>>("--first", "true", "--third", "false")
-                .ShouldSucceed(new ModelWithParams<bool?>(true, null, false));
+        //Unspecified params[]
+        Parse<ModelWithParams<bool?>>("--first", "true", "--third", "false")
+            .ShouldSucceed(new ModelWithParams<bool?>(true, null, false));
 
-            Parse<ModelWithParams<bool?>>("--first", "TRUE", "--third", "FALSE")
-                .ShouldSucceed(new ModelWithParams<bool?>(true, null, false));
+        Parse<ModelWithParams<bool?>>("--first", "TRUE", "--third", "FALSE")
+            .ShouldSucceed(new ModelWithParams<bool?>(true, null, false));
 
-            Parse<ModelWithParams<bool?>>("--first", "on", "--third", "off")
-                .ShouldSucceed(new ModelWithParams<bool?>(true, null, false));
+        Parse<ModelWithParams<bool?>>("--first", "on", "--third", "off")
+            .ShouldSucceed(new ModelWithParams<bool?>(true, null, false));
 
-            Parse<ModelWithParams<bool?>>("--first", "ON", "--third", "OFF")
-                .ShouldSucceed(new ModelWithParams<bool?>(true, null, false));
+        Parse<ModelWithParams<bool?>>("--first", "ON", "--third", "OFF")
+            .ShouldSucceed(new ModelWithParams<bool?>(true, null, false));
 
-            Parse<ModelWithParams<bool?>>("--first", "value1", "--third", "value2")
-                .ShouldFail("--first was not in the correct format.");
+        Parse<ModelWithParams<bool?>>("--first", "value1", "--third", "value2")
+            .ShouldFail("--first was not in the correct format.");
 
-            //Specified params[]
-            Parse<ModelWithParams<bool?>>("--first", "true", "--third", "false", "true", "false")
-                .ShouldSucceed(new ModelWithParams<bool?>(true, null, false, true, false));
+        //Specified params[]
+        Parse<ModelWithParams<bool?>>("--first", "true", "--third", "false", "true", "false")
+            .ShouldSucceed(new ModelWithParams<bool?>(true, null, false, true, false));
 
-            Parse<ModelWithParams<bool?>>("--first", "TRUE", "--third", "FALSE", "FALSE", "TRUE")
-                .ShouldSucceed(new ModelWithParams<bool?>(true, null, false, false, true));
+        Parse<ModelWithParams<bool?>>("--first", "TRUE", "--third", "FALSE", "FALSE", "TRUE")
+            .ShouldSucceed(new ModelWithParams<bool?>(true, null, false, false, true));
 
-            Parse<ModelWithParams<bool?>>("--first", "on", "--third", "off", "on", "off")
-                .ShouldSucceed(new ModelWithParams<bool?>(true, null, false, true, false));
+        Parse<ModelWithParams<bool?>>("--first", "on", "--third", "off", "on", "off")
+            .ShouldSucceed(new ModelWithParams<bool?>(true, null, false, true, false));
 
-            Parse<ModelWithParams<bool?>>("--first", "ON", "--third", "OFF", "OFF", "ON")
-                .ShouldSucceed(new ModelWithParams<bool?>(true, null, false, false, true));
+        Parse<ModelWithParams<bool?>>("--first", "ON", "--third", "OFF", "OFF", "ON")
+            .ShouldSucceed(new ModelWithParams<bool?>(true, null, false, false, true));
 
-            Parse<ModelWithParams<bool?>>("--first", "true", "--third", "false", "value")
-                .ShouldFail("rest was not in the correct format.");
-        }
+        Parse<ModelWithParams<bool?>>("--first", "true", "--third", "false", "value")
+            .ShouldFail("rest was not in the correct format.");
+    }
 
     public void ShouldParseEnumArgumentsByTheirCaseInsensitiveStringRepresentation()
     {
-            Parse<ModelWithConstructor<Level>>("--first", "Warning", "--third", "ErRoR")
-                .ShouldSucceed(new ModelWithConstructor<Level>(Level.Warning, Level.Information, Level.Error));
+        Parse<ModelWithConstructor<Level>>("--first", "Warning", "--third", "ErRoR")
+            .ShouldSucceed(new ModelWithConstructor<Level>(Level.Warning, Level.Information, Level.Error));
 
-            Parse<ModelWithConstructor<Level>>("--first", "Warning", "--third", "TYPO")
-                .ShouldFail("--third must be one of: Information, Warning, Error.");
+        Parse<ModelWithConstructor<Level>>("--first", "Warning", "--third", "TYPO")
+            .ShouldFail("--third must be one of: Information, Warning, Error.");
 
-            Parse<ModelWithConstructor<Level?>>("--first", "Warning", "--third", "eRrOr")
-                .ShouldSucceed(new ModelWithConstructor<Level?>(Level.Warning, null, Level.Error));
+        Parse<ModelWithConstructor<Level?>>("--first", "Warning", "--third", "eRrOr")
+            .ShouldSucceed(new ModelWithConstructor<Level?>(Level.Warning, null, Level.Error));
 
-            Parse<ModelWithConstructor<Level?>>("--first", "Warning", "--third", "TYPO")
-                .ShouldFail("--third must be one of: Information, Warning, Error.");
+        Parse<ModelWithConstructor<Level?>>("--first", "Warning", "--third", "TYPO")
+            .ShouldFail("--third must be one of: Information, Warning, Error.");
 
-            //Unspecified params[]
-            Parse<ModelWithParams<Level>>("--first", "Warning", "--third", "ErRoR")
-                .ShouldSucceed(new ModelWithParams<Level>(Level.Warning, Level.Information, Level.Error));
+        //Unspecified params[]
+        Parse<ModelWithParams<Level>>("--first", "Warning", "--third", "ErRoR")
+            .ShouldSucceed(new ModelWithParams<Level>(Level.Warning, Level.Information, Level.Error));
 
-            Parse<ModelWithParams<Level>>("--first", "Warning", "--third", "TYPO")
-                .ShouldFail("--third must be one of: Information, Warning, Error.");
+        Parse<ModelWithParams<Level>>("--first", "Warning", "--third", "TYPO")
+            .ShouldFail("--third must be one of: Information, Warning, Error.");
 
-            Parse<ModelWithParams<Level?>>("--first", "Warning", "--third", "eRrOr")
-                .ShouldSucceed(new ModelWithParams<Level?>(Level.Warning, null, Level.Error));
+        Parse<ModelWithParams<Level?>>("--first", "Warning", "--third", "eRrOr")
+            .ShouldSucceed(new ModelWithParams<Level?>(Level.Warning, null, Level.Error));
 
-            Parse<ModelWithParams<Level?>>("--first", "Warning", "--third", "TYPO")
-                .ShouldFail("--third must be one of: Information, Warning, Error.");
+        Parse<ModelWithParams<Level?>>("--first", "Warning", "--third", "TYPO")
+            .ShouldFail("--third must be one of: Information, Warning, Error.");
 
-            //Specified params[]
-            Parse<ModelWithParams<Level>>("--first", "Warning", "--third", "ErRoR", "Error")
-                .ShouldSucceed(new ModelWithParams<Level>(Level.Warning, Level.Information, Level.Error, Level.Error));
+        //Specified params[]
+        Parse<ModelWithParams<Level>>("--first", "Warning", "--third", "ErRoR", "Error")
+            .ShouldSucceed(new ModelWithParams<Level>(Level.Warning, Level.Information, Level.Error, Level.Error));
 
-            Parse<ModelWithParams<Level>>("--first", "Warning", "--third", "ErRoR", "TYPO")
-                .ShouldFail("rest must be one of: Information, Warning, Error.");
+        Parse<ModelWithParams<Level>>("--first", "Warning", "--third", "ErRoR", "TYPO")
+            .ShouldFail("rest must be one of: Information, Warning, Error.");
 
-            Parse<ModelWithParams<Level?>>("--first", "Warning", "--third", "ErRoR", "eRrOr")
-                .ShouldSucceed(new ModelWithParams<Level?>(Level.Warning, null, Level.Error, Level.Error));
+        Parse<ModelWithParams<Level?>>("--first", "Warning", "--third", "ErRoR", "eRrOr")
+            .ShouldSucceed(new ModelWithParams<Level?>(Level.Warning, null, Level.Error, Level.Error));
 
-            Parse<ModelWithParams<Level?>>("--first", "Warning", "--third", "ErRoR", "eRrOr", "TYPO")
-                .ShouldFail("rest must be one of: Information, Warning, Error.");
-        }
+        Parse<ModelWithParams<Level?>>("--first", "Warning", "--third", "ErRoR", "eRrOr", "TYPO")
+            .ShouldFail("rest must be one of: Information, Warning, Error.");
+    }
 
     public void ShouldFailForUnexpectedArguments()
     {
-            Parse<Empty>("first", "second")
-                .ShouldFail("Unexpected argument: first");
+        Parse<Empty>("first", "second")
+            .ShouldFail("Unexpected argument: first");
 
-            Parse<ModelWithConstructor<string>>(
+        Parse<ModelWithConstructor<string>>(
+            "--first", "value1",
+            "--second", "value2",
+            "--third", "value3",
+            "--fourth", "value4")
+            .ShouldFail("Unexpected argument: --fourth");
+        
+        Parse<ModelWithConstructor<string>>(
+            "--first", "value1",
+            "--second", "value2",
+            "--third", "value3",
+            "value4")
+            .ShouldFail("Unexpected argument: value4");
+
+        Parse<ModelWithConstructor<string>>(
                 "--first", "value1",
                 "--second", "value2",
                 "--third", "value3",
-                "--fourth", "value4")
-                .ShouldFail("Unexpected argument: --fourth");
-            
-            Parse<ModelWithConstructor<string>>(
-                "--first", "value1",
-                "--second", "value2",
-                "--third", "value3",
-                "value4")
-                .ShouldFail("Unexpected argument: value4");
-
-            Parse<ModelWithConstructor<string>>(
-                    "--first", "value1",
-                    "--second", "value2",
-                    "--third", "value3",
-                    "-x", "value4")
-                .ShouldFail("Unexpected argument: -x");
-        }
+                "-x", "value4")
+            .ShouldFail("Unexpected argument: -x");
+    }
 
     public void ShouldFailWhenNonArrayArgumentsAreRepeated()
     {
-            Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "-f", "3")
-                .ShouldFail("--first cannot be specified more than once.");
-        }
+        Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "-f", "3")
+            .ShouldFail("--first cannot be specified more than once.");
+    }
 
     class ModelWithArrays
     {
         public ModelWithArrays(int[] integer, string[] @string)
         {
-                Integer = integer;
-                String = @string;
-            }
+            Integer = integer;
+            String = @string;
+        }
 
         public int[] Integer { get; }
         public string[] String { get; }
@@ -320,25 +320,25 @@ public class ParserTests
 
     public void ShouldParseRepeatedArgumentsAsArrayItems()
     {
-            Parse<ModelWithArrays>(
-                "--integer", "1", "--integer", "2",
-                "--string", "three", "--string", "four")
-                .ShouldSucceed(new ModelWithArrays(new[] { 1, 2 }, new[] { "three", "four" }));
-        }
+        Parse<ModelWithArrays>(
+            "--integer", "1", "--integer", "2",
+            "--string", "three", "--string", "four")
+            .ShouldSucceed(new ModelWithArrays(new[] { 1, 2 }, new[] { "three", "four" }));
+    }
 
     public void ShouldSetEmptyArraysForMissingArrayArguments()
     {
-            Parse<ModelWithArrays>()
-                .ShouldSucceed(new ModelWithArrays(new int[] { }, new string[] { }));
-        }
+        Parse<ModelWithArrays>()
+            .ShouldSucceed(new ModelWithArrays(new int[] { }, new string[] { }));
+    }
 
     class AmbiguousParameters
     {
         public AmbiguousParameters(int PARAMETER, int parameter)
         {
-                this.PARAMETER = PARAMETER;
-                this.parameter = parameter;
-            }
+            this.PARAMETER = PARAMETER;
+            this.parameter = parameter;
+        }
 
         public int PARAMETER { get; }
         public int parameter { get; }
@@ -353,12 +353,12 @@ public class ParserTests
             string convention,
             string prefix)
         {
-                Pattern = pattern;
-                Configuration = configuration;
-                Password = password;
-                Convention = convention;
-                Prefix = prefix;
-            }
+            Pattern = pattern;
+            Configuration = configuration;
+            Password = password;
+            Convention = convention;
+            Prefix = prefix;
+        }
 
         public string Pattern { get; }
         public string Configuration { get; }
@@ -369,20 +369,20 @@ public class ParserTests
 
     public void ShouldDemandUnambiguousParameterNames()
     {
-            Parse<AmbiguousParameters>()
-                .ShouldFail("Parsing command line arguments for type AmbiguousParameters " +
-                            "is ambiguous, because it has more than one parameter corresponding " +
-                            "with the --parameter argument.");
-        }
+        Parse<AmbiguousParameters>()
+            .ShouldFail("Parsing command line arguments for type AmbiguousParameters " +
+                        "is ambiguous, because it has more than one parameter corresponding " +
+                        "with the --parameter argument.");
+    }
 
     public void ShouldDemandUnambiguousFirstLetterParameterNameAbbreviations()
     {
-            Parse<AmbiguousFirstLetterParameters>("-p", "a*c", "-c")
-                .ShouldFail("-p is not a recognized option. Did you mean --password, --pattern, or --prefix?");
+        Parse<AmbiguousFirstLetterParameters>("-p", "a*c", "-c")
+            .ShouldFail("-p is not a recognized option. Did you mean --password, --pattern, or --prefix?");
 
-            Parse<AmbiguousFirstLetterParameters>("--pattern", "a*c", "-c")
-                .ShouldFail("-c is not a recognized option. Did you mean --configuration or --convention?");
-        }
+        Parse<AmbiguousFirstLetterParameters>("--pattern", "a*c", "-c")
+            .ShouldFail("-c is not a recognized option. Did you mean --configuration or --convention?");
+    }
 
     class Complex
     {
@@ -395,14 +395,14 @@ public class ParserTests
             string[] strings,
             int[] integers)
         {
-                String = @string;
-                Integer = integer;
-                Bool = @bool;
-                NullableInteger = nullableInteger;
-                NullableBoolean = nullableBoolean;
-                Strings = strings;
-                Integers = integers;
-            }
+            String = @string;
+            Integer = integer;
+            Bool = @bool;
+            NullableInteger = nullableInteger;
+            NullableBoolean = nullableBoolean;
+            Strings = strings;
+            Integers = integers;
+        }
 
         public string? String { get; }
         public int Integer { get; }
@@ -415,25 +415,25 @@ public class ParserTests
 
     public void ShouldBindCommandLineArgumentsToComplexModels()
     {
-            Parse<Complex>()
-                .ShouldSucceed(new Complex(null, 0, false, null, null,
-                    new string[] { }, new int[] { }));
+        Parse<Complex>()
+            .ShouldSucceed(new Complex(null, 0, false, null, null,
+                new string[] { }, new int[] { }));
 
-            Parse<Complex>(
-                "--string", "def",
-                "--integer", "34",
-                "--bool",
-                "--nullable-integer", "56",
-                "--nullable-boolean", "off",
-                "--strings", "first",
-                "--strings", "second",
-                "--integers", "78",
-                "--integers", "90")
-                .ShouldSucceed(new Complex(
-                        "def", 34, true, 56, false,
-                        new[] { "first", "second" },
-                        new[] { 78, 90 }));
-        }
+        Parse<Complex>(
+            "--string", "def",
+            "--integer", "34",
+            "--bool",
+            "--nullable-integer", "56",
+            "--nullable-boolean", "off",
+            "--strings", "first",
+            "--strings", "second",
+            "--integers", "78",
+            "--integers", "90")
+            .ShouldSucceed(new Complex(
+                    "def", 34, true, 56, false,
+                    new[] { "first", "second" },
+                    new[] { 78, 90 }));
+    }
 
     class ComplexWithParams
     {
@@ -469,34 +469,34 @@ public class ParserTests
 
     public void ShouldBindCommandLineArgumentsToComplexModelsWithParams()
     {
-            Parse<ComplexWithParams>()
-                .ShouldSucceed(new ComplexWithParams(null, 0, false, null, null,
-                    new string[] { }, new int[] { }));
+        Parse<ComplexWithParams>()
+            .ShouldSucceed(new ComplexWithParams(null, 0, false, null, null,
+                new string[] { }, new int[] { }));
 
-            Parse<ComplexWithParams>(
-                "--string", "def",
-                "--integer", "34",
-                "--bool",
-                "--nullable-integer", "56",
-                "--nullable-boolean", "off",
-                "--strings", "first",
-                "--strings", "second",
-                "positionalArgumentA",
-                "--integers", "78",
-                "positionalArgumentB",
-                "--integers", "90",
-                "positionalArgumentC")
-                .ShouldSucceed(new ComplexWithParams(
-                        "def", 34, true, 56, false,
-                        new[] { "first", "second" },
-                        new[] { 78, 90 },
-                        "positionalArgumentA", "positionalArgumentB", "positionalArgumentC"));
-        }
+        Parse<ComplexWithParams>(
+            "--string", "def",
+            "--integer", "34",
+            "--bool",
+            "--nullable-integer", "56",
+            "--nullable-boolean", "off",
+            "--strings", "first",
+            "--strings", "second",
+            "positionalArgumentA",
+            "--integers", "78",
+            "positionalArgumentB",
+            "--integers", "90",
+            "positionalArgumentC")
+            .ShouldSucceed(new ComplexWithParams(
+                    "def", 34, true, 56, false,
+                    new[] { "first", "second" },
+                    new[] { 78, 90 },
+                    "positionalArgumentA", "positionalArgumentB", "positionalArgumentC"));
+    }
 
     static Scenario<T> Parse<T>(params string[] arguments) where T : class
     {
-            return new Scenario<T>(arguments);
-        }
+        return new Scenario<T>(arguments);
+    }
 
     class Scenario<T> where T : class
     {
@@ -504,20 +504,20 @@ public class ParserTests
 
         public Scenario(params string[] arguments)
         {
-                this.arguments = arguments;
-            }
+            this.arguments = arguments;
+        }
 
         public void ShouldSucceed(T expectedModel)
         {
-                var model = CommandLine.Parse<T>(arguments);
-                model.ShouldMatch(expectedModel);
-            }
+            var model = CommandLine.Parse<T>(arguments);
+            model.ShouldMatch(expectedModel);
+        }
 
         public void ShouldFail(string expectedExceptionMessage)
         {
-                Action shouldThrow = () => CommandLine.Parse<T>(arguments);
+            Action shouldThrow = () => CommandLine.Parse<T>(arguments);
 
-                shouldThrow.ShouldThrow<CommandLineException>(expectedExceptionMessage);
-            }
+            shouldThrow.ShouldThrow<CommandLineException>(expectedExceptionMessage);
+        }
     }
 }

--- a/src/Fixie.Tests/Console/ParserTests.cs
+++ b/src/Fixie.Tests/Console/ParserTests.cs
@@ -1,65 +1,65 @@
-﻿namespace Fixie.Tests.Console
+﻿namespace Fixie.Tests.Console;
+
+using System;
+using Assertions;
+using Fixie.Console;
+
+public class ParserTests
 {
-    using System;
-    using Assertions;
-    using Fixie.Console;
+    enum Level { Information, Warning, Error }
 
-    public class ParserTests
+    class Empty { }
+
+    public void ShouldParseEmptyModels()
     {
-        enum Level { Information, Warning, Error }
-
-        class Empty { }
-
-        public void ShouldParseEmptyModels()
-        {
             Parse<Empty>().ShouldSucceed(new Empty());
         }
 
-        class TooManyConstructors
-        {
-            public TooManyConstructors() { }
-            public TooManyConstructors(int x) { }
-        }
+    class TooManyConstructors
+    {
+        public TooManyConstructors() { }
+        public TooManyConstructors(int x) { }
+    }
 
-        public void ShouldDemandExactlyOneConstructor()
-        {
+    public void ShouldDemandExactlyOneConstructor()
+    {
             Parse<TooManyConstructors>()
                 .ShouldFail($"Could not construct an instance of type '{typeof(TooManyConstructors).FullName}'. " +
                             "Expected to find exactly 1 public constructor, but found 2.");
         }
 
-        class ModelWithConstructor<T>
-        {
-            public T First { get; }
-            public T Second { get; }
-            public T Third { get; }
+    class ModelWithConstructor<T>
+    {
+        public T First { get; }
+        public T Second { get; }
+        public T Third { get; }
 
-            public ModelWithConstructor(T first, T second, T third)
-            {
+        public ModelWithConstructor(T first, T second, T third)
+        {
                 First = first;
                 Second = second;
                 Third = third;
             }
-        }
+    }
 
-        class ModelWithParams<T>
+    class ModelWithParams<T>
+    {
+        public T First { get; }
+        public T Second { get; }
+        public T Third { get; }
+        public T[] Rest { get; }
+
+        public ModelWithParams(T first, T second, T third, params T[] rest)
         {
-            public T First { get; }
-            public T Second { get; }
-            public T Third { get; }
-            public T[] Rest { get; }
-
-            public ModelWithParams(T first, T second, T third, params T[] rest)
-            {
                 First = first;
                 Second = second;
                 Third = third;
                 Rest = rest;
             }
-        }
+    }
 
-        public void ShouldParseArgumentsAsConstructorParameters()
-        {
+    public void ShouldParseArgumentsAsConstructorParameters()
+    {
             Parse<ModelWithConstructor<string>>("--first", "value1", "--second", "value2", "--third", "value3")
                 .ShouldSucceed(new ModelWithConstructor<string>("value1", "value2", "value3"));
 
@@ -99,8 +99,8 @@
                 .ShouldFail("rest was not in the correct format.");
         }
 
-        public void ShouldFailWhenNamedArgumentsAreMissingTheirRequiredValues()
-        {
+    public void ShouldFailWhenNamedArgumentsAreMissingTheirRequiredValues()
+    {
             Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "--third")
                 .ShouldFail("--third is missing its required value.");
             
@@ -114,8 +114,8 @@
                 .ShouldFail("--second is missing its required value.");
         }
 
-        public void ShouldLeaveDefaultValuesForMissingNamedArguments()
-        {
+    public void ShouldLeaveDefaultValuesForMissingNamedArguments()
+    {
             Parse<ModelWithConstructor<string?>>("--first", "value1", "--second", "value2")
                 .ShouldSucceed(new ModelWithConstructor<string?>("value1", "value2", null));
 
@@ -130,8 +130,8 @@
                 .ShouldSucceed(new ModelWithParams<int>(1, 2, 0));
         }
 
-        public void ShouldParseNullableValueTypeArguments()
-        {
+    public void ShouldParseNullableValueTypeArguments()
+    {
             Parse<ModelWithConstructor<int?>>("--first", "1", "--third", "3")
                 .ShouldSucceed(new ModelWithConstructor<int?>(1, null, 3));
 
@@ -153,8 +153,8 @@
                 .ShouldSucceed(new ModelWithParams<char?>('a', null, 'c', 'd', 'e'));
         }
 
-        public void ShouldParseBoolArgumentsAsFlagsWithoutExplicitValues()
-        {
+    public void ShouldParseBoolArgumentsAsFlagsWithoutExplicitValues()
+    {
             Parse<ModelWithConstructor<bool>>("--first", "--third")
                 .ShouldSucceed(new ModelWithConstructor<bool>(true, false, true));
             
@@ -182,8 +182,8 @@
                 .ShouldFail("rest was not in the correct format.");
         }
 
-        public void ShouldParseNullableBoolArgumentsAsFlagsWithExplicitValues()
-        {
+    public void ShouldParseNullableBoolArgumentsAsFlagsWithExplicitValues()
+    {
             Parse<ModelWithConstructor<bool?>>("--first", "true", "--third", "false")
                 .ShouldSucceed(new ModelWithConstructor<bool?>(true, null, false));
 
@@ -232,8 +232,8 @@
                 .ShouldFail("rest was not in the correct format.");
         }
 
-        public void ShouldParseEnumArgumentsByTheirCaseInsensitiveStringRepresentation()
-        {
+    public void ShouldParseEnumArgumentsByTheirCaseInsensitiveStringRepresentation()
+    {
             Parse<ModelWithConstructor<Level>>("--first", "Warning", "--third", "ErRoR")
                 .ShouldSucceed(new ModelWithConstructor<Level>(Level.Warning, Level.Information, Level.Error));
 
@@ -273,8 +273,8 @@
                 .ShouldFail("rest must be one of: Information, Warning, Error.");
         }
 
-        public void ShouldFailForUnexpectedArguments()
-        {
+    public void ShouldFailForUnexpectedArguments()
+    {
             Parse<Empty>("first", "second")
                 .ShouldFail("Unexpected argument: first");
 
@@ -300,59 +300,59 @@
                 .ShouldFail("Unexpected argument: -x");
         }
 
-        public void ShouldFailWhenNonArrayArgumentsAreRepeated()
-        {
+    public void ShouldFailWhenNonArrayArgumentsAreRepeated()
+    {
             Parse<ModelWithConstructor<int>>("--first", "1", "--second", "2", "-f", "3")
                 .ShouldFail("--first cannot be specified more than once.");
         }
 
-        class ModelWithArrays
+    class ModelWithArrays
+    {
+        public ModelWithArrays(int[] integer, string[] @string)
         {
-            public ModelWithArrays(int[] integer, string[] @string)
-            {
                 Integer = integer;
                 String = @string;
             }
 
-            public int[] Integer { get; }
-            public string[] String { get; }
-        }
+        public int[] Integer { get; }
+        public string[] String { get; }
+    }
 
-        public void ShouldParseRepeatedArgumentsAsArrayItems()
-        {
+    public void ShouldParseRepeatedArgumentsAsArrayItems()
+    {
             Parse<ModelWithArrays>(
                 "--integer", "1", "--integer", "2",
                 "--string", "three", "--string", "four")
                 .ShouldSucceed(new ModelWithArrays(new[] { 1, 2 }, new[] { "three", "four" }));
         }
 
-        public void ShouldSetEmptyArraysForMissingArrayArguments()
-        {
+    public void ShouldSetEmptyArraysForMissingArrayArguments()
+    {
             Parse<ModelWithArrays>()
                 .ShouldSucceed(new ModelWithArrays(new int[] { }, new string[] { }));
         }
 
-        class AmbiguousParameters
+    class AmbiguousParameters
+    {
+        public AmbiguousParameters(int PARAMETER, int parameter)
         {
-            public AmbiguousParameters(int PARAMETER, int parameter)
-            {
                 this.PARAMETER = PARAMETER;
                 this.parameter = parameter;
             }
 
-            public int PARAMETER { get; }
-            public int parameter { get; }
-        }
+        public int PARAMETER { get; }
+        public int parameter { get; }
+    }
 
-        class AmbiguousFirstLetterParameters
+    class AmbiguousFirstLetterParameters
+    {
+        public AmbiguousFirstLetterParameters(
+            string pattern,
+            string configuration,
+            string password,
+            string convention,
+            string prefix)
         {
-            public AmbiguousFirstLetterParameters(
-                string pattern,
-                string configuration,
-                string password,
-                string convention,
-                string prefix)
-            {
                 Pattern = pattern;
                 Configuration = configuration;
                 Password = password;
@@ -360,23 +360,23 @@
                 Prefix = prefix;
             }
 
-            public string Pattern { get; }
-            public string Configuration { get; }
-            public string Password { get; }
-            public string Convention { get; }
-            public string Prefix { get; } 
-        }
+        public string Pattern { get; }
+        public string Configuration { get; }
+        public string Password { get; }
+        public string Convention { get; }
+        public string Prefix { get; } 
+    }
 
-        public void ShouldDemandUnambiguousParameterNames()
-        {
+    public void ShouldDemandUnambiguousParameterNames()
+    {
             Parse<AmbiguousParameters>()
                 .ShouldFail("Parsing command line arguments for type AmbiguousParameters " +
                             "is ambiguous, because it has more than one parameter corresponding " +
                             "with the --parameter argument.");
         }
 
-        public void ShouldDemandUnambiguousFirstLetterParameterNameAbbreviations()
-        {
+    public void ShouldDemandUnambiguousFirstLetterParameterNameAbbreviations()
+    {
             Parse<AmbiguousFirstLetterParameters>("-p", "a*c", "-c")
                 .ShouldFail("-p is not a recognized option. Did you mean --password, --pattern, or --prefix?");
 
@@ -384,17 +384,17 @@
                 .ShouldFail("-c is not a recognized option. Did you mean --configuration or --convention?");
         }
 
-        class Complex
+    class Complex
+    {
+        public Complex(
+            string? @string,
+            int integer,
+            bool @bool,
+            int? nullableInteger,
+            bool? nullableBoolean,
+            string[] strings,
+            int[] integers)
         {
-            public Complex(
-                string? @string,
-                int integer,
-                bool @bool,
-                int? nullableInteger,
-                bool? nullableBoolean,
-                string[] strings,
-                int[] integers)
-            {
                 String = @string;
                 Integer = integer;
                 Bool = @bool;
@@ -404,17 +404,17 @@
                 Integers = integers;
             }
 
-            public string? String { get; }
-            public int Integer { get; }
-            public bool Bool { get; }
-            public int? NullableInteger { get; }
-            public bool? NullableBoolean { get; }
-            public string[] Strings { get; }
-            public int[] Integers { get; }
-        }
+        public string? String { get; }
+        public int Integer { get; }
+        public bool Bool { get; }
+        public int? NullableInteger { get; }
+        public bool? NullableBoolean { get; }
+        public string[] Strings { get; }
+        public int[] Integers { get; }
+    }
 
-        public void ShouldBindCommandLineArgumentsToComplexModels()
-        {
+    public void ShouldBindCommandLineArgumentsToComplexModels()
+    {
             Parse<Complex>()
                 .ShouldSucceed(new Complex(null, 0, false, null, null,
                     new string[] { }, new int[] { }));
@@ -435,18 +435,18 @@
                         new[] { 78, 90 }));
         }
 
-        class ComplexWithParams
+    class ComplexWithParams
+    {
+        public ComplexWithParams(
+            string? @string,
+            int integer,
+            bool @bool,
+            int? nullableInteger,
+            bool? nullableBoolean,
+            string[] strings,
+            int[] integers,
+            params string[] rest)
         {
-            public ComplexWithParams(
-                string? @string,
-                int integer,
-                bool @bool,
-                int? nullableInteger,
-                bool? nullableBoolean,
-                string[] strings,
-                int[] integers,
-                params string[] rest)
-            {
                 String = @string;
                 Integer = integer;
                 Bool = @bool;
@@ -457,18 +457,18 @@
                 Rest = rest;
             }
 
-            public string? String { get; }
-            public int Integer { get; }
-            public bool Bool { get; }
-            public int? NullableInteger { get; }
-            public bool? NullableBoolean { get; }
-            public string[] Strings { get; }
-            public int[] Integers { get; }
-            public string[] Rest { get; }
-        }
+        public string? String { get; }
+        public int Integer { get; }
+        public bool Bool { get; }
+        public int? NullableInteger { get; }
+        public bool? NullableBoolean { get; }
+        public string[] Strings { get; }
+        public int[] Integers { get; }
+        public string[] Rest { get; }
+    }
 
-        public void ShouldBindCommandLineArgumentsToComplexModelsWithParams()
-        {
+    public void ShouldBindCommandLineArgumentsToComplexModelsWithParams()
+    {
             Parse<ComplexWithParams>()
                 .ShouldSucceed(new ComplexWithParams(null, 0, false, null, null,
                     new string[] { }, new int[] { }));
@@ -493,32 +493,31 @@
                         "positionalArgumentA", "positionalArgumentB", "positionalArgumentC"));
         }
 
-        static Scenario<T> Parse<T>(params string[] arguments) where T : class
-        {
+    static Scenario<T> Parse<T>(params string[] arguments) where T : class
+    {
             return new Scenario<T>(arguments);
         }
 
-        class Scenario<T> where T : class
-        {
-            readonly string[] arguments;
+    class Scenario<T> where T : class
+    {
+        readonly string[] arguments;
 
-            public Scenario(params string[] arguments)
-            {
+        public Scenario(params string[] arguments)
+        {
                 this.arguments = arguments;
             }
 
-            public void ShouldSucceed(T expectedModel)
-            {
+        public void ShouldSucceed(T expectedModel)
+        {
                 var model = CommandLine.Parse<T>(arguments);
                 model.ShouldMatch(expectedModel);
             }
 
-            public void ShouldFail(string expectedExceptionMessage)
-            {
+        public void ShouldFail(string expectedExceptionMessage)
+        {
                 Action shouldThrow = () => CommandLine.Parse<T>(arguments);
 
                 shouldThrow.ShouldThrow<CommandLineException>(expectedExceptionMessage);
             }
-        }
     }
 }

--- a/src/Fixie.Tests/DiffToolReport.cs
+++ b/src/Fixie.Tests/DiffToolReport.cs
@@ -1,43 +1,42 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+using DiffEngine;
+
+class DiffToolReport : IHandler<TestFailed>, IHandler<ExecutionCompleted>
 {
-    using System;
-    using System.IO;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
-    using DiffEngine;
+    int failures;
+    Exception? singleFailure;
 
-    class DiffToolReport : IHandler<TestFailed>, IHandler<ExecutionCompleted>
+    public Task Handle(TestFailed message)
     {
-        int failures;
-        Exception? singleFailure;
+        failures++;
 
-        public Task Handle(TestFailed message)
-        {
-            failures++;
+        singleFailure = failures == 1 ? message.Reason : null;
 
-            singleFailure = failures == 1 ? message.Reason : null;
+        return Task.CompletedTask;
+    }
 
-            return Task.CompletedTask;
-        }
+    public async Task Handle(ExecutionCompleted message)
+    {
+        if (singleFailure is AssertException exception)
+            if (!exception.HasCompactRepresentations)
+                await LaunchDiffTool(exception);
+    }
 
-        public async Task Handle(ExecutionCompleted message)
-        {
-            if (singleFailure is AssertException exception)
-                if (!exception.HasCompactRepresentations)
-                    await LaunchDiffTool(exception);
-        }
+    static async Task LaunchDiffTool(AssertException exception)
+    {
+        var tempPath = Path.GetTempPath();
+        var expectedPath = Path.Combine(tempPath, "expected.txt");
+        var actualPath = Path.Combine(tempPath, "actual.txt");
 
-        static async Task LaunchDiffTool(AssertException exception)
-        {
-            var tempPath = Path.GetTempPath();
-            var expectedPath = Path.Combine(tempPath, "expected.txt");
-            var actualPath = Path.Combine(tempPath, "actual.txt");
+        File.WriteAllText(expectedPath, exception.Expected);
+        File.WriteAllText(actualPath, exception.Actual);
 
-            File.WriteAllText(expectedPath, exception.Expected);
-            File.WriteAllText(actualPath, exception.Actual);
-
-            await DiffRunner.LaunchAsync(expectedPath, actualPath);
-        }
+        await DiffRunner.LaunchAsync(expectedPath, actualPath);
     }
 }

--- a/src/Fixie.Tests/FSharpAsync.cs
+++ b/src/Fixie.Tests/FSharpAsync.cs
@@ -2,26 +2,25 @@
 // reflect on it in the same way as we can against
 // the real implementation during F# test runs.
 
-namespace Microsoft.FSharp.Control
+namespace Microsoft.FSharp.Control;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class FSharpAsync<TResult>
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
+    readonly Func<TResult> getResult;
 
-    public class FSharpAsync<TResult>
-    {
-        readonly Func<TResult> getResult;
+    public FSharpAsync(TResult result) : this(() => result) { }
 
-        public FSharpAsync(TResult result) : this(() => result) { }
+    public FSharpAsync(Func<TResult> getResult) => this.getResult = getResult;
 
-        public FSharpAsync(Func<TResult> getResult) => this.getResult = getResult;
+    public TResult Result => getResult();
+}
 
-        public TResult Result => getResult();
-    }
-
-    public class FSharpAsync
-    {
-        public static Task<T> StartAsTask<T>(FSharpAsync<T> computation, TaskCreationOptions? options = null, CancellationToken? cancellationToken = null)
-            => Task.FromResult(computation.Result);
-    }
+public class FSharpAsync
+{
+    public static Task<T> StartAsTask<T>(FSharpAsync<T> computation, TaskCreationOptions? options = null, CancellationToken? cancellationToken = null)
+        => Task.FromResult(computation.Result);
 }

--- a/src/Fixie.Tests/FailureException.cs
+++ b/src/Fixie.Tests/FailureException.cs
@@ -1,11 +1,10 @@
-﻿namespace Fixie.Tests
-{
-    using System;
-    using System.Runtime.CompilerServices;
+﻿namespace Fixie.Tests;
 
-    public class FailureException : Exception
-    {
-        public FailureException([CallerMemberName] string member = default!)
-            : base($"'{member}' failed!") { }
-    }
+using System;
+using System.Runtime.CompilerServices;
+
+public class FailureException : Exception
+{
+    public FailureException([CallerMemberName] string member = default!)
+        : base($"'{member}' failed!") { }
 }

--- a/src/Fixie.Tests/InputAttribute.cs
+++ b/src/Fixie.Tests/InputAttribute.cs
@@ -1,13 +1,12 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+using System;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class InputAttribute : Attribute
 {
-    using System;
+    public InputAttribute(params object?[] parameters)
+        => Parameters = parameters;
 
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    public class InputAttribute : Attribute
-    {
-        public InputAttribute(params object?[] parameters)
-            => Parameters = parameters;
-
-        public object?[] Parameters { get; }
-    }
+    public object?[] Parameters { get; }
 }

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -1,124 +1,123 @@
-namespace Fixie.Tests
+namespace Fixie.Tests;
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Assertions;
+
+public abstract class InstrumentedExecutionTests
 {
-    using System;
-    using System.Linq;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
-    using Assertions;
+    static string? FailingMember;
+    static int? FailingMemberOccurrence;
 
-    public abstract class InstrumentedExecutionTests
+    protected InstrumentedExecutionTests()
     {
-        static string? FailingMember;
-        static int? FailingMemberOccurrence;
+        FailingMember = null;
+        FailingMemberOccurrence = null;
+    }
 
-        protected InstrumentedExecutionTests()
+    protected static void FailDuring(string failingMemberName, int? occurrence = null)
+    {
+        FailingMember = failingMemberName;
+        FailingMemberOccurrence = occurrence;
+    }
+
+    protected class Output
+    {
+        readonly string namespaceQualifiedTestClass;
+        readonly string[] lifecycle;
+        readonly string[] results;
+
+        public Output(string namespaceQualifiedTestClass, string[] lifecycle, string[] results)
         {
-            FailingMember = null;
-            FailingMemberOccurrence = null;
+            this.namespaceQualifiedTestClass = namespaceQualifiedTestClass;
+            this.lifecycle = lifecycle;
+            this.results = results;
         }
 
-        protected static void FailDuring(string failingMemberName, int? occurrence = null)
+        public void ShouldHaveLifecycle(params string[] expected)
         {
-            FailingMember = failingMemberName;
-            FailingMemberOccurrence = occurrence;
+            lifecycle.ShouldBe(expected);
         }
 
-        protected class Output
+        public void ShouldHaveResults(params string[] expected)
         {
-            readonly string namespaceQualifiedTestClass;
-            readonly string[] lifecycle;
-            readonly string[] results;
+            var namespaceQualifiedExpectation = expected.Select(x => namespaceQualifiedTestClass + "+" + x).ToArray();
 
-            public Output(string namespaceQualifiedTestClass, string[] lifecycle, string[] results)
-            {
-                this.namespaceQualifiedTestClass = namespaceQualifiedTestClass;
-                this.lifecycle = lifecycle;
-                this.results = results;
-            }
-
-            public void ShouldHaveLifecycle(params string[] expected)
-            {
-                lifecycle.ShouldBe(expected);
-            }
-
-            public void ShouldHaveResults(params string[] expected)
-            {
-                var namespaceQualifiedExpectation = expected.Select(x => namespaceQualifiedTestClass + "+" + x).ToArray();
-
-                results.ShouldBe(namespaceQualifiedExpectation);
-            }
+            results.ShouldBe(namespaceQualifiedExpectation);
         }
+    }
 
-        protected static void WhereAmI(object parameter, [CallerMemberName] string member = default!)
-        {
-            System.Console.WriteLine($"{member}({parameter})");
+    protected static void WhereAmI(object parameter, [CallerMemberName] string member = default!)
+    {
+        System.Console.WriteLine($"{member}({parameter})");
 
-            ProcessScriptedFailure(member);
-        }
+        ProcessScriptedFailure(member);
+    }
         
-        protected static void WhereAmI([CallerMemberName] string member = default!)
-        {
-            System.Console.WriteLine(member);
+    protected static void WhereAmI([CallerMemberName] string member = default!)
+    {
+        System.Console.WriteLine(member);
 
-            ProcessScriptedFailure(member);
-        }
+        ProcessScriptedFailure(member);
+    }
 
-        protected static void ProcessScriptedFailure([CallerMemberName] string member = default!)
+    protected static void ProcessScriptedFailure([CallerMemberName] string member = default!)
+    {
+        if (FailingMember == member)
         {
-            if (FailingMember == member)
+            if (FailingMemberOccurrence == null)
+                throw new FailureException(member);
+
+            if (FailingMemberOccurrence > 0)
             {
-                if (FailingMemberOccurrence == null)
+                FailingMemberOccurrence--;
+
+                if (FailingMemberOccurrence == 0)
                     throw new FailureException(member);
-
-                if (FailingMemberOccurrence > 0)
-                {
-                    FailingMemberOccurrence--;
-
-                    if (FailingMemberOccurrence == 0)
-                        throw new FailureException(member);
-                }
             }
         }
+    }
 
-        protected Task<Output> Run<TSampleTestClass1, TSampleTestClass2, TExecution>()
-            where TExecution : IExecution, new()
-            => Run(
-                new[] {typeof(TSampleTestClass1), typeof(TSampleTestClass2)},
-                new TExecution());
+    protected Task<Output> Run<TSampleTestClass1, TSampleTestClass2, TExecution>()
+        where TExecution : IExecution, new()
+        => Run(
+            new[] {typeof(TSampleTestClass1), typeof(TSampleTestClass2)},
+            new TExecution());
 
-        protected Task<Output> Run<TSampleTestClass1, TSampleTestClass2>(IExecution execution)
-            => Run(
-                new[] {typeof(TSampleTestClass1), typeof(TSampleTestClass2)},
-                execution);
+    protected Task<Output> Run<TSampleTestClass1, TSampleTestClass2>(IExecution execution)
+        => Run(
+            new[] {typeof(TSampleTestClass1), typeof(TSampleTestClass2)},
+            execution);
    
-        protected Task<Output> Run<TSampleTestClass>()
-            => Run<DefaultExecution>(typeof(TSampleTestClass));
+    protected Task<Output> Run<TSampleTestClass>()
+        => Run<DefaultExecution>(typeof(TSampleTestClass));
 
-        protected Task<Output> Run<TSampleTestClass, TExecution>() where TExecution : IExecution, new()
-            => Run<TExecution>(typeof(TSampleTestClass));
+    protected Task<Output> Run<TSampleTestClass, TExecution>() where TExecution : IExecution, new()
+        => Run<TExecution>(typeof(TSampleTestClass));
 
-        protected Task<Output> Run<TSampleTestClass>(IExecution execution)
-            => Run(typeof(TSampleTestClass), execution);
+    protected Task<Output> Run<TSampleTestClass>(IExecution execution)
+        => Run(typeof(TSampleTestClass), execution);
 
-        protected Task<Output> Run<TExecution>(Type testClass) where TExecution : IExecution, new()
-            => Run(testClass, new TExecution());
+    protected Task<Output> Run<TExecution>(Type testClass) where TExecution : IExecution, new()
+        => Run(testClass, new TExecution());
 
-        async Task<Output> Run(Type testClass, IExecution execution)
-        {
-            using var console = new RedirectedConsole();
+    async Task<Output> Run(Type testClass, IExecution execution)
+    {
+        using var console = new RedirectedConsole();
 
-            var results = await Utility.Run(testClass, execution);
+        var results = await Utility.Run(testClass, execution);
 
-            return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
-        }
+        return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
+    }
 
-        async Task<Output> Run(Type[] testClasses, IExecution execution)
-        {
-            using var console = new RedirectedConsole();
+    async Task<Output> Run(Type[] testClasses, IExecution execution)
+    {
+        using var console = new RedirectedConsole();
 
-            var results = await Utility.Run(testClasses, execution);
+        var results = await Utility.Run(testClasses, execution);
 
-            return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
-        }
+        return new Output(GetType().FullName!, console.Lines().ToArray(), results.ToArray());
     }
 }

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -1,16 +1,16 @@
-﻿namespace Fixie.Tests.Internal
-{
-    using System;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Internal;
-    using Fixie.Reports;
-    using static Utility;
+﻿namespace Fixie.Tests.Internal;
 
-    public class BusTests
+using System;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Internal;
+using Fixie.Reports;
+using static Utility;
+
+public class BusTests
+{
+    public async Task ShouldPublishEventsToAllReports()
     {
-        public async Task ShouldPublishEventsToAllReports()
-        {
             var reports = new IReport[]
             {
                 new EventHandler(),
@@ -35,8 +35,8 @@
                     FullName<CombinationEventHandler>() + " handled Event 3");
         }
 
-        public async Task ShouldCatchAndLogExceptionsThrowByProblematicReportsRatherThanInterruptExecution()
-        {
+    public async Task ShouldCatchAndLogExceptionsThrowByProblematicReportsRatherThanInterruptExecution()
+    {
             var reports = new IReport[]
             {
                 new EventHandler(),
@@ -65,67 +65,66 @@
                     "<<Stack Trace>>");
         }
 
-        class Event : IMessage
-        {
-            public Event(int id) { Id = id; }
-            public int Id { get; }
-        }
+    class Event : IMessage
+    {
+        public Event(int id) { Id = id; }
+        public int Id { get; }
+    }
 
-        class AnotherEvent : IMessage
-        {
-            public AnotherEvent(int id) { Id = id; }
-            public int Id { get; }
-        }
+    class AnotherEvent : IMessage
+    {
+        public AnotherEvent(int id) { Id = id; }
+        public int Id { get; }
+    }
 
-        class EventHandler : IHandler<Event>
+    class EventHandler : IHandler<Event>
+    {
+        public Task Handle(Event message)
         {
-            public Task Handle(Event message)
-            {
                 Log<EventHandler, Event>(message.Id);
                 return Task.CompletedTask;
             }
-        }
+    }
 
-        class AnotherEventHandler : IHandler<AnotherEvent>
+    class AnotherEventHandler : IHandler<AnotherEvent>
+    {
+        public Task Handle(AnotherEvent message)
         {
-            public Task Handle(AnotherEvent message)
-            {
                 Log<AnotherEventHandler, AnotherEvent>(message.Id);
                 return Task.CompletedTask;
             }
-        }
+    }
 
-        class CombinationEventHandler : IHandler<Event>, IHandler<AnotherEvent>
+    class CombinationEventHandler : IHandler<Event>, IHandler<AnotherEvent>
+    {
+        public Task Handle(Event message)
         {
-            public Task Handle(Event message)
-            {
                 Log<CombinationEventHandler, Event>(message.Id);
                 return Task.CompletedTask;
             }
 
-            public Task Handle(AnotherEvent message)
-            {
+        public Task Handle(AnotherEvent message)
+        {
                 Log<CombinationEventHandler, AnotherEvent>(message.Id);
                 return Task.CompletedTask;
             }
-        }
+    }
 
-        class FailingEventHandler : IHandler<Event>
-        {
-            public Task Handle(Event message)
-                => throw new StubException($"Could not handle {nameof(Event)} {message.Id}");
-        }
+    class FailingEventHandler : IHandler<Event>
+    {
+        public Task Handle(Event message)
+            => throw new StubException($"Could not handle {nameof(Event)} {message.Id}");
+    }
 
-        static void Log<THandler, TEvent>(int id)
-            => Console.WriteLine($"{typeof(THandler).FullName} handled {typeof(TEvent).Name} {id}");
+    static void Log<THandler, TEvent>(int id)
+        => Console.WriteLine($"{typeof(THandler).FullName} handled {typeof(TEvent).Name} {id}");
 
-        class StubException : Exception
-        {
-            public StubException(string message)
-                : base(message) { }
+    class StubException : Exception
+    {
+        public StubException(string message)
+            : base(message) { }
 
-            public override string StackTrace
-                => "<<Stack Trace>>";
-        }
+        public override string StackTrace
+            => "<<Stack Trace>>";
     }
 }

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -11,59 +11,59 @@ public class BusTests
 {
     public async Task ShouldPublishEventsToAllReports()
     {
-            var reports = new IReport[]
-            {
-                new EventHandler(),
-                new AnotherEventHandler(),
-                new CombinationEventHandler()
-            };
+        var reports = new IReport[]
+        {
+            new EventHandler(),
+            new AnotherEventHandler(),
+            new CombinationEventHandler()
+        };
 
-            using var console = new RedirectedConsole();
+        using var console = new RedirectedConsole();
 
-            var bus = new Bus(Console.Out, reports);
-            await bus.Publish(new Event(1));
-            await bus.Publish(new AnotherEvent(2));
-            await bus.Publish(new Event(3));
+        var bus = new Bus(Console.Out, reports);
+        await bus.Publish(new Event(1));
+        await bus.Publish(new AnotherEvent(2));
+        await bus.Publish(new Event(3));
 
-            console.Lines()
-                .ShouldBe(
-                    FullName<EventHandler>() + " handled Event 1",
-                    FullName<CombinationEventHandler>() + " handled Event 1",
-                    FullName<AnotherEventHandler>() + " handled AnotherEvent 2",
-                    FullName<CombinationEventHandler>() + " handled AnotherEvent 2",
-                    FullName<EventHandler>() + " handled Event 3",
-                    FullName<CombinationEventHandler>() + " handled Event 3");
-        }
+        console.Lines()
+            .ShouldBe(
+                FullName<EventHandler>() + " handled Event 1",
+                FullName<CombinationEventHandler>() + " handled Event 1",
+                FullName<AnotherEventHandler>() + " handled AnotherEvent 2",
+                FullName<CombinationEventHandler>() + " handled AnotherEvent 2",
+                FullName<EventHandler>() + " handled Event 3",
+                FullName<CombinationEventHandler>() + " handled Event 3");
+    }
 
     public async Task ShouldCatchAndLogExceptionsThrowByProblematicReportsRatherThanInterruptExecution()
     {
-            var reports = new IReport[]
-            {
-                new EventHandler(),
-                new FailingEventHandler()
-            };
+        var reports = new IReport[]
+        {
+            new EventHandler(),
+            new FailingEventHandler()
+        };
 
-            using var console = new RedirectedConsole();
+        using var console = new RedirectedConsole();
 
-            var bus = new Bus(Console.Out, reports);
-            await bus.Publish(new Event(1));
-            await bus.Publish(new AnotherEvent(2));
-            await bus.Publish(new Event(3));
+        var bus = new Bus(Console.Out, reports);
+        await bus.Publish(new Event(1));
+        await bus.Publish(new AnotherEvent(2));
+        await bus.Publish(new Event(3));
 
-            console.Lines()
-                .ShouldBe(
-                    FullName<EventHandler>() + " handled Event 1",
-                    FullName<FailingEventHandler>() + $" threw an exception while attempting to handle a message of type {FullName<Event>()}:",
-                    "",
-                    FullName<StubException>() + ": Could not handle Event 1",
-                    "<<Stack Trace>>",
-                    "",
-                    FullName<EventHandler>() + " handled Event 3",
-                    FullName<FailingEventHandler>() + $" threw an exception while attempting to handle a message of type {FullName<Event>()}:",
-                    "",
-                    FullName<StubException>() + ": Could not handle Event 3",
-                    "<<Stack Trace>>");
-        }
+        console.Lines()
+            .ShouldBe(
+                FullName<EventHandler>() + " handled Event 1",
+                FullName<FailingEventHandler>() + $" threw an exception while attempting to handle a message of type {FullName<Event>()}:",
+                "",
+                FullName<StubException>() + ": Could not handle Event 1",
+                "<<Stack Trace>>",
+                "",
+                FullName<EventHandler>() + " handled Event 3",
+                FullName<FailingEventHandler>() + $" threw an exception while attempting to handle a message of type {FullName<Event>()}:",
+                "",
+                FullName<StubException>() + ": Could not handle Event 3",
+                "<<Stack Trace>>");
+    }
 
     class Event : IMessage
     {
@@ -81,33 +81,33 @@ public class BusTests
     {
         public Task Handle(Event message)
         {
-                Log<EventHandler, Event>(message.Id);
-                return Task.CompletedTask;
-            }
+            Log<EventHandler, Event>(message.Id);
+            return Task.CompletedTask;
+        }
     }
 
     class AnotherEventHandler : IHandler<AnotherEvent>
     {
         public Task Handle(AnotherEvent message)
         {
-                Log<AnotherEventHandler, AnotherEvent>(message.Id);
-                return Task.CompletedTask;
-            }
+            Log<AnotherEventHandler, AnotherEvent>(message.Id);
+            return Task.CompletedTask;
+        }
     }
 
     class CombinationEventHandler : IHandler<Event>, IHandler<AnotherEvent>
     {
         public Task Handle(Event message)
         {
-                Log<CombinationEventHandler, Event>(message.Id);
-                return Task.CompletedTask;
-            }
+            Log<CombinationEventHandler, Event>(message.Id);
+            return Task.CompletedTask;
+        }
 
         public Task Handle(AnotherEvent message)
         {
-                Log<CombinationEventHandler, AnotherEvent>(message.Id);
-                return Task.CompletedTask;
-            }
+            Log<CombinationEventHandler, AnotherEvent>(message.Id);
+            return Task.CompletedTask;
+        }
     }
 
     class FailingEventHandler : IHandler<Event>

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -1,17 +1,17 @@
-﻿namespace Fixie.Tests.Internal
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Internal;
+﻿namespace Fixie.Tests.Internal;
 
-    public class ClassDiscovererTests
-    {
-        static readonly Type[] CandidateTypes =
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Internal;
+
+public class ClassDiscovererTests
+{
+    static readonly Type[] CandidateTypes =
         {
             typeof(Decimal),
             typeof(StaticClass),
@@ -26,48 +26,48 @@
             typeof(InheritanceSample)
         };
 
-        class MaximumDiscovery : IDiscovery
-        {
-            public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-                => concreteClasses;
+    class MaximumDiscovery : IDiscovery
+    {
+        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
+            => concreteClasses;
 
-            public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-                => throw new ShouldBeUnreachableException();
-        }
+        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => throw new ShouldBeUnreachableException();
+    }
 
-        class NarrowDiscovery : IDiscovery
+    class NarrowDiscovery : IDiscovery
+    {
+        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
         {
-            public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-            {
                 return concreteClasses
                     .Where(x => (x.Namespace ?? "").StartsWith("Fixie.Tests"))
                     .Where(x => x.Name.Contains("i"))
                     .Where(x => !x.IsStatic());
             }
 
-            public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-                => throw new ShouldBeUnreachableException();
-        }
+        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => throw new ShouldBeUnreachableException();
+    }
         
-        class BuggyDiscovery : IDiscovery
+    class BuggyDiscovery : IDiscovery
+    {
+        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
         {
-            public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-            {
                 return concreteClasses.Where(x => throw new Exception("Unsafe class-discovery predicate threw!"));
             }
 
-            public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-                => throw new ShouldBeUnreachableException();
-        }
+        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => throw new ShouldBeUnreachableException();
+    }
 
-        class SampleExecution : IExecution
-        {
-            public Task Run(TestSuite testSuite)
-                => Task.CompletedTask;
-        }
+    class SampleExecution : IExecution
+    {
+        public Task Run(TestSuite testSuite)
+            => Task.CompletedTask;
+    }
 
-        public void ShouldDiscoverClassesWhoseNameEndsWithTestsByDefault()
-        {
+    public void ShouldDiscoverClassesWhoseNameEndsWithTestsByDefault()
+    {
             var discovery = new DefaultDiscovery();
 
             DiscoveredTestClasses(discovery)
@@ -75,8 +75,8 @@
                     typeof(NameEndsWithTests));
         }
 
-        public void ShouldSupportMaximalDiscoveryOfConcreteClasses()
-        {
+    public void ShouldSupportMaximalDiscoveryOfConcreteClasses()
+    {
             var discovery = new MaximumDiscovery();
 
             DiscoveredTestClasses(discovery)
@@ -90,8 +90,8 @@
                     typeof(InheritanceSample));
         }
 
-        public void ShouldNotConsiderCompilerGeneratedClosureClasses()
-        {
+    public void ShouldNotConsiderCompilerGeneratedClosureClasses()
+    {
             var nested = typeof(ClassThatCausesCompilerGeneratedNestedClosureClass)
                 .GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
                 .Single();
@@ -113,8 +113,8 @@
                     typeof(InheritanceSample));
         }
 
-        public void ShouldDiscoverClassesSatisfyingAllSpecifiedConditions()
-        {
+    public void ShouldDiscoverClassesSatisfyingAllSpecifiedConditions()
+    {
             var discovery = new NarrowDiscovery();
 
             DiscoveredTestClasses(discovery)
@@ -124,8 +124,8 @@
                     typeof(InheritanceSample));
         }
 
-        public void ShouldFailWithClearExplanationWhenDiscoveryThrows()
-        {
+    public void ShouldFailWithClearExplanationWhenDiscoveryThrows()
+    {
             var discovery = new BuggyDiscovery();
 
             Action attemptFaultyDiscovery = () => DiscoveredTestClasses(discovery);
@@ -139,33 +139,33 @@
                 .Message.ShouldBe("Unsafe class-discovery predicate threw!");
         }
 
-        static IEnumerable<Type> DiscoveredTestClasses(IDiscovery discovery)
-        {
+    static IEnumerable<Type> DiscoveredTestClasses(IDiscovery discovery)
+    {
             return new ClassDiscoverer(discovery)
                 .TestClasses(CandidateTypes);
         }
 
-        static IEnumerable<Type> DiscoveredTestClasses(IDiscovery discovery, params Type[] additionalCandidates)
-        {
+    static IEnumerable<Type> DiscoveredTestClasses(IDiscovery discovery, params Type[] additionalCandidates)
+    {
             return new ClassDiscoverer(discovery)
                 .TestClasses(CandidateTypes.Concat(additionalCandidates));
         }
 
-        static class StaticClass { }
-        abstract class AbstractClass { }
-        class DefaultConstructor { }
-        class NoDefaultConstructor { public NoDefaultConstructor(int arg) { } }
-        class NameEndsWithTests { }
-        interface Interface { }
+    static class StaticClass { }
+    abstract class AbstractClass { }
+    class DefaultConstructor { }
+    class NoDefaultConstructor { public NoDefaultConstructor(int arg) { } }
+    class NameEndsWithTests { }
+    interface Interface { }
 
-        class InheritanceSampleBase { }
+    class InheritanceSampleBase { }
 
-        class InheritanceSample : InheritanceSampleBase { }
+    class InheritanceSample : InheritanceSampleBase { }
 
-        class ClassThatCausesCompilerGeneratedNestedClosureClass
+    class ClassThatCausesCompilerGeneratedNestedClosureClass
+    {
+        void MethodThatCausesCompilerGeneratedClosureClass()
         {
-            void MethodThatCausesCompilerGeneratedClosureClass()
-            {
                 //Because this lambda expression refers to a variable in the surrounding
                 //method, the compiler generates a special nested class as an implementation
                 //detail.  Such generated classes should never be mistaken for test classes.
@@ -173,6 +173,5 @@
                 var s = string.Empty;
                 var func = new Func<string, string>(_ => s);
             }
-        }
     }
 }

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -12,19 +12,19 @@ using Fixie.Internal;
 public class ClassDiscovererTests
 {
     static readonly Type[] CandidateTypes =
-        {
-            typeof(Decimal),
-            typeof(StaticClass),
-            typeof(AbstractClass),
-            typeof(DateTime),
-            typeof(DefaultConstructor),
-            typeof(NoDefaultConstructor),
-            typeof(NameEndsWithTests),
-            typeof(String),
-            typeof(Interface),
-            typeof(InheritanceSampleBase),
-            typeof(InheritanceSample)
-        };
+    {
+        typeof(Decimal),
+        typeof(StaticClass),
+        typeof(AbstractClass),
+        typeof(DateTime),
+        typeof(DefaultConstructor),
+        typeof(NoDefaultConstructor),
+        typeof(NameEndsWithTests),
+        typeof(String),
+        typeof(Interface),
+        typeof(InheritanceSampleBase),
+        typeof(InheritanceSample)
+    };
 
     class MaximumDiscovery : IDiscovery
     {
@@ -39,11 +39,11 @@ public class ClassDiscovererTests
     {
         public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
         {
-                return concreteClasses
-                    .Where(x => (x.Namespace ?? "").StartsWith("Fixie.Tests"))
-                    .Where(x => x.Name.Contains("i"))
-                    .Where(x => !x.IsStatic());
-            }
+            return concreteClasses
+                .Where(x => (x.Namespace ?? "").StartsWith("Fixie.Tests"))
+                .Where(x => x.Name.Contains("i"))
+                .Where(x => !x.IsStatic());
+        }
 
         public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
             => throw new ShouldBeUnreachableException();
@@ -53,8 +53,8 @@ public class ClassDiscovererTests
     {
         public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
         {
-                return concreteClasses.Where(x => throw new Exception("Unsafe class-discovery predicate threw!"));
-            }
+            return concreteClasses.Where(x => throw new Exception("Unsafe class-discovery predicate threw!"));
+        }
 
         public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
             => throw new ShouldBeUnreachableException();
@@ -68,88 +68,88 @@ public class ClassDiscovererTests
 
     public void ShouldDiscoverClassesWhoseNameEndsWithTestsByDefault()
     {
-            var discovery = new DefaultDiscovery();
+        var discovery = new DefaultDiscovery();
 
-            DiscoveredTestClasses(discovery)
-                .ShouldBe(
-                    typeof(NameEndsWithTests));
-        }
+        DiscoveredTestClasses(discovery)
+            .ShouldBe(
+                typeof(NameEndsWithTests));
+    }
 
     public void ShouldSupportMaximalDiscoveryOfConcreteClasses()
     {
-            var discovery = new MaximumDiscovery();
+        var discovery = new MaximumDiscovery();
 
-            DiscoveredTestClasses(discovery)
-                .ShouldBe(
-                    typeof(StaticClass),
-                    typeof(DefaultConstructor),
-                    typeof(NoDefaultConstructor),
-                    typeof(NameEndsWithTests),
-                    typeof(String),
-                    typeof(InheritanceSampleBase),
-                    typeof(InheritanceSample));
-        }
+        DiscoveredTestClasses(discovery)
+            .ShouldBe(
+                typeof(StaticClass),
+                typeof(DefaultConstructor),
+                typeof(NoDefaultConstructor),
+                typeof(NameEndsWithTests),
+                typeof(String),
+                typeof(InheritanceSampleBase),
+                typeof(InheritanceSample));
+    }
 
     public void ShouldNotConsiderCompilerGeneratedClosureClasses()
     {
-            var nested = typeof(ClassThatCausesCompilerGeneratedNestedClosureClass)
-                .GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
-                .Single();
+        var nested = typeof(ClassThatCausesCompilerGeneratedNestedClosureClass)
+            .GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+            .Single();
 
-            //Confirm that a nested closure class has actually been generated.
-            nested.Has<CompilerGeneratedAttribute>().ShouldBe(true);
+        //Confirm that a nested closure class has actually been generated.
+        nested.Has<CompilerGeneratedAttribute>().ShouldBe(true);
 
-            //Confirm that the nested closure class is omitted from test class discovery.
-            var discovery = new MaximumDiscovery();
+        //Confirm that the nested closure class is omitted from test class discovery.
+        var discovery = new MaximumDiscovery();
 
-            DiscoveredTestClasses(discovery, nested)
-                .ShouldBe(
-                    typeof(StaticClass),
-                    typeof(DefaultConstructor),
-                    typeof(NoDefaultConstructor),
-                    typeof(NameEndsWithTests),
-                    typeof(String),
-                    typeof(InheritanceSampleBase),
-                    typeof(InheritanceSample));
-        }
+        DiscoveredTestClasses(discovery, nested)
+            .ShouldBe(
+                typeof(StaticClass),
+                typeof(DefaultConstructor),
+                typeof(NoDefaultConstructor),
+                typeof(NameEndsWithTests),
+                typeof(String),
+                typeof(InheritanceSampleBase),
+                typeof(InheritanceSample));
+    }
 
     public void ShouldDiscoverClassesSatisfyingAllSpecifiedConditions()
     {
-            var discovery = new NarrowDiscovery();
+        var discovery = new NarrowDiscovery();
 
-            DiscoveredTestClasses(discovery)
-                .ShouldBe(
-                    typeof(NameEndsWithTests),
-                    typeof(InheritanceSampleBase),
-                    typeof(InheritanceSample));
-        }
+        DiscoveredTestClasses(discovery)
+            .ShouldBe(
+                typeof(NameEndsWithTests),
+                typeof(InheritanceSampleBase),
+                typeof(InheritanceSample));
+    }
 
     public void ShouldFailWithClearExplanationWhenDiscoveryThrows()
     {
-            var discovery = new BuggyDiscovery();
+        var discovery = new BuggyDiscovery();
 
-            Action attemptFaultyDiscovery = () => DiscoveredTestClasses(discovery);
+        Action attemptFaultyDiscovery = () => DiscoveredTestClasses(discovery);
 
-            var exception = attemptFaultyDiscovery.ShouldThrow<Exception>(
-                "Exception thrown during test class discovery. " +
-                "Check the inner exception for more details.");
+        var exception = attemptFaultyDiscovery.ShouldThrow<Exception>(
+            "Exception thrown during test class discovery. " +
+            "Check the inner exception for more details.");
 
-            exception.InnerException
-                .ShouldBe<Exception>()
-                .Message.ShouldBe("Unsafe class-discovery predicate threw!");
-        }
+        exception.InnerException
+            .ShouldBe<Exception>()
+            .Message.ShouldBe("Unsafe class-discovery predicate threw!");
+    }
 
     static IEnumerable<Type> DiscoveredTestClasses(IDiscovery discovery)
     {
-            return new ClassDiscoverer(discovery)
-                .TestClasses(CandidateTypes);
-        }
+        return new ClassDiscoverer(discovery)
+            .TestClasses(CandidateTypes);
+    }
 
     static IEnumerable<Type> DiscoveredTestClasses(IDiscovery discovery, params Type[] additionalCandidates)
     {
-            return new ClassDiscoverer(discovery)
-                .TestClasses(CandidateTypes.Concat(additionalCandidates));
-        }
+        return new ClassDiscoverer(discovery)
+            .TestClasses(CandidateTypes.Concat(additionalCandidates));
+    }
 
     static class StaticClass { }
     abstract class AbstractClass { }
@@ -166,12 +166,12 @@ public class ClassDiscovererTests
     {
         void MethodThatCausesCompilerGeneratedClosureClass()
         {
-                //Because this lambda expression refers to a variable in the surrounding
-                //method, the compiler generates a special nested class as an implementation
-                //detail.  Such generated classes should never be mistaken for test classes.
+            //Because this lambda expression refers to a variable in the surrounding
+            //method, the compiler generates a special nested class as an implementation
+            //detail.  Such generated classes should never be mistaken for test classes.
 
-                var s = string.Empty;
-                var func = new Func<string, string>(_ => s);
-            }
+            var s = string.Empty;
+            var func = new Func<string, string>(_ => s);
+        }
     }
 }

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -1,15 +1,15 @@
-﻿namespace Fixie.Tests.Internal
-{
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
-    using static Utility;
+﻿namespace Fixie.Tests.Internal;
 
-    public class ExecutionSummaryTests
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+using static Utility;
+
+public class ExecutionSummaryTests
+{
+    public async Task ShouldAccumulateTestResultCounts()
     {
-        public async Task ShouldAccumulateTestResultCounts()
-        {
             var report = new StubExecutionSummaryReport();
             var discovery = new SelfTestDiscovery();
             var execution = new CreateInstancePerCase();
@@ -26,43 +26,42 @@
             executionCompleted.Total.ShouldBe(9);
         }
 
-        class StubExecutionSummaryReport :
-            IHandler<ExecutionCompleted>
-        {
-            public List<ExecutionCompleted> ExecutionCompletions { get; } = new List<ExecutionCompleted>();
+    class StubExecutionSummaryReport :
+        IHandler<ExecutionCompleted>
+    {
+        public List<ExecutionCompleted> ExecutionCompletions { get; } = new List<ExecutionCompleted>();
 
-            public Task Handle(ExecutionCompleted message)
-            {
+        public Task Handle(ExecutionCompleted message)
+        {
                 ExecutionCompletions.Add(message);
                 return Task.CompletedTask;
             }
-        }
+    }
 
-        class FirstSampleTestClass
-        {
-            public void Pass() { }
-            public void Fail() { throw new FailureException(); }
-            public void Skip() { }
-        }
+    class FirstSampleTestClass
+    {
+        public void Pass() { }
+        public void Fail() { throw new FailureException(); }
+        public void Skip() { }
+    }
 
-        class SecondSampleTestClass
-        {
-            public void Pass() { }
-            public void FailA() { throw new FailureException(); }
-            public void FailB() { throw new FailureException(); }
-            public void SkipA() { }
-            public void SkipB() { }
-            public void SkipC() { }
-        }
+    class SecondSampleTestClass
+    {
+        public void Pass() { }
+        public void FailA() { throw new FailureException(); }
+        public void FailB() { throw new FailureException(); }
+        public void SkipA() { }
+        public void SkipB() { }
+        public void SkipC() { }
+    }
 
-        class CreateInstancePerCase : IExecution
+    class CreateInstancePerCase : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var test in testSuite.Tests)
                     if (!test.Name.Contains("Skip"))
                         await test.Run();
             }
-        }
     }
 }

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -10,21 +10,21 @@ public class ExecutionSummaryTests
 {
     public async Task ShouldAccumulateTestResultCounts()
     {
-            var report = new StubExecutionSummaryReport();
-            var discovery = new SelfTestDiscovery();
-            var execution = new CreateInstancePerCase();
+        var report = new StubExecutionSummaryReport();
+        var discovery = new SelfTestDiscovery();
+        var execution = new CreateInstancePerCase();
 
-            await Run(report, discovery, execution, typeof(FirstSampleTestClass), typeof(SecondSampleTestClass));
+        await Run(report, discovery, execution, typeof(FirstSampleTestClass), typeof(SecondSampleTestClass));
 
-            report.ExecutionCompletions.Count.ShouldBe(1);
+        report.ExecutionCompletions.Count.ShouldBe(1);
 
-            var executionCompleted = report.ExecutionCompletions[0];
+        var executionCompleted = report.ExecutionCompletions[0];
 
-            executionCompleted.Passed.ShouldBe(2);
-            executionCompleted.Failed.ShouldBe(3);
-            executionCompleted.Skipped.ShouldBe(4);
-            executionCompleted.Total.ShouldBe(9);
-        }
+        executionCompleted.Passed.ShouldBe(2);
+        executionCompleted.Failed.ShouldBe(3);
+        executionCompleted.Skipped.ShouldBe(4);
+        executionCompleted.Total.ShouldBe(9);
+    }
 
     class StubExecutionSummaryReport :
         IHandler<ExecutionCompleted>
@@ -33,9 +33,9 @@ public class ExecutionSummaryTests
 
         public Task Handle(ExecutionCompleted message)
         {
-                ExecutionCompletions.Add(message);
-                return Task.CompletedTask;
-            }
+            ExecutionCompletions.Add(message);
+            return Task.CompletedTask;
+        }
     }
 
     class FirstSampleTestClass
@@ -59,9 +59,9 @@ public class ExecutionSummaryTests
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var test in testSuite.Tests)
-                    if (!test.Name.Contains("Skip"))
-                        await test.Run();
-            }
+            foreach (var test in testSuite.Tests)
+                if (!test.Name.Contains("Skip"))
+                    await test.Run();
+        }
     }
 }

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -12,262 +12,262 @@ public class GenericArgumentResolverTests
 
     public void ShouldResolveNothingWhenThereAreNoInputParameters()
     {
-            Resolve("NoParameters")
-                .ShouldBe(Empty);
-        }
+        Resolve("NoParameters")
+            .ShouldBe(Empty);
+    }
 
     public void ShouldResolveNothingWhenThereAreNoGenericParameters()
     {
-            Resolve("NoGenericArguments", 0, "")
-                .ShouldBe(Empty);
-        }
+        Resolve("NoGenericArguments", 0, "")
+            .ShouldBe(Empty);
+    }
 
     public void ShouldNotResolveWhenGenericTypeHasNoMatchingParameters()
     {
-            Resolve("NoMatchingParameters", 0, "")
-                .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
-        }
+        Resolve("NoMatchingParameters", 0, "")
+            .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
+    }
 
     public void ShouldNotResolveWhenGenericTypeHasOneNullMatchingParameter()
     {
-            Resolve("OneMatchingParameter", new object?[] {null})
-                .ShouldSatisfy(t => t.ShouldBeGenericTypeParameter("T"));
-        }
+        Resolve("OneMatchingParameter", new object?[] {null})
+            .ShouldSatisfy(t => t.ShouldBeGenericTypeParameter("T"));
+    }
         
     public void ShouldResolveToConcreteTypeOfValueWhenGenericTypeHasOneNonNullMatchingParameter()
     {
-            Resolve("OneMatchingParameter", 1.2m)
-                .ShouldBe(typeof(decimal));
+        Resolve("OneMatchingParameter", 1.2m)
+            .ShouldBe(typeof(decimal));
 
-            Resolve("OneMatchingParameter", "string")
-                .ShouldBe(typeof(string));
-        }
+        Resolve("OneMatchingParameter", "string")
+            .ShouldBe(typeof(string));
+    }
 
     public void ShouldResolveToFirstConcreteTypeWhenGenericTypeHasMultipleMatchingParametersOfInconsistentConcreteTypes()
     {
-            Resolve("MultipleMatchingParameter", 1.2m, "string", 0)
-                .ShouldBe(typeof(decimal));
-            
-            Resolve("MultipleMatchingParameter", 1.2m, "string a", "string b")
-                .ShouldBe(typeof(decimal));
-        }
+        Resolve("MultipleMatchingParameter", 1.2m, "string", 0)
+            .ShouldBe(typeof(decimal));
+        
+        Resolve("MultipleMatchingParameter", 1.2m, "string a", "string b")
+            .ShouldBe(typeof(decimal));
+    }
 
     public void ShouldResolveToConcreteTypeOfValuesWhenGenericTypeHasMultipleMatchingParametersOfTheExactSameConcreteType()
     {
-            Resolve("MultipleMatchingParameter", 1.2m, 2.3m, 3.4m)
-                .ShouldBe(typeof(decimal));
+        Resolve("MultipleMatchingParameter", 1.2m, 2.3m, 3.4m)
+            .ShouldBe(typeof(decimal));
 
-            Resolve("MultipleMatchingParameter", "string a", "string b", "string c")
-                .ShouldBe(typeof(string));
-        }
+        Resolve("MultipleMatchingParameter", "string a", "string b", "string c")
+            .ShouldBe(typeof(string));
+    }
 
     public void ShouldNotResolveWhenGenericTypeHasMultipleMatchingParametersButAllAreNull()
     {
-            Resolve("MultipleMatchingParameter", null, null, null)
-                .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
-        }
+        Resolve("MultipleMatchingParameter", null, null, null)
+            .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
+    }
 
     public void ShouldTreatNullsAsTypeCompatibleWithReferenceTypes()
     {
-            Resolve("MultipleMatchingParameter", null, "string b", "string c")
-                .ShouldBe(typeof(string));
+        Resolve("MultipleMatchingParameter", null, "string b", "string c")
+            .ShouldBe(typeof(string));
 
-            Resolve("MultipleMatchingParameter", "string a", null, "string c")
-                .ShouldBe(typeof(string));
+        Resolve("MultipleMatchingParameter", "string a", null, "string c")
+            .ShouldBe(typeof(string));
 
-            Resolve("MultipleMatchingParameter", "string a", "string b", null)
-                .ShouldBe(typeof(string));
-        }
+        Resolve("MultipleMatchingParameter", "string a", "string b", null)
+            .ShouldBe(typeof(string));
+    }
 
     public void ShouldIgnoreNullAsTypeIncompatibleWithValueTypes()
     {
-            Resolve("MultipleMatchingParameter", null, 2.3m, 3.4m)
-                .ShouldBe(typeof(decimal));
+        Resolve("MultipleMatchingParameter", null, 2.3m, 3.4m)
+            .ShouldBe(typeof(decimal));
 
-            Resolve("MultipleMatchingParameter", 1.2m, null, 3.4m)
-                .ShouldBe(typeof(decimal));
+        Resolve("MultipleMatchingParameter", 1.2m, null, 3.4m)
+            .ShouldBe(typeof(decimal));
 
-            Resolve("MultipleMatchingParameter", 1.2m, 2.3m, null)
-                .ShouldBe(typeof(decimal));
-        }
+        Resolve("MultipleMatchingParameter", 1.2m, 2.3m, null)
+            .ShouldBe(typeof(decimal));
+    }
 
     public void ShouldResolveGenericArgumentsIfAndOnlyIfTheyCanAllBeResolved()
     {
-            Resolve("MultipleUnsatisfiableGenericArguments", null, 1.2m, "string", 0)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        Resolve("MultipleUnsatisfiableGenericArguments", null, 1.2m, "string", 0)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, "string", 0)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, "string", 0)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, "string a", "string b")
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, "string a", "string b")
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, 2.3m, 3.4m)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, 2.3m, 3.4m)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleUnsatisfiableGenericArguments", false, "string a", "string b", "string c")
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        Resolve("MultipleUnsatisfiableGenericArguments", false, "string a", "string b", "string c")
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleUnsatisfiableGenericArguments", false, null, null, null)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
-            
-            Resolve("MultipleUnsatisfiableGenericArguments", false, "string a", "string b", null)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        Resolve("MultipleUnsatisfiableGenericArguments", false, null, null, null)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        
+        Resolve("MultipleUnsatisfiableGenericArguments", false, "string a", "string b", null)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, 2.3m, null)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TNoMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, 2.3m, null)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TNoMatch"),
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleSatisfiableGenericArguments", null, 1.2m, "string", 0)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        Resolve("MultipleSatisfiableGenericArguments", null, 1.2m, "string", 0)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
-            Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string", 0)
-                .ShouldBe(typeof(bool), typeof(decimal));
+        Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string", 0)
+            .ShouldBe(typeof(bool), typeof(decimal));
 
-            Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string a", "string b")
-                .ShouldBe(typeof(bool), typeof(decimal));
+        Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string a", "string b")
+            .ShouldBe(typeof(bool), typeof(decimal));
 
-            Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, 2.3m, 3.4m)
-                .ShouldBe(typeof(bool), typeof(decimal));
+        Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, 2.3m, 3.4m)
+            .ShouldBe(typeof(bool), typeof(decimal));
 
-            Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", "string c")
-                .ShouldBe(typeof(bool), typeof(string));
+        Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", "string c")
+            .ShouldBe(typeof(bool), typeof(string));
 
-            Resolve("MultipleSatisfiableGenericArguments", false, null, null, null)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                    x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
-            
-            Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", null)
-                .ShouldBe(typeof(bool), typeof(string));
+        Resolve("MultipleSatisfiableGenericArguments", false, null, null, null)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("TOneMatch"),
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+        
+        Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", null)
+            .ShouldBe(typeof(bool), typeof(string));
 
-            Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, 2.3m, null)
-                .ShouldBe(typeof(bool), typeof(decimal));
-        }
+        Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, 2.3m, null)
+            .ShouldBe(typeof(bool), typeof(decimal));
+    }
 
     public void ShouldNotResolveWhenInputParameterCountIsLessThanDeclaredParameterCount()
     {
-            Resolve("MultipleMatchingParameter", 1, 2)
-                .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
-        }
+        Resolve("MultipleMatchingParameter", 1, 2)
+            .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
+    }
 
     public void ShouldAttemptReasonableResolutionByIgnoringExcessParametersWhenInputParameterCountIsGreaterThanDeclaredParameterCount()
     {
-            Resolve("MultipleMatchingParameter", 1, 2, 3, 4)
-                .ShouldBe(typeof(int));
-        }
+        Resolve("MultipleMatchingParameter", 1, 2, 3, 4)
+            .ShouldBe(typeof(int));
+    }
 
     public void ShouldResolveGenericArgumentsWhenGenericConstraintsAreSatisfied()
     {
-            Resolve("ConstrainedGeneric", 1)
-                .ShouldBe(typeof(int));
+        Resolve("ConstrainedGeneric", 1)
+            .ShouldBe(typeof(int));
 
-            Resolve("ConstrainedGeneric", true)
-                .ShouldBe(typeof(bool));
-        }
+        Resolve("ConstrainedGeneric", true)
+            .ShouldBe(typeof(bool));
+    }
 
     public void ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
     {
-            Resolve("CompoundGenericParameter", new KeyValuePair<int, string>(1, "A"))
-                .ShouldBe(typeof(int), typeof(string));
+        Resolve("CompoundGenericParameter", new KeyValuePair<int, string>(1, "A"))
+            .ShouldBe(typeof(int), typeof(string));
 
-            Resolve("CompoundGenericParameter", new KeyValuePair<string, int>("A", 1))
-                .ShouldBe(typeof(string), typeof(int));
+        Resolve("CompoundGenericParameter", new KeyValuePair<string, int>("A", 1))
+            .ShouldBe(typeof(string), typeof(int));
 
-            Resolve("GenericFuncParameter", 5, new Func<int, int>(i => i * 2), 10)
-                .ShouldBe(typeof(int));
+        Resolve("GenericFuncParameter", 5, new Func<int, int>(i => i * 2), 10)
+            .ShouldBe(typeof(int));
 
-            Resolve("GenericFuncParameter", 5, new Func<int, string>(i => i.ToString()), "5")
-                .ShouldBe(typeof(string));
+        Resolve("GenericFuncParameter", 5, new Func<int, string>(i => i.ToString()), "5")
+            .ShouldBe(typeof(string));
 
-            //We select string as our T, though the char argument would fail to cast at runtime,
-            //causing this test to fail.
-            Resolve("GenericFuncParameter", 5, new Func<int, string>(i => i.ToString()), '5')
-                .ShouldBe(typeof(string));
-        }
+        //We select string as our T, though the char argument would fail to cast at runtime,
+        //causing this test to fail.
+        Resolve("GenericFuncParameter", 5, new Func<int, string>(i => i.ToString()), '5')
+            .ShouldBe(typeof(string));
+    }
 
     public void ShouldResolveGenericTypeParametersAppearingWithinArrays()
     {
-            Resolve("GenericArrayResolution", new[] {1}, "A")
-                .ShouldBe(typeof(int), typeof(string));
+        Resolve("GenericArrayResolution", new[] {1}, "A")
+            .ShouldBe(typeof(int), typeof(string));
 
-            Resolve("GenericArrayResolution", new[] {"B"}, 2)
-                .ShouldBe(typeof(string), typeof(int));
+        Resolve("GenericArrayResolution", new[] {"B"}, 2)
+            .ShouldBe(typeof(string), typeof(int));
 
-            Resolve("GenericArrayResolution", new[] {"C"}, new[] {3})
-                .ShouldBe(typeof(string), typeof(int[]));
+        Resolve("GenericArrayResolution", new[] {"C"}, new[] {3})
+            .ShouldBe(typeof(string), typeof(int[]));
 
-            Resolve("GenericArrayResolution", 0, 1)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("T1"),
-                    x => x.ShouldBeGenericTypeParameter("T2"));
-        }
+        Resolve("GenericArrayResolution", 0, 1)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("T1"),
+                x => x.ShouldBeGenericTypeParameter("T2"));
+    }
 
     public void ShouldResolveNullableValueTypeParametersWithConcreteValueTypes()
     {
-            Resolve("NullableValueTypeResolution", 1, 2, 3, 4)
-                .ShouldBe(typeof(int), typeof(int));
+        Resolve("NullableValueTypeResolution", 1, 2, 3, 4)
+            .ShouldBe(typeof(int), typeof(int));
 
-            Resolve("NullableValueTypeResolution", 'a', 2.0d, 3.0d, 4)
-                .ShouldBe(typeof(char), typeof(double));
-            
-            Resolve("NullableValueTypeResolution", 'a', 2.0d, 3, 4)
-                .ShouldBe(typeof(char), typeof(double));
-            
-            Resolve("NullableValueTypeResolution", 'a', 2, 3.03, 4)
-                .ShouldBe(typeof(char), typeof(int));
+        Resolve("NullableValueTypeResolution", 'a', 2.0d, 3.0d, 4)
+            .ShouldBe(typeof(char), typeof(double));
+        
+        Resolve("NullableValueTypeResolution", 'a', 2.0d, 3, 4)
+            .ShouldBe(typeof(char), typeof(double));
+        
+        Resolve("NullableValueTypeResolution", 'a', 2, 3.03, 4)
+            .ShouldBe(typeof(char), typeof(int));
 
-            Resolve("NullableValueTypeResolution", 'a', null, 3.03, 4)
-                .ShouldBe(typeof(char), typeof(double));
+        Resolve("NullableValueTypeResolution", 'a', null, 3.03, 4)
+            .ShouldBe(typeof(char), typeof(double));
 
-            Resolve("NullableValueTypeResolution", 'a', 2, null, 4)
-                .ShouldBe(typeof(char), typeof(int));
+        Resolve("NullableValueTypeResolution", 'a', 2, null, 4)
+            .ShouldBe(typeof(char), typeof(int));
 
-            Resolve("NullableValueTypeResolution", null, 2, 3, 4)
-                .ShouldSatisfy(
-                    x => x.ShouldBeGenericTypeParameter("T1"),
-                    x => x.ShouldBeGenericTypeParameter("T2"));
-        }
+        Resolve("NullableValueTypeResolution", null, 2, 3, 4)
+            .ShouldSatisfy(
+                x => x.ShouldBeGenericTypeParameter("T1"),
+                x => x.ShouldBeGenericTypeParameter("T2"));
+    }
 
     public void ShouldLeaveGenericTypeParameterWhenGenericTypeParametersCannotBeResolved()
     {
-            var unresolved = Resolve("ConstrainedGeneric", "Incompatible").Single();
-            unresolved.Name.ShouldBe("T");
-            unresolved.IsGenericParameter.ShouldBe(true);
-        }
+        var unresolved = Resolve("ConstrainedGeneric", "Incompatible").Single();
+        unresolved.Name.ShouldBe("T");
+        unresolved.IsGenericParameter.ShouldBe(true);
+    }
 
     static IEnumerable<Type> Resolve(string methodName, params object?[] parameters)
     {
-            return typeof(Generic)
-                .GetInstanceMethod(methodName)
-                .TryResolveTypeArguments(parameters)
-                .GetGenericArguments();
-        }
+        return typeof(Generic)
+            .GetInstanceMethod(methodName)
+            .TryResolveTypeArguments(parameters)
+            .GetGenericArguments();
+    }
 
     class Generic
     {

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -1,41 +1,41 @@
-﻿namespace Fixie.Tests.Internal
+﻿namespace Fixie.Tests.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Assertions;
+using Fixie.Internal;
+
+public class GenericArgumentResolverTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using Assertions;
-    using Fixie.Internal;
+    static readonly Type[] Empty = { };
 
-    public class GenericArgumentResolverTests
+    public void ShouldResolveNothingWhenThereAreNoInputParameters()
     {
-        static readonly Type[] Empty = { };
-
-        public void ShouldResolveNothingWhenThereAreNoInputParameters()
-        {
             Resolve("NoParameters")
                 .ShouldBe(Empty);
         }
 
-        public void ShouldResolveNothingWhenThereAreNoGenericParameters()
-        {
+    public void ShouldResolveNothingWhenThereAreNoGenericParameters()
+    {
             Resolve("NoGenericArguments", 0, "")
                 .ShouldBe(Empty);
         }
 
-        public void ShouldNotResolveWhenGenericTypeHasNoMatchingParameters()
-        {
+    public void ShouldNotResolveWhenGenericTypeHasNoMatchingParameters()
+    {
             Resolve("NoMatchingParameters", 0, "")
                 .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
         }
 
-        public void ShouldNotResolveWhenGenericTypeHasOneNullMatchingParameter()
-        {
+    public void ShouldNotResolveWhenGenericTypeHasOneNullMatchingParameter()
+    {
             Resolve("OneMatchingParameter", new object?[] {null})
                 .ShouldSatisfy(t => t.ShouldBeGenericTypeParameter("T"));
         }
         
-        public void ShouldResolveToConcreteTypeOfValueWhenGenericTypeHasOneNonNullMatchingParameter()
-        {
+    public void ShouldResolveToConcreteTypeOfValueWhenGenericTypeHasOneNonNullMatchingParameter()
+    {
             Resolve("OneMatchingParameter", 1.2m)
                 .ShouldBe(typeof(decimal));
 
@@ -43,8 +43,8 @@
                 .ShouldBe(typeof(string));
         }
 
-        public void ShouldResolveToFirstConcreteTypeWhenGenericTypeHasMultipleMatchingParametersOfInconsistentConcreteTypes()
-        {
+    public void ShouldResolveToFirstConcreteTypeWhenGenericTypeHasMultipleMatchingParametersOfInconsistentConcreteTypes()
+    {
             Resolve("MultipleMatchingParameter", 1.2m, "string", 0)
                 .ShouldBe(typeof(decimal));
             
@@ -52,8 +52,8 @@
                 .ShouldBe(typeof(decimal));
         }
 
-        public void ShouldResolveToConcreteTypeOfValuesWhenGenericTypeHasMultipleMatchingParametersOfTheExactSameConcreteType()
-        {
+    public void ShouldResolveToConcreteTypeOfValuesWhenGenericTypeHasMultipleMatchingParametersOfTheExactSameConcreteType()
+    {
             Resolve("MultipleMatchingParameter", 1.2m, 2.3m, 3.4m)
                 .ShouldBe(typeof(decimal));
 
@@ -61,14 +61,14 @@
                 .ShouldBe(typeof(string));
         }
 
-        public void ShouldNotResolveWhenGenericTypeHasMultipleMatchingParametersButAllAreNull()
-        {
+    public void ShouldNotResolveWhenGenericTypeHasMultipleMatchingParametersButAllAreNull()
+    {
             Resolve("MultipleMatchingParameter", null, null, null)
                 .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
         }
 
-        public void ShouldTreatNullsAsTypeCompatibleWithReferenceTypes()
-        {
+    public void ShouldTreatNullsAsTypeCompatibleWithReferenceTypes()
+    {
             Resolve("MultipleMatchingParameter", null, "string b", "string c")
                 .ShouldBe(typeof(string));
 
@@ -79,8 +79,8 @@
                 .ShouldBe(typeof(string));
         }
 
-        public void ShouldIgnoreNullAsTypeIncompatibleWithValueTypes()
-        {
+    public void ShouldIgnoreNullAsTypeIncompatibleWithValueTypes()
+    {
             Resolve("MultipleMatchingParameter", null, 2.3m, 3.4m)
                 .ShouldBe(typeof(decimal));
 
@@ -91,8 +91,8 @@
                 .ShouldBe(typeof(decimal));
         }
 
-        public void ShouldResolveGenericArgumentsIfAndOnlyIfTheyCanAllBeResolved()
-        {
+    public void ShouldResolveGenericArgumentsIfAndOnlyIfTheyCanAllBeResolved()
+    {
             Resolve("MultipleUnsatisfiableGenericArguments", null, 1.2m, "string", 0)
                 .ShouldSatisfy(
                     x => x.ShouldBeGenericTypeParameter("TNoMatch"),
@@ -170,20 +170,20 @@
                 .ShouldBe(typeof(bool), typeof(decimal));
         }
 
-        public void ShouldNotResolveWhenInputParameterCountIsLessThanDeclaredParameterCount()
-        {
+    public void ShouldNotResolveWhenInputParameterCountIsLessThanDeclaredParameterCount()
+    {
             Resolve("MultipleMatchingParameter", 1, 2)
                 .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
         }
 
-        public void ShouldAttemptReasonableResolutionByIgnoringExcessParametersWhenInputParameterCountIsGreaterThanDeclaredParameterCount()
-        {
+    public void ShouldAttemptReasonableResolutionByIgnoringExcessParametersWhenInputParameterCountIsGreaterThanDeclaredParameterCount()
+    {
             Resolve("MultipleMatchingParameter", 1, 2, 3, 4)
                 .ShouldBe(typeof(int));
         }
 
-        public void ShouldResolveGenericArgumentsWhenGenericConstraintsAreSatisfied()
-        {
+    public void ShouldResolveGenericArgumentsWhenGenericConstraintsAreSatisfied()
+    {
             Resolve("ConstrainedGeneric", 1)
                 .ShouldBe(typeof(int));
 
@@ -191,8 +191,8 @@
                 .ShouldBe(typeof(bool));
         }
 
-        public void ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
-        {
+    public void ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
+    {
             Resolve("CompoundGenericParameter", new KeyValuePair<int, string>(1, "A"))
                 .ShouldBe(typeof(int), typeof(string));
 
@@ -211,8 +211,8 @@
                 .ShouldBe(typeof(string));
         }
 
-        public void ShouldResolveGenericTypeParametersAppearingWithinArrays()
-        {
+    public void ShouldResolveGenericTypeParametersAppearingWithinArrays()
+    {
             Resolve("GenericArrayResolution", new[] {1}, "A")
                 .ShouldBe(typeof(int), typeof(string));
 
@@ -228,8 +228,8 @@
                     x => x.ShouldBeGenericTypeParameter("T2"));
         }
 
-        public void ShouldResolveNullableValueTypeParametersWithConcreteValueTypes()
-        {
+    public void ShouldResolveNullableValueTypeParametersWithConcreteValueTypes()
+    {
             Resolve("NullableValueTypeResolution", 1, 2, 3, 4)
                 .ShouldBe(typeof(int), typeof(int));
 
@@ -254,41 +254,40 @@
                     x => x.ShouldBeGenericTypeParameter("T2"));
         }
 
-        public void ShouldLeaveGenericTypeParameterWhenGenericTypeParametersCannotBeResolved()
-        {
+    public void ShouldLeaveGenericTypeParameterWhenGenericTypeParametersCannotBeResolved()
+    {
             var unresolved = Resolve("ConstrainedGeneric", "Incompatible").Single();
             unresolved.Name.ShouldBe("T");
             unresolved.IsGenericParameter.ShouldBe(true);
         }
 
-        static IEnumerable<Type> Resolve(string methodName, params object?[] parameters)
-        {
+    static IEnumerable<Type> Resolve(string methodName, params object?[] parameters)
+    {
             return typeof(Generic)
                 .GetInstanceMethod(methodName)
                 .TryResolveTypeArguments(parameters)
                 .GetGenericArguments();
         }
 
-        class Generic
-        {
-            public void NoParameters() { }
-            public void NoGenericArguments(int i, string s) { }
-            public void NoMatchingParameters<T>(int i, string s) { }
-            public void OneMatchingParameter<T>(T match) { }
-            public void MultipleMatchingParameter<T>(T firstMatch, T secondMatch, T thirdMatch) { }
-            public void MultipleUnsatisfiableGenericArguments<TNoMatch, TOneMatch, TMultipleMatch>(
-                TOneMatch oneMatch,
-                TMultipleMatch firstMultiMatch, TMultipleMatch secondMultiMatch, TMultipleMatch thirdMultiMatch) { }
-            public void MultipleSatisfiableGenericArguments<TOneMatch, TMultipleMatch>(
-                TOneMatch oneMatch,
-                TMultipleMatch firstMultiMatch, TMultipleMatch secondMultiMatch, TMultipleMatch thirdMultiMatch) { }
-            void ConstrainedGeneric<T>(T t) where T : struct { }
-            public void CompoundGenericParameter<TKey, TValue>(KeyValuePair<TKey, TValue> pair) { }
-            public void GenericFuncParameter<TResult>(int input, Func<int, TResult> transform, TResult expectedResult) { }
-            public void GenericArrayResolution<T1, T2>(T1[] array, T2 arbitrary) { }
-            public void NullableValueTypeResolution<T1, T2>(T1? a, T2? b, T2? c, int? i)
-                where T1: struct
-                where T2: struct { }
-        }
+    class Generic
+    {
+        public void NoParameters() { }
+        public void NoGenericArguments(int i, string s) { }
+        public void NoMatchingParameters<T>(int i, string s) { }
+        public void OneMatchingParameter<T>(T match) { }
+        public void MultipleMatchingParameter<T>(T firstMatch, T secondMatch, T thirdMatch) { }
+        public void MultipleUnsatisfiableGenericArguments<TNoMatch, TOneMatch, TMultipleMatch>(
+            TOneMatch oneMatch,
+            TMultipleMatch firstMultiMatch, TMultipleMatch secondMultiMatch, TMultipleMatch thirdMultiMatch) { }
+        public void MultipleSatisfiableGenericArguments<TOneMatch, TMultipleMatch>(
+            TOneMatch oneMatch,
+            TMultipleMatch firstMultiMatch, TMultipleMatch secondMultiMatch, TMultipleMatch thirdMultiMatch) { }
+        void ConstrainedGeneric<T>(T t) where T : struct { }
+        public void CompoundGenericParameter<TKey, TValue>(KeyValuePair<TKey, TValue> pair) { }
+        public void GenericFuncParameter<TResult>(int input, Func<int, TResult> transform, TResult expectedResult) { }
+        public void GenericArrayResolution<T1, T2>(T1[] array, T2 arbitrary) { }
+        public void NullableValueTypeResolution<T1, T2>(T1? a, T2? b, T2? c, int? i)
+            where T1: struct
+            where T2: struct { }
     }
 }

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -1,19 +1,19 @@
-﻿namespace Fixie.Tests.Internal
-{
-    using Assertions;
-    using Fixie.Internal;
-    using Reports;
-    using static System.Text.Json.JsonSerializer;
+﻿namespace Fixie.Tests.Internal;
 
-    public class JsonSerializationTests : MessagingTests
+using Assertions;
+using Fixie.Internal;
+using Reports;
+using static System.Text.Json.JsonSerializer;
+
+public class JsonSerializationTests : MessagingTests
+{
+    public void ShouldSerializeDiscoverTestsMessage()
     {
-        public void ShouldSerializeDiscoverTestsMessage()
-        {
             Expect(new PipeMessage.DiscoverTests(), "{}");
         }
 
-        public void ShouldSerializeExecuteTestsMessage()
-        {
+    public void ShouldSerializeExecuteTestsMessage()
+    {
             // Unintended case allowed by the type system.
             Expect(new PipeMessage.ExecuteTests(),
                 "{\"Filter\":null}");
@@ -29,8 +29,8 @@
                 "{\"Filter\":[\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\",\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\"]}");
         }
 
-        public void ShouldSerializeTestDiscoveredMessage()
-        {
+    public void ShouldSerializeTestDiscoveredMessage()
+    {
             // Unintended case allowed by the type system.
             Expect(new PipeMessage.TestDiscovered(), "{\"Test\":null}");
 
@@ -38,8 +38,8 @@
                 "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
         }
 
-        public void ShouldSerializeTestStartedMessage()
-        {
+    public void ShouldSerializeTestStartedMessage()
+    {
             // Unintended case allowed by the type system.
             Expect(new PipeMessage.TestStarted(), "{\"Test\":null}");
 
@@ -47,8 +47,8 @@
                 "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
         }
 
-        public void ShouldSerializeTestSkippedMessage()
-        {
+    public void ShouldSerializeTestSkippedMessage()
+    {
             // Unintended case allowed by the type system.
             Expect(new PipeMessage.TestSkipped(),
                 "{\"Reason\":null,\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
@@ -64,8 +64,8 @@
                 "{\"Reason\":\"\\u26A0 Skipped!\",\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\r\\nLine 2\"}");
         }
 
-        public void ShouldSerializeTestPassedMessage()
-        {
+    public void ShouldSerializeTestPassedMessage()
+    {
             // Unintended case allowed by the type system.
             Expect(new PipeMessage.TestPassed(),
                 "{\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
@@ -80,8 +80,8 @@
                 "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\rLine 2\"}");
         }
 
-        public void ShouldSerializeTestFailedMessage()
-        {
+    public void ShouldSerializeTestFailedMessage()
+    {
             // Unintended case allowed by the type system.
             Expect(new PipeMessage.TestFailed(),
                 "{\"Reason\":null,\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
@@ -104,8 +104,8 @@
                 "{\"Reason\":{\"Type\":\"Fixie.Tests.Assertions.AssertException\",\"Message\":\"Expected: System.String\\nActual:   System.Int32\",\"StackTrace\":\"" + at + "\"},\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\nLine 2\"}");
         }
 
-        public void ShouldSerializeExceptionMessage()
-        {
+    public void ShouldSerializeExceptionMessage()
+    {
             // Unintended case allowed by the type system.
             Expect(new PipeMessage.Exception(),
                 "{\"Type\":null,\"Message\":null,\"StackTrace\":null}");
@@ -121,15 +121,14 @@
                 "{\"Type\":\"Fixie.Tests.Assertions.AssertException\",\"Message\":\"Expected: System.String\\nActual:   System.Int32\",\"StackTrace\":\"" + at + "\"}");
         }
 
-        public void ShouldSerializeEndOfPipeMessage()
-        {
+    public void ShouldSerializeEndOfPipeMessage()
+    {
             Expect(new PipeMessage.EndOfPipe(), "{}");
         }
 
-        static void Expect<TMessage>(TMessage message, string expectedJson)
-        {
+    static void Expect<TMessage>(TMessage message, string expectedJson)
+    {
             Serialize(Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
             Serialize(message).ShouldBe(expectedJson);
         }
-    }
 }

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -9,126 +9,126 @@ public class JsonSerializationTests : MessagingTests
 {
     public void ShouldSerializeDiscoverTestsMessage()
     {
-            Expect(new PipeMessage.DiscoverTests(), "{}");
-        }
+        Expect(new PipeMessage.DiscoverTests(), "{}");
+    }
 
     public void ShouldSerializeExecuteTestsMessage()
     {
-            // Unintended case allowed by the type system.
-            Expect(new PipeMessage.ExecuteTests(),
-                "{\"Filter\":null}");
+        // Unintended case allowed by the type system.
+        Expect(new PipeMessage.ExecuteTests(),
+            "{\"Filter\":null}");
 
-            Expect(new PipeMessage.ExecuteTests { Filter = new string[] { } },
-                "{\"Filter\":[]}");
+        Expect(new PipeMessage.ExecuteTests { Filter = new string[] { } },
+            "{\"Filter\":[]}");
 
-            Expect(new PipeMessage.ExecuteTests { Filter = new[]
-                {
-                    TestClass + ".Pass",
-                    GenericTestClass + ".ShouldBeString"
-                } },
-                "{\"Filter\":[\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\",\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\"]}");
-        }
+        Expect(new PipeMessage.ExecuteTests { Filter = new[]
+            {
+                TestClass + ".Pass",
+                GenericTestClass + ".ShouldBeString"
+            } },
+            "{\"Filter\":[\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\",\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\"]}");
+    }
 
     public void ShouldSerializeTestDiscoveredMessage()
     {
-            // Unintended case allowed by the type system.
-            Expect(new PipeMessage.TestDiscovered(), "{\"Test\":null}");
+        // Unintended case allowed by the type system.
+        Expect(new PipeMessage.TestDiscovered(), "{\"Test\":null}");
 
-            Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass" },
-                "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
-        }
+        Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass" },
+            "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
+    }
 
     public void ShouldSerializeTestStartedMessage()
     {
-            // Unintended case allowed by the type system.
-            Expect(new PipeMessage.TestStarted(), "{\"Test\":null}");
+        // Unintended case allowed by the type system.
+        Expect(new PipeMessage.TestStarted(), "{\"Test\":null}");
 
-            Expect(new PipeMessage.TestStarted { Test = TestClass + ".Pass" },
-                "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
-        }
+        Expect(new PipeMessage.TestStarted { Test = TestClass + ".Pass" },
+            "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
+    }
 
     public void ShouldSerializeTestSkippedMessage()
     {
-            // Unintended case allowed by the type system.
-            Expect(new PipeMessage.TestSkipped(),
-                "{\"Reason\":null,\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
+        // Unintended case allowed by the type system.
+        Expect(new PipeMessage.TestSkipped(),
+            "{\"Reason\":null,\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
 
-            Expect(new PipeMessage.TestSkipped
-                {
-                    Reason = "⚠ Skipped!",
-                    Test = GenericTestClass + ".ShouldBeString",
-                    TestCase = GenericTestClass + ".ShouldBeString<System.Int32>(123)",
-                    DurationInMilliseconds = 123.456d,
-                    Output = "Line 1\r\nLine 2"
-                },
-                "{\"Reason\":\"\\u26A0 Skipped!\",\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\r\\nLine 2\"}");
-        }
+        Expect(new PipeMessage.TestSkipped
+            {
+                Reason = "⚠ Skipped!",
+                Test = GenericTestClass + ".ShouldBeString",
+                TestCase = GenericTestClass + ".ShouldBeString<System.Int32>(123)",
+                DurationInMilliseconds = 123.456d,
+                Output = "Line 1\r\nLine 2"
+            },
+            "{\"Reason\":\"\\u26A0 Skipped!\",\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\r\\nLine 2\"}");
+    }
 
     public void ShouldSerializeTestPassedMessage()
     {
-            // Unintended case allowed by the type system.
-            Expect(new PipeMessage.TestPassed(),
-                "{\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
+        // Unintended case allowed by the type system.
+        Expect(new PipeMessage.TestPassed(),
+            "{\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
 
-            Expect(new PipeMessage.TestPassed
-                {
-                    Test = GenericTestClass + ".ShouldBeString",
-                    TestCase = GenericTestClass + ".ShouldBeString<System.Int32>(123)",
-                    DurationInMilliseconds = 123.456d,
-                    Output = "Line 1\rLine 2"
-                },
-                "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\rLine 2\"}");
-        }
+        Expect(new PipeMessage.TestPassed
+            {
+                Test = GenericTestClass + ".ShouldBeString",
+                TestCase = GenericTestClass + ".ShouldBeString<System.Int32>(123)",
+                DurationInMilliseconds = 123.456d,
+                Output = "Line 1\rLine 2"
+            },
+            "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\rLine 2\"}");
+    }
 
     public void ShouldSerializeTestFailedMessage()
     {
-            // Unintended case allowed by the type system.
-            Expect(new PipeMessage.TestFailed(),
-                "{\"Reason\":null,\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
+        // Unintended case allowed by the type system.
+        Expect(new PipeMessage.TestFailed(),
+            "{\"Reason\":null,\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
 
-            var at = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)").Replace("\\", "\\\\");
+        var at = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)").Replace("\\", "\\\\");
 
-            Expect(new PipeMessage.TestFailed
-                {
-                    Reason = new PipeMessage.Exception
-                    {
-                        Type = "Fixie.Tests.Assertions.AssertException",
-                        Message = "Expected: System.String\nActual:   System.Int32",
-                        StackTrace = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
-                    },
-                    Test = GenericTestClass + ".ShouldBeString",
-                    TestCase = GenericTestClass + ".ShouldBeString<System.Int32>(123)",
-                    DurationInMilliseconds = 123.456d,
-                    Output = "Line 1\nLine 2"
-                },
-                "{\"Reason\":{\"Type\":\"Fixie.Tests.Assertions.AssertException\",\"Message\":\"Expected: System.String\\nActual:   System.Int32\",\"StackTrace\":\"" + at + "\"},\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\nLine 2\"}");
-        }
-
-    public void ShouldSerializeExceptionMessage()
-    {
-            // Unintended case allowed by the type system.
-            Expect(new PipeMessage.Exception(),
-                "{\"Type\":null,\"Message\":null,\"StackTrace\":null}");
-
-            var at = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)").Replace("\\", "\\\\");
-
-            Expect(new PipeMessage.Exception
+        Expect(new PipeMessage.TestFailed
+            {
+                Reason = new PipeMessage.Exception
                 {
                     Type = "Fixie.Tests.Assertions.AssertException",
                     Message = "Expected: System.String\nActual:   System.Int32",
                     StackTrace = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
                 },
-                "{\"Type\":\"Fixie.Tests.Assertions.AssertException\",\"Message\":\"Expected: System.String\\nActual:   System.Int32\",\"StackTrace\":\"" + at + "\"}");
-        }
+                Test = GenericTestClass + ".ShouldBeString",
+                TestCase = GenericTestClass + ".ShouldBeString<System.Int32>(123)",
+                DurationInMilliseconds = 123.456d,
+                Output = "Line 1\nLine 2"
+            },
+            "{\"Reason\":{\"Type\":\"Fixie.Tests.Assertions.AssertException\",\"Message\":\"Expected: System.String\\nActual:   System.Int32\",\"StackTrace\":\"" + at + "\"},\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\",\"TestCase\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\\u003CSystem.Int32\\u003E(123)\",\"DurationInMilliseconds\":123.456,\"Output\":\"Line 1\\nLine 2\"}");
+    }
+
+    public void ShouldSerializeExceptionMessage()
+    {
+        // Unintended case allowed by the type system.
+        Expect(new PipeMessage.Exception(),
+            "{\"Type\":null,\"Message\":null,\"StackTrace\":null}");
+
+        var at = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)").Replace("\\", "\\\\");
+
+        Expect(new PipeMessage.Exception
+            {
+                Type = "Fixie.Tests.Assertions.AssertException",
+                Message = "Expected: System.String\nActual:   System.Int32",
+                StackTrace = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
+            },
+            "{\"Type\":\"Fixie.Tests.Assertions.AssertException\",\"Message\":\"Expected: System.String\\nActual:   System.Int32\",\"StackTrace\":\"" + at + "\"}");
+    }
 
     public void ShouldSerializeEndOfPipeMessage()
     {
-            Expect(new PipeMessage.EndOfPipe(), "{}");
-        }
+        Expect(new PipeMessage.EndOfPipe(), "{}");
+    }
 
     static void Expect<TMessage>(TMessage message, string expectedJson)
     {
-            Serialize(Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
-            Serialize(message).ShouldBe(expectedJson);
-        }
+        Serialize(Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
+        Serialize(message).ShouldBe(expectedJson);
+    }
 }

--- a/src/Fixie.Tests/Internal/MaybeTests.cs
+++ b/src/Fixie.Tests/Internal/MaybeTests.cs
@@ -8,28 +8,28 @@ public class MaybeTests
 {
     public void ShouldProvideTryPatternShorthandForFuncWithZeroParameters()
     {
-            Func<string?> returnNull = () => null;
-            Func<string?> returnNotNull = () => "";
+        Func<string?> returnNull = () => null;
+        Func<string?> returnNotNull = () => "";
 
-            var hasValue = Try(returnNull, out var value);
-            hasValue.ShouldBe(false);
-            value.ShouldBe(null);
+        var hasValue = Try(returnNull, out var value);
+        hasValue.ShouldBe(false);
+        value.ShouldBe(null);
 
-            hasValue = Try(returnNotNull, out value);
-            hasValue.ShouldBe(true);
-            value.ShouldBe("");
-        }
+        hasValue = Try(returnNotNull, out value);
+        hasValue.ShouldBe(true);
+        value.ShouldBe("");
+    }
 
     public void ShouldProvideTryPatternShorthandForFuncWithOneParameter()
     {
-            Func<string?, string?> returnThis = argument => argument;
+        Func<string?, string?> returnThis = argument => argument;
 
-            var hasValue = Try(returnThis, null, out var value);
-            hasValue.ShouldBe(false);
-            value.ShouldBe(null);
+        var hasValue = Try(returnThis, null, out var value);
+        hasValue.ShouldBe(false);
+        value.ShouldBe(null);
 
-            hasValue = Try(returnThis, "Value", out value);
-            hasValue.ShouldBe(true);
-            value.ShouldBe("Value");
-        }
+        hasValue = Try(returnThis, "Value", out value);
+        hasValue.ShouldBe(true);
+        value.ShouldBe("Value");
+    }
 }

--- a/src/Fixie.Tests/Internal/MaybeTests.cs
+++ b/src/Fixie.Tests/Internal/MaybeTests.cs
@@ -1,13 +1,13 @@
-﻿namespace Fixie.Tests.Internal
-{
-    using System;
-    using Assertions;
-    using static Fixie.Internal.Maybe;
+﻿namespace Fixie.Tests.Internal;
 
-    public class MaybeTests
+using System;
+using Assertions;
+using static Fixie.Internal.Maybe;
+
+public class MaybeTests
+{
+    public void ShouldProvideTryPatternShorthandForFuncWithZeroParameters()
     {
-        public void ShouldProvideTryPatternShorthandForFuncWithZeroParameters()
-        {
             Func<string?> returnNull = () => null;
             Func<string?> returnNotNull = () => "";
 
@@ -20,8 +20,8 @@
             value.ShouldBe("");
         }
 
-        public void ShouldProvideTryPatternShorthandForFuncWithOneParameter()
-        {
+    public void ShouldProvideTryPatternShorthandForFuncWithOneParameter()
+    {
             Func<string?, string?> returnThis = argument => argument;
 
             var hasValue = Try(returnThis, null, out var value);
@@ -32,5 +32,4 @@
             hasValue.ShouldBe(true);
             value.ShouldBe("Value");
         }
-    }
 }

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -26,11 +26,11 @@ public class MethodDiscovererTests
 
         public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
         {
-                return publicMethods
-                    .Where(x => x.Name.Contains("Void"))
-                    .Where(x => x.Name.Contains("No"))
-                    .Where(x => !x.IsStatic);
-            }
+            return publicMethods
+                .Where(x => x.Name.Contains("Void"))
+                .Where(x => x.Name.Contains("No"))
+                .Where(x => !x.IsStatic);
+        }
     }
 
     class BuggyDiscovery : IDiscovery
@@ -40,88 +40,88 @@ public class MethodDiscovererTests
 
         public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
         {
-                return publicMethods.Where(x => throw new Exception("Unsafe method discovery predicate threw!"));
-            }
+            return publicMethods.Where(x => throw new Exception("Unsafe method discovery predicate threw!"));
+        }
     }
 
     public void ShouldDiscoverOnlyPublicInstanceMethodsByDefault()
     {
-            var discovery = new DefaultDiscovery();
+        var discovery = new DefaultDiscovery();
 
-            DiscoveredTestMethods<Sample>(discovery)
-                .ShouldBe(
-                    "PublicInstanceNoArgsVoid()",
-                    "PublicInstanceNoArgsWithReturn()",
-                    "PublicInstanceWithArgsVoid(x)",
-                    "PublicInstanceWithArgsWithReturn(x)");
+        DiscoveredTestMethods<Sample>(discovery)
+            .ShouldBe(
+                "PublicInstanceNoArgsVoid()",
+                "PublicInstanceNoArgsWithReturn()",
+                "PublicInstanceWithArgsVoid(x)",
+                "PublicInstanceWithArgsWithReturn(x)");
 
-            DiscoveredTestMethods<AsyncSample>(discovery)
-                .ShouldBe(
-                    "PublicInstanceNoArgsVoid()",
-                    "PublicInstanceNoArgsWithReturn()",
-                    "PublicInstanceWithArgsVoid(x)",
-                    "PublicInstanceWithArgsWithReturn(x)");
-        }
+        DiscoveredTestMethods<AsyncSample>(discovery)
+            .ShouldBe(
+                "PublicInstanceNoArgsVoid()",
+                "PublicInstanceNoArgsWithReturn()",
+                "PublicInstanceWithArgsVoid(x)",
+                "PublicInstanceWithArgsWithReturn(x)");
+    }
 
     public void ShouldSupportMaximalDiscoveryOfAllPublicMethods()
     {
-            var discovery = new MaximumDiscovery();
+        var discovery = new MaximumDiscovery();
 
-            DiscoveredTestMethods<Sample>(discovery)
-                .ShouldBe(
-                    "PublicInstanceNoArgsVoid()",
-                    "PublicInstanceNoArgsWithReturn()",
-                    "PublicInstanceWithArgsVoid(x)",
-                    "PublicInstanceWithArgsWithReturn(x)",
+        DiscoveredTestMethods<Sample>(discovery)
+            .ShouldBe(
+                "PublicInstanceNoArgsVoid()",
+                "PublicInstanceNoArgsWithReturn()",
+                "PublicInstanceWithArgsVoid(x)",
+                "PublicInstanceWithArgsWithReturn(x)",
 
-                    "PublicStaticNoArgsVoid()",
-                    "PublicStaticNoArgsWithReturn()",
-                    "PublicStaticWithArgsVoid(x)",
-                    "PublicStaticWithArgsWithReturn(x)");
+                "PublicStaticNoArgsVoid()",
+                "PublicStaticNoArgsWithReturn()",
+                "PublicStaticWithArgsVoid(x)",
+                "PublicStaticWithArgsWithReturn(x)");
 
-            DiscoveredTestMethods<AsyncSample>(discovery)
-                .ShouldBe(
-                    "PublicInstanceNoArgsVoid()",
-                    "PublicInstanceNoArgsWithReturn()",
-                    "PublicInstanceWithArgsVoid(x)",
-                    "PublicInstanceWithArgsWithReturn(x)",
+        DiscoveredTestMethods<AsyncSample>(discovery)
+            .ShouldBe(
+                "PublicInstanceNoArgsVoid()",
+                "PublicInstanceNoArgsWithReturn()",
+                "PublicInstanceWithArgsVoid(x)",
+                "PublicInstanceWithArgsWithReturn(x)",
 
-                    "PublicStaticNoArgsVoid()",
-                    "PublicStaticNoArgsWithReturn()",
-                    "PublicStaticWithArgsVoid(x)",
-                    "PublicStaticWithArgsWithReturn(x)");
-        }
+                "PublicStaticNoArgsVoid()",
+                "PublicStaticNoArgsWithReturn()",
+                "PublicStaticWithArgsVoid(x)",
+                "PublicStaticWithArgsWithReturn(x)");
+    }
 
     public void ShouldDiscoverMethodsSatisfyingAllSpecifiedConditions()
     {
-            var discovery = new NarrowDiscovery();
+        var discovery = new NarrowDiscovery();
 
-            DiscoveredTestMethods<Sample>(discovery)
-                .ShouldBe("PublicInstanceNoArgsVoid()");
-        }
+        DiscoveredTestMethods<Sample>(discovery)
+            .ShouldBe("PublicInstanceNoArgsVoid()");
+    }
 
     public void ShouldFailWithClearExplanationWhenDiscoveryThrows()
     {
-            var discovery = new BuggyDiscovery();
+        var discovery = new BuggyDiscovery();
 
-            Action attemptFaultyDiscovery = () => DiscoveredTestMethods<Sample>(discovery);
+        Action attemptFaultyDiscovery = () => DiscoveredTestMethods<Sample>(discovery);
 
-            var exception = attemptFaultyDiscovery.ShouldThrow<Exception>(
-                "Exception thrown during test method discovery. " +
-                "Check the inner exception for more details.");
+        var exception = attemptFaultyDiscovery.ShouldThrow<Exception>(
+            "Exception thrown during test method discovery. " +
+            "Check the inner exception for more details.");
 
-            exception.InnerException
-                .ShouldBe<Exception>()
-                .Message.ShouldBe("Unsafe method discovery predicate threw!");
-        }
+        exception.InnerException
+            .ShouldBe<Exception>()
+            .Message.ShouldBe("Unsafe method discovery predicate threw!");
+    }
 
     static IEnumerable<string> DiscoveredTestMethods<TTestClass>(IDiscovery discovery)
     {
-            return new MethodDiscoverer(discovery)
-                .TestMethods(typeof(TTestClass))
-                .Select(method => $"{method.Name}({string.Join(", ", method.GetParameters().Select(x => x.Name))})")
-                .OrderBy(name => name, StringComparer.Ordinal);
-        }
+        return new MethodDiscoverer(discovery)
+            .TestMethods(typeof(TTestClass))
+            .Select(method => $"{method.Name}({string.Join(", ", method.GetParameters().Select(x => x.Name))})")
+            .OrderBy(name => name, StringComparer.Ordinal);
+    }
 
     class SampleBase
     {
@@ -175,7 +175,7 @@ public class MethodDiscovererTests
 
         static Task<int> Zero()
         {
-                return Task.Run(() => 0);
-            }
+            return Task.Run(() => 0);
+        }
     }
 }

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -1,51 +1,51 @@
-﻿namespace Fixie.Tests.Internal
+﻿namespace Fixie.Tests.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Internal;
+
+public class MethodDiscovererTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Internal;
-
-    public class MethodDiscovererTests
+    class MaximumDiscovery : IDiscovery
     {
-        class MaximumDiscovery : IDiscovery
+        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
+            => throw new ShouldBeUnreachableException();
+
+        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => publicMethods;
+    }
+
+    class NarrowDiscovery : IDiscovery
+    {
+        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
+            => throw new ShouldBeUnreachableException();
+
+        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
         {
-            public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-                => throw new ShouldBeUnreachableException();
-
-            public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-                => publicMethods;
-        }
-
-        class NarrowDiscovery : IDiscovery
-        {
-            public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-                => throw new ShouldBeUnreachableException();
-
-            public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-            {
                 return publicMethods
                     .Where(x => x.Name.Contains("Void"))
                     .Where(x => x.Name.Contains("No"))
                     .Where(x => !x.IsStatic);
             }
-        }
+    }
 
-        class BuggyDiscovery : IDiscovery
+    class BuggyDiscovery : IDiscovery
+    {
+        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
+            => throw new ShouldBeUnreachableException();
+
+        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
         {
-            public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-                => throw new ShouldBeUnreachableException();
-
-            public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-            {
                 return publicMethods.Where(x => throw new Exception("Unsafe method discovery predicate threw!"));
             }
-        }
+    }
 
-        public void ShouldDiscoverOnlyPublicInstanceMethodsByDefault()
-        {
+    public void ShouldDiscoverOnlyPublicInstanceMethodsByDefault()
+    {
             var discovery = new DefaultDiscovery();
 
             DiscoveredTestMethods<Sample>(discovery)
@@ -63,8 +63,8 @@
                     "PublicInstanceWithArgsWithReturn(x)");
         }
 
-        public void ShouldSupportMaximalDiscoveryOfAllPublicMethods()
-        {
+    public void ShouldSupportMaximalDiscoveryOfAllPublicMethods()
+    {
             var discovery = new MaximumDiscovery();
 
             DiscoveredTestMethods<Sample>(discovery)
@@ -92,16 +92,16 @@
                     "PublicStaticWithArgsWithReturn(x)");
         }
 
-        public void ShouldDiscoverMethodsSatisfyingAllSpecifiedConditions()
-        {
+    public void ShouldDiscoverMethodsSatisfyingAllSpecifiedConditions()
+    {
             var discovery = new NarrowDiscovery();
 
             DiscoveredTestMethods<Sample>(discovery)
                 .ShouldBe("PublicInstanceNoArgsVoid()");
         }
 
-        public void ShouldFailWithClearExplanationWhenDiscoveryThrows()
-        {
+    public void ShouldFailWithClearExplanationWhenDiscoveryThrows()
+    {
             var discovery = new BuggyDiscovery();
 
             Action attemptFaultyDiscovery = () => DiscoveredTestMethods<Sample>(discovery);
@@ -115,68 +115,67 @@
                 .Message.ShouldBe("Unsafe method discovery predicate threw!");
         }
 
-        static IEnumerable<string> DiscoveredTestMethods<TTestClass>(IDiscovery discovery)
-        {
+    static IEnumerable<string> DiscoveredTestMethods<TTestClass>(IDiscovery discovery)
+    {
             return new MethodDiscoverer(discovery)
                 .TestMethods(typeof(TTestClass))
                 .Select(method => $"{method.Name}({string.Join(", ", method.GetParameters().Select(x => x.Name))})")
                 .OrderBy(name => name, StringComparer.Ordinal);
         }
 
-        class SampleBase
+    class SampleBase
+    {
+        public virtual int PublicInstanceNoArgsWithReturn() { return 0; }
+    }
+
+    class Sample : SampleBase
+    {
+        public static int PublicStaticWithArgsWithReturn(int x) { return 0; }
+        public static int PublicStaticNoArgsWithReturn() { return 0; }
+        public static void PublicStaticWithArgsVoid(int x) { }
+        public static void PublicStaticNoArgsVoid() { }
+
+        public int PublicInstanceWithArgsWithReturn(int x) { return 0; }
+        public override int PublicInstanceNoArgsWithReturn() { return 0; }
+        public void PublicInstanceWithArgsVoid(int x) { }
+        public void PublicInstanceNoArgsVoid() { }
+
+        private static int PrivateStaticWithArgsWithReturn(int x) { return 0; }
+        private static int PrivateStaticNoArgsWithReturn() { return 0; }
+        private static void PrivateStaticWithArgsVoid(int x) { }
+        private static void PrivateStaticNoArgsVoid() { }
+
+        private int PrivateInstanceWithArgsWithReturn(int x) { return 0; }
+        private int PrivateInstanceNoArgsWithReturn() { return 0; }
+        private void PrivateInstanceWithArgsVoid(int x) { }
+        private void PrivateInstanceNoArgsVoid() { }
+    }
+
+    class AsyncSample
+    {
+        public static async Task<int> PublicStaticWithArgsWithReturn(int x) { return await Zero(); }
+        public static async Task<int> PublicStaticNoArgsWithReturn() { return await Zero(); }
+        public static async void PublicStaticWithArgsVoid(int x) { await Zero(); }
+        public static async void PublicStaticNoArgsVoid() { await Zero(); }
+
+        public async Task<int> PublicInstanceWithArgsWithReturn(int x) { return await Zero(); }
+        public async Task<int> PublicInstanceNoArgsWithReturn() { return await Zero(); }
+        public async void PublicInstanceWithArgsVoid(int x) { await Zero(); }
+        public async void PublicInstanceNoArgsVoid() { await Zero(); }
+
+        private static async Task<int> PrivateStaticWithArgsWithReturn(int x) { return await Zero(); }
+        private static async Task<int> PrivateStaticNoArgsWithReturn() { return await Zero(); }
+        private static async void PrivateStaticWithArgsVoid(int x) { await Zero(); }
+        private static async void PrivateStaticNoArgsVoid() { await Zero(); }
+
+        private async Task<int> PrivateInstanceWithArgsWithReturn(int x) { return await Zero(); }
+        private async Task<int> PrivateInstanceNoArgsWithReturn() { return await Zero(); }
+        private async void PrivateInstanceWithArgsVoid(int x) { await Zero(); }
+        private async void PrivateInstanceNoArgsVoid() { await Zero(); }
+
+        static Task<int> Zero()
         {
-            public virtual int PublicInstanceNoArgsWithReturn() { return 0; }
-        }
-
-        class Sample : SampleBase
-        {
-            public static int PublicStaticWithArgsWithReturn(int x) { return 0; }
-            public static int PublicStaticNoArgsWithReturn() { return 0; }
-            public static void PublicStaticWithArgsVoid(int x) { }
-            public static void PublicStaticNoArgsVoid() { }
-
-            public int PublicInstanceWithArgsWithReturn(int x) { return 0; }
-            public override int PublicInstanceNoArgsWithReturn() { return 0; }
-            public void PublicInstanceWithArgsVoid(int x) { }
-            public void PublicInstanceNoArgsVoid() { }
-
-            private static int PrivateStaticWithArgsWithReturn(int x) { return 0; }
-            private static int PrivateStaticNoArgsWithReturn() { return 0; }
-            private static void PrivateStaticWithArgsVoid(int x) { }
-            private static void PrivateStaticNoArgsVoid() { }
-
-            private int PrivateInstanceWithArgsWithReturn(int x) { return 0; }
-            private int PrivateInstanceNoArgsWithReturn() { return 0; }
-            private void PrivateInstanceWithArgsVoid(int x) { }
-            private void PrivateInstanceNoArgsVoid() { }
-        }
-
-        class AsyncSample
-        {
-            public static async Task<int> PublicStaticWithArgsWithReturn(int x) { return await Zero(); }
-            public static async Task<int> PublicStaticNoArgsWithReturn() { return await Zero(); }
-            public static async void PublicStaticWithArgsVoid(int x) { await Zero(); }
-            public static async void PublicStaticNoArgsVoid() { await Zero(); }
-
-            public async Task<int> PublicInstanceWithArgsWithReturn(int x) { return await Zero(); }
-            public async Task<int> PublicInstanceNoArgsWithReturn() { return await Zero(); }
-            public async void PublicInstanceWithArgsVoid(int x) { await Zero(); }
-            public async void PublicInstanceNoArgsVoid() { await Zero(); }
-
-            private static async Task<int> PrivateStaticWithArgsWithReturn(int x) { return await Zero(); }
-            private static async Task<int> PrivateStaticNoArgsWithReturn() { return await Zero(); }
-            private static async void PrivateStaticWithArgsVoid(int x) { await Zero(); }
-            private static async void PrivateStaticNoArgsVoid() { await Zero(); }
-
-            private async Task<int> PrivateInstanceWithArgsWithReturn(int x) { return await Zero(); }
-            private async Task<int> PrivateInstanceNoArgsWithReturn() { return await Zero(); }
-            private async void PrivateInstanceWithArgsVoid(int x) { await Zero(); }
-            private async void PrivateInstanceNoArgsVoid() { await Zero(); }
-
-            static Task<int> Zero()
-            {
                 return Task.Run(() => 0);
             }
-        }
     }
 }

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -14,65 +14,65 @@ public class RunnerTests
 
     public async Task ShouldPerformDiscoveryPhase()
     {
-            var report = new StubReport();
+        var report = new StubReport();
 
-            var candidateTypes = new[]
-            {
-                typeof(SampleIrrelevantClass), typeof(PassTestClass), typeof(int),
-                typeof(PassFailTestClass), typeof(SkipTestClass)
-            };
-            var discovery = new SelfTestDiscovery();
-            
-            var environment = new TestEnvironment(GetType().Assembly, Console.Out, Directory.GetCurrentDirectory());
-            var runner = new Runner(environment, report);
+        var candidateTypes = new[]
+        {
+            typeof(SampleIrrelevantClass), typeof(PassTestClass), typeof(int),
+            typeof(PassFailTestClass), typeof(SkipTestClass)
+        };
+        var discovery = new SelfTestDiscovery();
+        
+        var environment = new TestEnvironment(GetType().Assembly, Console.Out, Directory.GetCurrentDirectory());
+        var runner = new Runner(environment, report);
 
-            await runner.Discover(candidateTypes, discovery);
+        await runner.Discover(candidateTypes, discovery);
 
-            report.Entries.ShouldBe(
-                Self + "+PassTestClass.PassA discovered",
-                Self + "+PassTestClass.PassB discovered",
-                Self + "+PassFailTestClass.Fail discovered",
-                Self + "+PassFailTestClass.Pass discovered",
-                Self + "+SkipTestClass.SkipA discovered",
-                Self + "+SkipTestClass.SkipB discovered");
-        }
+        report.Entries.ShouldBe(
+            Self + "+PassTestClass.PassA discovered",
+            Self + "+PassTestClass.PassB discovered",
+            Self + "+PassFailTestClass.Fail discovered",
+            Self + "+PassFailTestClass.Pass discovered",
+            Self + "+SkipTestClass.SkipA discovered",
+            Self + "+SkipTestClass.SkipB discovered");
+    }
 
     public async Task ShouldPerformExecutionPhase()
     {
-            var report = new StubReport();
+        var report = new StubReport();
 
-            var candidateTypes = new[]
-            {
-                typeof(SampleIrrelevantClass), typeof(PassTestClass), typeof(int),
-                typeof(PassFailTestClass), typeof(SkipTestClass)
-            };
-            var discovery = new SelfTestDiscovery();
-            var execution = new CreateInstancePerCase();
+        var candidateTypes = new[]
+        {
+            typeof(SampleIrrelevantClass), typeof(PassTestClass), typeof(int),
+            typeof(PassFailTestClass), typeof(SkipTestClass)
+        };
+        var discovery = new SelfTestDiscovery();
+        var execution = new CreateInstancePerCase();
 
-            var environment = new TestEnvironment(GetType().Assembly, Console.Out, Directory.GetCurrentDirectory());
-            var runner = new Runner(environment, report);
-            var configuration = new TestConfiguration();
-            configuration.Conventions.Add(discovery, execution);
+        var environment = new TestEnvironment(GetType().Assembly, Console.Out, Directory.GetCurrentDirectory());
+        var runner = new Runner(environment, report);
+        var configuration = new TestConfiguration();
+        configuration.Conventions.Add(discovery, execution);
 
-            await runner.Run(candidateTypes, configuration, new HashSet<string>());
+        await runner.Run(candidateTypes, configuration, new HashSet<string>());
 
-            report.Entries.ShouldBe(
-                Self + "+PassTestClass.PassA passed",
-                Self + "+PassTestClass.PassB passed",
-                Self + "+PassFailTestClass.Fail failed: 'Fail' failed!",
-                Self + "+PassFailTestClass.Pass passed",
-                Self + "+SkipTestClass.SkipA skipped: This test did not run.",
-                Self + "+SkipTestClass.SkipB skipped: This test did not run.");
-        }
+        report.Entries.ShouldBe(
+            Self + "+PassTestClass.PassA passed",
+            Self + "+PassTestClass.PassB passed",
+            Self + "+PassFailTestClass.Fail failed: 'Fail' failed!",
+            Self + "+PassFailTestClass.Pass passed",
+            Self + "+SkipTestClass.SkipA skipped: This test did not run.",
+            Self + "+SkipTestClass.SkipB skipped: This test did not run.");
+    }
 
     class CreateInstancePerCase : IExecution
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var test in testSuite.Tests)
-                    if (!test.Name.Contains("Skip"))
-                        await test.Run();
-            }
+            foreach (var test in testSuite.Tests)
+                if (!test.Name.Contains("Skip"))
+                    await test.Run();
+        }
     }
 
     class SampleIrrelevantClass

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -1,19 +1,19 @@
-namespace Fixie.Tests.Internal
+namespace Fixie.Tests.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Internal;
+using static Utility;
+
+public class RunnerTests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Internal;
-    using static Utility;
+    static readonly string Self = FullName<RunnerTests>();
 
-    public class RunnerTests
+    public async Task ShouldPerformDiscoveryPhase()
     {
-        static readonly string Self = FullName<RunnerTests>();
-
-        public async Task ShouldPerformDiscoveryPhase()
-        {
             var report = new StubReport();
 
             var candidateTypes = new[]
@@ -37,8 +37,8 @@ namespace Fixie.Tests.Internal
                 Self + "+SkipTestClass.SkipB discovered");
         }
 
-        public async Task ShouldPerformExecutionPhase()
-        {
+    public async Task ShouldPerformExecutionPhase()
+    {
             var report = new StubReport();
 
             var candidateTypes = new[]
@@ -65,38 +65,37 @@ namespace Fixie.Tests.Internal
                 Self + "+SkipTestClass.SkipB skipped: This test did not run.");
         }
 
-        class CreateInstancePerCase : IExecution
+    class CreateInstancePerCase : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var test in testSuite.Tests)
                     if (!test.Name.Contains("Skip"))
                         await test.Run();
             }
-        }
+    }
 
-        class SampleIrrelevantClass
-        {
-            public void PassA() { }
-            public void PassB() { }
-        }
+    class SampleIrrelevantClass
+    {
+        public void PassA() { }
+        public void PassB() { }
+    }
 
-        class PassTestClass
-        {
-            public void PassA() { }
-            public void PassB() { }
-        }
+    class PassTestClass
+    {
+        public void PassA() { }
+        public void PassB() { }
+    }
 
-        class PassFailTestClass
-        {
-            public void Fail() { throw new FailureException(); }
-            public void Pass() { }
-        }
+    class PassFailTestClass
+    {
+        public void Fail() { throw new FailureException(); }
+        public void Pass() { }
+    }
 
-        class SkipTestClass
-        {
-            public void SkipA() { throw new ShouldBeUnreachableException(); }
-            public void SkipB() { throw new ShouldBeUnreachableException(); }
-        }
+    class SkipTestClass
+    {
+        public void SkipA() { throw new ShouldBeUnreachableException(); }
+        public void SkipB() { throw new ShouldBeUnreachableException(); }
     }
 }

--- a/src/Fixie.Tests/Internal/TestPatternTests.cs
+++ b/src/Fixie.Tests/Internal/TestPatternTests.cs
@@ -7,197 +7,197 @@ public class TestPatternTests
 {
     public void CanDetermineWhetherTestsMatchTheGivenPattern()
     {
-            var childClassChildMethod = "Fixie.Tests.TestTests+ChildClass.MethodDefinedWithinChildClass";
-            var parentClassParentMethod = "Fixie.Tests.TestTests+ParentClass.MethodDefinedWithinParentClass";
-            var childClassParentMethod = "Fixie.Tests.TestTests+ChildClass.MethodDefinedWithinParentClass";
+        var childClassChildMethod = "Fixie.Tests.TestTests+ChildClass.MethodDefinedWithinChildClass";
+        var parentClassParentMethod = "Fixie.Tests.TestTests+ParentClass.MethodDefinedWithinParentClass";
+        var childClassParentMethod = "Fixie.Tests.TestTests+ChildClass.MethodDefinedWithinParentClass";
 
-            foreach (var test in new[] {childClassChildMethod, parentClassParentMethod, childClassParentMethod})
-            {
-                // The empty pattern matches everything, as it is essentially an empty substring match.
-                new TestPattern("").Matches(test).ShouldBe(true);
-                
-                // Clear mismatch.
-                new TestPattern("ZZZ").Matches(test).ShouldBe(false);
-                
-                // Perfect match on full name.
-                new TestPattern(test).Matches(test).ShouldBe(true);
-                
-                // Substring match on full name: implicit leading *, explicit closing *.
-                new TestPattern("Fixie.Tests.TestTests+").Matches(test).ShouldBe(false);
-                new TestPattern("Fixie.Tests.TestTests+*").Matches(test).ShouldBe(true);
-                new TestPattern("Class.MethodDefinedWithin").Matches(test).ShouldBe(false);
-                new TestPattern("Class.MethodDefinedWithin*").Matches(test).ShouldBe(true);
-
-                // Explicit wildcard matches everything.
-                new TestPattern("*").Matches(test).ShouldBe(true);
-                new TestPattern("F*Tests+*").Matches(test).ShouldBe(true);
-                new TestPattern("Cla*hodDef*thin*").Matches(test).ShouldBe(true);
-
-                // Implicit [a-z]* after upper-case characters that are not followed by lower-case characters.
-                new TestPattern("T+*").Matches(test).ShouldBe(true);
-                new TestPattern("F.T.TT+*").Matches(test).ShouldBe(true);
-                new TestPattern("C.MDW").Matches(test).ShouldBe(false);
-                new TestPattern("C.MDW*").Matches(test).ShouldBe(true);
-                new TestPattern("C.MDW*C").Matches(test).ShouldBe(true);
-
-                // Explicit lower-case can prevent the implied wildcard.
-                new TestPattern("Te+*").Matches(test).ShouldBe(false);
-                new TestPattern("Te*+*").Matches(test).ShouldBe(true);
-                new TestPattern("Fi.T.TT+*").Matches(test).ShouldBe(false);
-                new TestPattern("Fi*.T.TT+*").Matches(test).ShouldBe(true);
-                new TestPattern("Cl.MDW*").Matches(test).ShouldBe(false);
-                new TestPattern("Cl*.MDW*").Matches(test).ShouldBe(true);
-                new TestPattern("C.MDW*Cl").Matches(test).ShouldBe(false);
-                new TestPattern("C.MDW*Cl*").Matches(test).ShouldBe(true);
-            }
-
-            var testPattern = new TestPattern("C");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-            testPattern =new TestPattern("T");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("T*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+        foreach (var test in new[] {childClassChildMethod, parentClassParentMethod, childClassParentMethod})
+        {
+            // The empty pattern matches everything, as it is essentially an empty substring match.
+            new TestPattern("").Matches(test).ShouldBe(true);
             
-            testPattern = new TestPattern("CC");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("CC*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+            // Clear mismatch.
+            new TestPattern("ZZZ").Matches(test).ShouldBe(false);
+            
+            // Perfect match on full name.
+            new TestPattern(test).Matches(test).ShouldBe(true);
+            
+            // Substring match on full name: implicit leading *, explicit closing *.
+            new TestPattern("Fixie.Tests.TestTests+").Matches(test).ShouldBe(false);
+            new TestPattern("Fixie.Tests.TestTests+*").Matches(test).ShouldBe(true);
+            new TestPattern("Class.MethodDefinedWithin").Matches(test).ShouldBe(false);
+            new TestPattern("Class.MethodDefinedWithin*").Matches(test).ShouldBe(true);
 
-            testPattern = new TestPattern("CC.MDW");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("CC.MDW*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+            // Explicit wildcard matches everything.
+            new TestPattern("*").Matches(test).ShouldBe(true);
+            new TestPattern("F*Tests+*").Matches(test).ShouldBe(true);
+            new TestPattern("Cla*hodDef*thin*").Matches(test).ShouldBe(true);
 
-            testPattern = new TestPattern("C.MDW");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("C.MDW*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+            // Implicit [a-z]* after upper-case characters that are not followed by lower-case characters.
+            new TestPattern("T+*").Matches(test).ShouldBe(true);
+            new TestPattern("F.T.TT+*").Matches(test).ShouldBe(true);
+            new TestPattern("C.MDW").Matches(test).ShouldBe(false);
+            new TestPattern("C.MDW*").Matches(test).ShouldBe(true);
+            new TestPattern("C.MDW*C").Matches(test).ShouldBe(true);
 
-            testPattern = new TestPattern("C.MDWC");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("C.MDWC*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("C.MDWCC");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("C.MDWCCl");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("C.MDWCClass");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-
-            testPattern = new TestPattern("C.MDWP");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("C.MDWP*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-            testPattern = new TestPattern("C.MDWPC");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-            testPattern = new TestPattern("C.MDWPCl");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("C.MDWPClass");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("ChildClass");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("ChildClass*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-            testPattern = new TestPattern("ParentClass");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("ChildClass.MethodDefinedWithin");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("ChildClass.MethodDefinedWithin*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-            testPattern = new TestPattern("ChildClass.MethodDefinedWithinC");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("ChildClass.MethodDefinedWithinCC");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-
-            testPattern = new TestPattern("ChildClass.MethodDefinedWithinP");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("ChildClass.MethodDefinedWithinP*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-            testPattern = new TestPattern("ChildClass.MethodDefinedWithinPC");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("ChildClass.Met*odDefinedWithin*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(true);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("ChildClass.Met*odDefinedWithinP*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("*M*e*t*h*o*d*D*e*f*i*n*e*d*W*i*t*h*i*n*P*");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
-
-            testPattern = new TestPattern("C*.M*D*W*P");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(false);
-            testPattern.Matches(childClassParentMethod).ShouldBe(false);
-            testPattern = new TestPattern("C*.M*D*W*PC");
-            testPattern.Matches(childClassChildMethod).ShouldBe(false);
-            testPattern.Matches(parentClassParentMethod).ShouldBe(true);
-            testPattern.Matches(childClassParentMethod).ShouldBe(true);
+            // Explicit lower-case can prevent the implied wildcard.
+            new TestPattern("Te+*").Matches(test).ShouldBe(false);
+            new TestPattern("Te*+*").Matches(test).ShouldBe(true);
+            new TestPattern("Fi.T.TT+*").Matches(test).ShouldBe(false);
+            new TestPattern("Fi*.T.TT+*").Matches(test).ShouldBe(true);
+            new TestPattern("Cl.MDW*").Matches(test).ShouldBe(false);
+            new TestPattern("Cl*.MDW*").Matches(test).ShouldBe(true);
+            new TestPattern("C.MDW*Cl").Matches(test).ShouldBe(false);
+            new TestPattern("C.MDW*Cl*").Matches(test).ShouldBe(true);
         }
+
+        var testPattern = new TestPattern("C");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+        testPattern =new TestPattern("T");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("T*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+        
+        testPattern = new TestPattern("CC");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("CC*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("CC.MDW");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("CC.MDW*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("C.MDW");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("C.MDW*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("C.MDWC");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("C.MDWC*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("C.MDWCC");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("C.MDWCCl");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("C.MDWCClass");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+
+        testPattern = new TestPattern("C.MDWP");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("C.MDWP*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+        testPattern = new TestPattern("C.MDWPC");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+        testPattern = new TestPattern("C.MDWPCl");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("C.MDWPClass");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("ChildClass");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("ChildClass*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+        testPattern = new TestPattern("ParentClass");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("ChildClass.MethodDefinedWithin");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("ChildClass.MethodDefinedWithin*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+        testPattern = new TestPattern("ChildClass.MethodDefinedWithinC");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("ChildClass.MethodDefinedWithinCC");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+
+        testPattern = new TestPattern("ChildClass.MethodDefinedWithinP");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("ChildClass.MethodDefinedWithinP*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+        testPattern = new TestPattern("ChildClass.MethodDefinedWithinPC");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("ChildClass.Met*odDefinedWithin*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(true);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("ChildClass.Met*odDefinedWithinP*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("*M*e*t*h*o*d*D*e*f*i*n*e*d*W*i*t*h*i*n*P*");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+
+        testPattern = new TestPattern("C*.M*D*W*P");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(false);
+        testPattern.Matches(childClassParentMethod).ShouldBe(false);
+        testPattern = new TestPattern("C*.M*D*W*PC");
+        testPattern.Matches(childClassChildMethod).ShouldBe(false);
+        testPattern.Matches(parentClassParentMethod).ShouldBe(true);
+        testPattern.Matches(childClassParentMethod).ShouldBe(true);
+    }
 }

--- a/src/Fixie.Tests/Internal/TestPatternTests.cs
+++ b/src/Fixie.Tests/Internal/TestPatternTests.cs
@@ -1,12 +1,12 @@
-﻿namespace Fixie.Tests.Internal
-{
-    using Assertions;
-    using Fixie.Internal;
+﻿namespace Fixie.Tests.Internal;
 
-    public class TestPatternTests
+using Assertions;
+using Fixie.Internal;
+
+public class TestPatternTests
+{
+    public void CanDetermineWhetherTestsMatchTheGivenPattern()
     {
-        public void CanDetermineWhetherTestsMatchTheGivenPattern()
-        {
             var childClassChildMethod = "Fixie.Tests.TestTests+ChildClass.MethodDefinedWithinChildClass";
             var parentClassParentMethod = "Fixie.Tests.TestTests+ParentClass.MethodDefinedWithinParentClass";
             var childClassParentMethod = "Fixie.Tests.TestTests+ChildClass.MethodDefinedWithinParentClass";
@@ -200,5 +200,4 @@
             testPattern.Matches(parentClassParentMethod).ShouldBe(true);
             testPattern.Matches(childClassParentMethod).ShouldBe(true);
         }
-    }
 }

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -15,202 +15,202 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var testClass in testSuite.TestClasses)
-                    foreach (var test in testClass.Tests)
-                        foreach (var parameters in FromInputAttributes(test))
+            foreach (var testClass in testSuite.TestClasses)
+                foreach (var test in testClass.Tests)
+                    foreach (var parameters in FromInputAttributes(test))
+                    {
+                        try
                         {
-                            try
-                            {
-                                var instance = testClass.Construct();
+                            var instance = testClass.Construct();
 
-                                var result = await test.Method.Call(instance, parameters);
+                            var result = await test.Method.Call(instance, parameters);
 
-                                if (result != null)
-                                    System.Console.WriteLine($"{test.Method.Name} resulted in {result.GetType().FullName} with value {result}");
-                                else if (test.Method.ReturnType != typeof(void) &&
-                                         test.Method.ReturnType != typeof(Task) &&
-                                         test.Method.ReturnType != typeof(ValueTask))
-                                    System.Console.WriteLine($"{test.Method.Name} resulted in null");
+                            if (result != null)
+                                System.Console.WriteLine($"{test.Method.Name} resulted in {result.GetType().FullName} with value {result}");
+                            else if (test.Method.ReturnType != typeof(void) &&
+                                     test.Method.ReturnType != typeof(Task) &&
+                                     test.Method.ReturnType != typeof(ValueTask))
+                                System.Console.WriteLine($"{test.Method.Name} resulted in null");
 
-                                await test.Pass(parameters);
-                            }
-                            catch (Exception exception)
-                            {
-                                await test.Fail(parameters, exception);
-                            }
+                            await test.Pass(parameters);
                         }
-            }
+                        catch (Exception exception)
+                        {
+                            await test.Fail(parameters, exception);
+                        }
+                    }
+        }
     }
 
     public async Task ShouldCallSynchronousMethods()
     {
-            var output = await Run<SyncTestClass, MethodInfoAccessingExecution>();
+        var output = await Run<SyncTestClass, MethodInfoAccessingExecution>();
 
-            output.ShouldHaveResults(
-                "SyncTestClass.Args(1, 2, 3) passed",
-                "SyncTestClass.Args(1, 2, 3, \"Extra\") failed: Parameter count mismatch.",
-                "SyncTestClass.ReturnsInteger passed",
-                "SyncTestClass.ReturnsNull passed",
-                "SyncTestClass.ReturnsObject passed",
-                "SyncTestClass.ReturnsString passed",
-                "SyncTestClass.Throws failed: 'Throws' failed!",
-                "SyncTestClass.ZeroArgs passed");
+        output.ShouldHaveResults(
+            "SyncTestClass.Args(1, 2, 3) passed",
+            "SyncTestClass.Args(1, 2, 3, \"Extra\") failed: Parameter count mismatch.",
+            "SyncTestClass.ReturnsInteger passed",
+            "SyncTestClass.ReturnsNull passed",
+            "SyncTestClass.ReturnsObject passed",
+            "SyncTestClass.ReturnsString passed",
+            "SyncTestClass.Throws failed: 'Throws' failed!",
+            "SyncTestClass.ZeroArgs passed");
 
-            output.ShouldHaveLifecycle(
-                "Args",
-                "ReturnsInteger",
-                "ReturnsInteger resulted in System.Int32 with value 42",
-                "ReturnsNull",
-                "ReturnsNull resulted in null",
-                "ReturnsObject",
-                "ReturnsObject resulted in Fixie.Tests.MethodInfoExtensionsTests+Example with value <example>",
-                "ReturnsString",
-                "ReturnsString resulted in System.String with value ABC",
-                "Throws",
-                "ZeroArgs");
-        }
+        output.ShouldHaveLifecycle(
+            "Args",
+            "ReturnsInteger",
+            "ReturnsInteger resulted in System.Int32 with value 42",
+            "ReturnsNull",
+            "ReturnsNull resulted in null",
+            "ReturnsObject",
+            "ReturnsObject resulted in Fixie.Tests.MethodInfoExtensionsTests+Example with value <example>",
+            "ReturnsString",
+            "ReturnsString resulted in System.String with value ABC",
+            "Throws",
+            "ZeroArgs");
+    }
 
     public async Task ShouldResolveGenericTypeParametersWhenPossible()
     {
-            var output = await Run<GenericTestClass, MethodInfoAccessingExecution>();
+        var output = await Run<GenericTestClass, MethodInfoAccessingExecution>();
 
-            output.ShouldHaveResults(
-                "GenericTestClass.Args<System.Int32, System.Int32>(1, 2, System.Int32, System.Int32) passed",
-                "GenericTestClass.Args<System.Char, System.Double>('a', 3, System.Char, System.Double) passed",
+        output.ShouldHaveResults(
+            "GenericTestClass.Args<System.Int32, System.Int32>(1, 2, System.Int32, System.Int32) passed",
+            "GenericTestClass.Args<System.Char, System.Double>('a', 3, System.Char, System.Double) passed",
 
-                "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(1, 'a', System.Int32, System.Char) passed",
-                "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(2, 'b', System.Int32, System.Int32) failed: Expected: System.Int32" + NewLine + "Actual:   System.Char",
-                "GenericTestClass.ConstrainedArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
-                "GenericTestClass.ConstrainedArgs<T1, T2>(null, 2, System.Object, System.Int32) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
+            "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(1, 'a', System.Int32, System.Char) passed",
+            "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(2, 'b', System.Int32, System.Int32) failed: Expected: System.Int32" + NewLine + "Actual:   System.Char",
+            "GenericTestClass.ConstrainedArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
+            "GenericTestClass.ConstrainedArgs<T1, T2>(null, 2, System.Object, System.Int32) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
 
-                "GenericTestClass.NullableValueTypeArgs<System.Int32, System.Int32>(1, 2, System.Int32, System.Int32) passed",
-                "GenericTestClass.NullableValueTypeArgs<System.Char, System.Double>('a', 3, System.Char, System.Double) passed",
-                "GenericTestClass.NullableValueTypeArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method NullableValueTypeArgs could not be resolved.");
+            "GenericTestClass.NullableValueTypeArgs<System.Int32, System.Int32>(1, 2, System.Int32, System.Int32) passed",
+            "GenericTestClass.NullableValueTypeArgs<System.Char, System.Double>('a', 3, System.Char, System.Double) passed",
+            "GenericTestClass.NullableValueTypeArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method NullableValueTypeArgs could not be resolved.");
 
-            output.ShouldHaveLifecycle("Args", "Args", "ConstrainedArgs", "ConstrainedArgs", "NullableValueTypeArgs", "NullableValueTypeArgs");
-        }
+        output.ShouldHaveLifecycle("Args", "Args", "ConstrainedArgs", "ConstrainedArgs", "NullableValueTypeArgs", "NullableValueTypeArgs");
+    }
 
     public async Task ShouldAwaitAsynchronousMethodsToEnsureCompleteExecution()
     {
-            var output = await Run<AsyncTestClass, MethodInfoAccessingExecution>();
+        var output = await Run<AsyncTestClass, MethodInfoAccessingExecution>();
 
-            output.ShouldHaveResults(
-                "AsyncTestClass.AwaitTaskThenPass passed",
-                "AsyncTestClass.AwaitValueTaskThenPass passed",
-                "AsyncTestClass.CompleteTaskThenPass passed",
-                "AsyncTestClass.FailAfterAwaitTask failed: Expected: 0" + NewLine + "Actual:   3",
-                "AsyncTestClass.FailAfterAwaitValueTask failed: Expected: 0" + NewLine + "Actual:   3",
-                "AsyncTestClass.FailBeforeAwaitTask failed: 'FailBeforeAwaitTask' failed!",
-                "AsyncTestClass.FailBeforeAwaitValueTask failed: 'FailBeforeAwaitValueTask' failed!",
-                "AsyncTestClass.FailDuringAwaitTask failed: Attempted to divide by zero.",
-                "AsyncTestClass.FailDuringAwaitValueTask failed: Attempted to divide by zero.",
-                "AsyncTestClass.GenericAsyncTaskFail failed: Attempted to divide by zero.",
-                "AsyncTestClass.GenericAsyncTaskWithResult passed",
-                "AsyncTestClass.GenericAsyncValueTaskFail failed: Attempted to divide by zero.",
-                "AsyncTestClass.GenericAsyncValueTaskWithResult passed",
-                "AsyncTestClass.GenericTaskFail failed: One or more errors occurred. (Attempted to divide by zero.)",
-                "AsyncTestClass.GenericTaskWithResult passed",
-                "AsyncTestClass.NullTask failed: The asynchronous method NullTask returned null, " +
-                "but a non-null awaitable object was expected.");
+        output.ShouldHaveResults(
+            "AsyncTestClass.AwaitTaskThenPass passed",
+            "AsyncTestClass.AwaitValueTaskThenPass passed",
+            "AsyncTestClass.CompleteTaskThenPass passed",
+            "AsyncTestClass.FailAfterAwaitTask failed: Expected: 0" + NewLine + "Actual:   3",
+            "AsyncTestClass.FailAfterAwaitValueTask failed: Expected: 0" + NewLine + "Actual:   3",
+            "AsyncTestClass.FailBeforeAwaitTask failed: 'FailBeforeAwaitTask' failed!",
+            "AsyncTestClass.FailBeforeAwaitValueTask failed: 'FailBeforeAwaitValueTask' failed!",
+            "AsyncTestClass.FailDuringAwaitTask failed: Attempted to divide by zero.",
+            "AsyncTestClass.FailDuringAwaitValueTask failed: Attempted to divide by zero.",
+            "AsyncTestClass.GenericAsyncTaskFail failed: Attempted to divide by zero.",
+            "AsyncTestClass.GenericAsyncTaskWithResult passed",
+            "AsyncTestClass.GenericAsyncValueTaskFail failed: Attempted to divide by zero.",
+            "AsyncTestClass.GenericAsyncValueTaskWithResult passed",
+            "AsyncTestClass.GenericTaskFail failed: One or more errors occurred. (Attempted to divide by zero.)",
+            "AsyncTestClass.GenericTaskWithResult passed",
+            "AsyncTestClass.NullTask failed: The asynchronous method NullTask returned null, " +
+            "but a non-null awaitable object was expected.");
 
-            output.ShouldHaveLifecycle(
-                "AwaitTaskThenPass",
-                "AwaitValueTaskThenPass",
-                "CompleteTaskThenPass",
-                "FailAfterAwaitTask",
-                "FailAfterAwaitValueTask",
-                "FailBeforeAwaitTask",
-                "FailBeforeAwaitValueTask",
-                "FailDuringAwaitTask",
-                "FailDuringAwaitValueTask",
-                "GenericAsyncTaskFail",
-                "GenericAsyncTaskWithResult",
-                "GenericAsyncTaskWithResult resulted in System.Int32 with value 3",
-                "GenericAsyncValueTaskFail",
-                "GenericAsyncValueTaskWithResult",
-                "GenericAsyncValueTaskWithResult resulted in System.Int32 with value 4",
-                "GenericTaskFail",
-                "GenericTaskWithResult",
-                "GenericTaskWithResult resulted in System.Boolean with value True",
-                "NullTask");
-        }
+        output.ShouldHaveLifecycle(
+            "AwaitTaskThenPass",
+            "AwaitValueTaskThenPass",
+            "CompleteTaskThenPass",
+            "FailAfterAwaitTask",
+            "FailAfterAwaitValueTask",
+            "FailBeforeAwaitTask",
+            "FailBeforeAwaitValueTask",
+            "FailDuringAwaitTask",
+            "FailDuringAwaitValueTask",
+            "GenericAsyncTaskFail",
+            "GenericAsyncTaskWithResult",
+            "GenericAsyncTaskWithResult resulted in System.Int32 with value 3",
+            "GenericAsyncValueTaskFail",
+            "GenericAsyncValueTaskWithResult",
+            "GenericAsyncValueTaskWithResult resulted in System.Int32 with value 4",
+            "GenericTaskFail",
+            "GenericTaskWithResult",
+            "GenericTaskWithResult resulted in System.Boolean with value True",
+            "NullTask");
+    }
 
     public async Task ShouldRunFSharpAsyncResultsToEnsureCompleteExecution()
     {
-            var output = await Run<FSharpAsyncTestClass, MethodInfoAccessingExecution>();
+        var output = await Run<FSharpAsyncTestClass, MethodInfoAccessingExecution>();
 
-            output.ShouldHaveResults(
-                "FSharpAsyncTestClass.AsyncPass passed",
-                "FSharpAsyncTestClass.FailBeforeAsync failed: 'FailBeforeAsync' failed!",
-                "FSharpAsyncTestClass.FailFromAsync failed: Expected: 0" + NewLine + "Actual:   3",
-                "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync returned null, " +
-                "but a non-null awaitable object was expected.");
+        output.ShouldHaveResults(
+            "FSharpAsyncTestClass.AsyncPass passed",
+            "FSharpAsyncTestClass.FailBeforeAsync failed: 'FailBeforeAsync' failed!",
+            "FSharpAsyncTestClass.FailFromAsync failed: Expected: 0" + NewLine + "Actual:   3",
+            "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync returned null, " +
+            "but a non-null awaitable object was expected.");
 
-            output.ShouldHaveLifecycle(
-                "AsyncPass",
-                "AsyncPass resulted in System.Int32 with value 3",
-                "FailBeforeAsync",
-                "FailFromAsync",
-                "NullAsync");
-        }
+        output.ShouldHaveLifecycle(
+            "AsyncPass",
+            "AsyncPass resulted in System.Int32 with value 3",
+            "FailBeforeAsync",
+            "FailFromAsync",
+            "NullAsync");
+    }
 
     public async Task ShouldThrowWithClearExplanationWhenMethodReturnsNonStartedTask()
     {
-            var output = await Run<FailDueToNonStartedTaskTestClass, MethodInfoAccessingExecution>();
+        var output = await Run<FailDueToNonStartedTaskTestClass, MethodInfoAccessingExecution>();
 
-            output.ShouldHaveResults(
-                "FailDueToNonStartedTaskTestClass.Test failed: The method Test returned a non-started task, which cannot " +
-                "be awaited. Consider using Task.Run or Task.Factory.StartNew.");
+        output.ShouldHaveResults(
+            "FailDueToNonStartedTaskTestClass.Test failed: The method Test returned a non-started task, which cannot " +
+            "be awaited. Consider using Task.Run or Task.Factory.StartNew.");
 
-            output.ShouldHaveLifecycle("Test");
-        }
+        output.ShouldHaveLifecycle("Test");
+    }
 
     public async Task ShouldThrowForUnsupportedReturnTypeDeclarationsRatherThanAttemptExecution()
     {
-            var output = await Run<UnsupportedReturnTypeDeclarationsTestClass, MethodInfoAccessingExecution>();
+        var output = await Run<UnsupportedReturnTypeDeclarationsTestClass, MethodInfoAccessingExecution>();
 
-            output.ShouldHaveResults(
-                "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerable failed: " +
-                "The return type of method AsyncEnumerable is an unsupported awaitable type. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
-                "or `ValueTask<T>`.",
+        output.ShouldHaveResults(
+            "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerable failed: " +
+            "The return type of method AsyncEnumerable is an unsupported awaitable type. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
+            "or `ValueTask<T>`.",
 
-                "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerator failed: " +
-                "The return type of method AsyncEnumerator is an unsupported awaitable type. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
-                "or `ValueTask<T>`.",
+            "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerator failed: " +
+            "The return type of method AsyncEnumerator is an unsupported awaitable type. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
+            "or `ValueTask<T>`.",
 
-                "UnsupportedReturnTypeDeclarationsTestClass.AsyncVoid failed: " +
-                "The method AsyncVoid is declared as `async void`, which is not supported. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method as `async Task`.",
+            "UnsupportedReturnTypeDeclarationsTestClass.AsyncVoid failed: " +
+            "The method AsyncVoid is declared as `async void`, which is not supported. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method as `async Task`.",
 
-                "UnsupportedReturnTypeDeclarationsTestClass.UntrustworthyAwaitable failed: " +
-                "The return type of method UntrustworthyAwaitable is an unsupported awaitable type. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
-                "or `ValueTask<T>`."
-            );
+            "UnsupportedReturnTypeDeclarationsTestClass.UntrustworthyAwaitable failed: " +
+            "The return type of method UntrustworthyAwaitable is an unsupported awaitable type. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
+            "or `ValueTask<T>`."
+        );
 
-            output.ShouldHaveLifecycle();
-        }
+        output.ShouldHaveLifecycle();
+    }
 
     static void ThrowException([CallerMemberName] string member = default!)
     {
-            throw new FailureException(member);
-        }
+        throw new FailureException(member);
+    }
 
     static Task<int> DivideAsync(int numerator, int denominator)
     {
-            return Task.Run(() => numerator/denominator);
-        }
+        return Task.Run(() => numerator/denominator);
+    }
 
     static int Divide(int numerator, int denominator)
     {
-            return numerator/denominator;
-        }
+        return numerator/denominator;
+    }
 
     class SyncTestClass
     {
@@ -224,31 +224,31 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
 
         public int ReturnsInteger()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return 42;
-            }
+            return 42;
+        }
 
         public object? ReturnsNull()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return null;
-            }
+            return null;
+        }
 
         public object ReturnsObject()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return new Example("example");
-            }
+            return new Example("example");
+        }
 
         public string ReturnsString()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return "ABC";
-            }
+            return "ABC";
+        }
     }
 
     public class Example
@@ -266,10 +266,10 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
         [Input('a', 3.0d, typeof(char), typeof(double))]
         public void Args<T1, T2>(T1 a, T2 b, Type expectedT1, Type expectedT2)
         {
-                WhereAmI();
-                typeof(T1).ShouldBe(expectedT1);
-                typeof(T2).ShouldBe(expectedT2);
-            }
+            WhereAmI();
+            typeof(T1).ShouldBe(expectedT1);
+            typeof(T2).ShouldBe(expectedT2);
+        }
 
         [Input(1, 'a', typeof(int), typeof(char))]
         [Input(2, 'b', typeof(int), typeof(int))]
@@ -279,260 +279,260 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
             where T1: struct
             where T2: struct
         {
-                WhereAmI();
-                typeof(T1).ShouldBe(expectedT1);
-                typeof(T2).ShouldBe(expectedT2);
-            }
+            WhereAmI();
+            typeof(T1).ShouldBe(expectedT1);
+            typeof(T2).ShouldBe(expectedT2);
+        }
 
         [Input(1, 2, typeof(int), typeof(int))]
         [Input('a', 3.0d, typeof(char), typeof(double))]
         [Input(1, null, typeof(int), typeof(object))]
         public void NullableValueTypeArgs<T1, T2>(T1 a, T2? b, Type expectedT1, Type expectedT2) where T2: struct
         {
-                WhereAmI();
-                typeof(T1).ShouldBe(expectedT1);
-                typeof(T2).ShouldBe(expectedT2);
-            }
+            WhereAmI();
+            typeof(T1).ShouldBe(expectedT1);
+            typeof(T2).ShouldBe(expectedT2);
+        }
     }
 
     class AsyncTestClass
     {
         public async Task AwaitTaskThenPass()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = await DivideAsync(15, 5);
+            var result = await DivideAsync(15, 5);
 
-                result.ShouldBe(3);
-            }
+            result.ShouldBe(3);
+        }
 
         public async ValueTask AwaitValueTaskThenPass()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = await DivideAsync(15, 5);
+            var result = await DivideAsync(15, 5);
 
-                result.ShouldBe(3);
-            }
+            result.ShouldBe(3);
+        }
 
         public Task CompleteTaskThenPass()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var divide = DivideAsync(15, 5);
+            var divide = DivideAsync(15, 5);
 
-                return divide.ContinueWith(division =>
-                {
-                    division.Result.ShouldBe(3);
-                });
-            }
+            return divide.ContinueWith(division =>
+            {
+                division.Result.ShouldBe(3);
+            });
+        }
 
         public async Task FailAfterAwaitTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = await DivideAsync(15, 5);
+            var result = await DivideAsync(15, 5);
 
-                result.ShouldBe(0);
-            }
+            result.ShouldBe(0);
+        }
 
         public async ValueTask FailAfterAwaitValueTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = await DivideAsync(15, 5);
+            var result = await DivideAsync(15, 5);
 
-                result.ShouldBe(0);
-            }
+            result.ShouldBe(0);
+        }
 
         public async Task FailBeforeAwaitTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                ThrowException();
+            ThrowException();
 
-                await DivideAsync(15, 5);
-            }
+            await DivideAsync(15, 5);
+        }
 
         public async ValueTask FailBeforeAwaitValueTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                ThrowException();
+            ThrowException();
 
-                await DivideAsync(15, 5);
-            }
+            await DivideAsync(15, 5);
+        }
 
         public async Task FailDuringAwaitTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                await DivideAsync(15, 0);
+            await DivideAsync(15, 0);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
 
         public async ValueTask FailDuringAwaitValueTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                await DivideAsync(15, 0);
+            await DivideAsync(15, 0);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
 
         public async Task<int> GenericAsyncTaskFail()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return await DivideAsync(15, 0);
-            }
+            return await DivideAsync(15, 0);
+        }
 
         public async Task<int> GenericAsyncTaskWithResult()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return await DivideAsync(15, 5);
-            }
+            return await DivideAsync(15, 5);
+        }
 
         public async ValueTask<int> GenericAsyncValueTaskWithResult()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return await DivideAsync(20, 5);
-            }
+            return await DivideAsync(20, 5);
+        }
 
         public async ValueTask<int> GenericAsyncValueTaskFail()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return await DivideAsync(15, 0);
-            }
+            return await DivideAsync(15, 0);
+        }
 
         public Task<bool> GenericTaskFail()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var divide = DivideAsync(15, 0);
+            var divide = DivideAsync(15, 0);
 
-                return divide.ContinueWith(division => division.Result == 42);
-            }
+            return divide.ContinueWith(division => division.Result == 42);
+        }
 
         public Task<bool> GenericTaskWithResult()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var divide = DivideAsync(15, 5);
+            var divide = DivideAsync(15, 5);
 
-                return divide.ContinueWith(division => division.Result == 3);
-            }
+            return divide.ContinueWith(division => division.Result == 3);
+        }
 
         public Task? NullTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                // Although unlikely, we must ensure that
-                // we don't attempt to wait on a Task that
-                // is in fact null.
-                return null;
-            }
+            // Although unlikely, we must ensure that
+            // we don't attempt to wait on a Task that
+            // is in fact null.
+            return null;
+        }
     }
 
     class FSharpAsyncTestClass
     {
         public FSharpAsync<int> AsyncPass()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return new FSharpAsync<int>(() =>
-                {
-                    var result = Divide(15, 5);
+            return new FSharpAsync<int>(() =>
+            {
+                var result = Divide(15, 5);
 
-                    result.ShouldBe(3);
+                result.ShouldBe(3);
 
-                    return result;
-                });
-            }
+                return result;
+            });
+        }
 
         public FSharpAsync<int> FailBeforeAsync()
         {
-                WhereAmI();
+            WhereAmI();
 
-                ThrowException();
+            ThrowException();
 
-                return new FSharpAsync<int>(() => Divide(15, 5));
-            }
+            return new FSharpAsync<int>(() => Divide(15, 5));
+        }
 
         public FSharpAsync<int> FailFromAsync()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return new FSharpAsync<int>(() =>
-                {
-                    var result = Divide(15, 5);
+            return new FSharpAsync<int>(() =>
+            {
+                var result = Divide(15, 5);
 
-                    result.ShouldBe(0);
+                result.ShouldBe(0);
 
-                    return result;
-                });
-            }
+                return result;
+            });
+        }
 
         public FSharpAsync<int>? NullAsync()
         {
-                WhereAmI();
+            WhereAmI();
 
-                // Although unlikely, we must ensure that
-                // we don't attempt to wait on an FSharpAsync that
-                // is in fact null.
-                return null;
-            }
+            // Although unlikely, we must ensure that
+            // we don't attempt to wait on an FSharpAsync that
+            // is in fact null.
+            return null;
+        }
     }
 
     class FailDueToNonStartedTaskTestClass
     {
         public Task Test()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return new Task(() => throw new ShouldBeUnreachableException());
-            }
+            return new Task(() => throw new ShouldBeUnreachableException());
+        }
     }
 
     class UnsupportedReturnTypeDeclarationsTestClass
     {
         public async void AsyncVoid()
         {
-                WhereAmI();
+            WhereAmI();
 
-                await DivideAsync(15, 5);
-                throw new ShouldBeUnreachableException();
-            }
+            await DivideAsync(15, 5);
+            throw new ShouldBeUnreachableException();
+        }
 
         public async UntrustworthyAwaitable UntrustworthyAwaitable()
         {
-                WhereAmI();
+            WhereAmI();
 
-                await DivideAsync(15, 0);
+            await DivideAsync(15, 0);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
 
         public async IAsyncEnumerable<int> AsyncEnumerable()
         {
-                WhereAmI();
+            WhereAmI();
 
-                yield return await DivideAsync(15, 5);
+            yield return await DivideAsync(15, 5);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
 
         public async IAsyncEnumerator<int> AsyncEnumerator()
         {
-                WhereAmI();
+            WhereAmI();
 
-                yield return await DivideAsync(15, 5);
+            yield return await DivideAsync(15, 5);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
     }
 }

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -1,20 +1,20 @@
-﻿namespace Fixie.Tests
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Microsoft.FSharp.Control;
-    using static System.Environment;
-    using static Utility;
+﻿namespace Fixie.Tests;
 
-    public class MethodInfoExtensionsTests : InstrumentedExecutionTests
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Assertions;
+using Microsoft.FSharp.Control;
+using static System.Environment;
+using static Utility;
+
+public class MethodInfoExtensionsTests : InstrumentedExecutionTests
+{
+    class MethodInfoAccessingExecution : IExecution
     {
-        class MethodInfoAccessingExecution : IExecution
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var testClass in testSuite.TestClasses)
                     foreach (var test in testClass.Tests)
                         foreach (var parameters in FromInputAttributes(test))
@@ -40,10 +40,10 @@
                             }
                         }
             }
-        }
+    }
 
-        public async Task ShouldCallSynchronousMethods()
-        {
+    public async Task ShouldCallSynchronousMethods()
+    {
             var output = await Run<SyncTestClass, MethodInfoAccessingExecution>();
 
             output.ShouldHaveResults(
@@ -70,8 +70,8 @@
                 "ZeroArgs");
         }
 
-        public async Task ShouldResolveGenericTypeParametersWhenPossible()
-        {
+    public async Task ShouldResolveGenericTypeParametersWhenPossible()
+    {
             var output = await Run<GenericTestClass, MethodInfoAccessingExecution>();
 
             output.ShouldHaveResults(
@@ -90,8 +90,8 @@
             output.ShouldHaveLifecycle("Args", "Args", "ConstrainedArgs", "ConstrainedArgs", "NullableValueTypeArgs", "NullableValueTypeArgs");
         }
 
-        public async Task ShouldAwaitAsynchronousMethodsToEnsureCompleteExecution()
-        {
+    public async Task ShouldAwaitAsynchronousMethodsToEnsureCompleteExecution()
+    {
             var output = await Run<AsyncTestClass, MethodInfoAccessingExecution>();
 
             output.ShouldHaveResults(
@@ -135,8 +135,8 @@
                 "NullTask");
         }
 
-        public async Task ShouldRunFSharpAsyncResultsToEnsureCompleteExecution()
-        {
+    public async Task ShouldRunFSharpAsyncResultsToEnsureCompleteExecution()
+    {
             var output = await Run<FSharpAsyncTestClass, MethodInfoAccessingExecution>();
 
             output.ShouldHaveResults(
@@ -154,8 +154,8 @@
                 "NullAsync");
         }
 
-        public async Task ShouldThrowWithClearExplanationWhenMethodReturnsNonStartedTask()
-        {
+    public async Task ShouldThrowWithClearExplanationWhenMethodReturnsNonStartedTask()
+    {
             var output = await Run<FailDueToNonStartedTaskTestClass, MethodInfoAccessingExecution>();
 
             output.ShouldHaveResults(
@@ -165,8 +165,8 @@
             output.ShouldHaveLifecycle("Test");
         }
 
-        public async Task ShouldThrowForUnsupportedReturnTypeDeclarationsRatherThanAttemptExecution()
-        {
+    public async Task ShouldThrowForUnsupportedReturnTypeDeclarationsRatherThanAttemptExecution()
+    {
             var output = await Run<UnsupportedReturnTypeDeclarationsTestClass, MethodInfoAccessingExecution>();
 
             output.ShouldHaveResults(
@@ -197,108 +197,108 @@
             output.ShouldHaveLifecycle();
         }
 
-        static void ThrowException([CallerMemberName] string member = default!)
-        {
+    static void ThrowException([CallerMemberName] string member = default!)
+    {
             throw new FailureException(member);
         }
 
-        static Task<int> DivideAsync(int numerator, int denominator)
-        {
+    static Task<int> DivideAsync(int numerator, int denominator)
+    {
             return Task.Run(() => numerator/denominator);
         }
 
-        static int Divide(int numerator, int denominator)
-        {
+    static int Divide(int numerator, int denominator)
+    {
             return numerator/denominator;
         }
 
-        class SyncTestClass
+    class SyncTestClass
+    {
+        public void ZeroArgs() { WhereAmI(); }
+
+        public void Throws() { WhereAmI(); ThrowException(); }
+
+        [Input(1, 2, 3)]
+        [Input(1, 2, 3, "Extra")]
+        public void Args(int a, int b, int c) { WhereAmI(); }
+
+        public int ReturnsInteger()
         {
-            public void ZeroArgs() { WhereAmI(); }
-
-            public void Throws() { WhereAmI(); ThrowException(); }
-
-            [Input(1, 2, 3)]
-            [Input(1, 2, 3, "Extra")]
-            public void Args(int a, int b, int c) { WhereAmI(); }
-
-            public int ReturnsInteger()
-            {
                 WhereAmI();
 
                 return 42;
             }
 
-            public object? ReturnsNull()
-            {
+        public object? ReturnsNull()
+        {
                 WhereAmI();
 
                 return null;
             }
 
-            public object ReturnsObject()
-            {
+        public object ReturnsObject()
+        {
                 WhereAmI();
 
                 return new Example("example");
             }
 
-            public string ReturnsString()
-            {
+        public string ReturnsString()
+        {
                 WhereAmI();
 
                 return "ABC";
             }
-        }
+    }
 
-        public class Example
-        {
-            readonly string name;
+    public class Example
+    {
+        readonly string name;
 
-            public Example(string name) => this.name = name;
+        public Example(string name) => this.name = name;
             
-            public override string ToString() => $"<{name}>";
-        }
+        public override string ToString() => $"<{name}>";
+    }
 
-        class GenericTestClass
+    class GenericTestClass
+    {
+        [Input(1, 2, typeof(int), typeof(int))]
+        [Input('a', 3.0d, typeof(char), typeof(double))]
+        public void Args<T1, T2>(T1 a, T2 b, Type expectedT1, Type expectedT2)
         {
-            [Input(1, 2, typeof(int), typeof(int))]
-            [Input('a', 3.0d, typeof(char), typeof(double))]
-            public void Args<T1, T2>(T1 a, T2 b, Type expectedT1, Type expectedT2)
-            {
                 WhereAmI();
                 typeof(T1).ShouldBe(expectedT1);
                 typeof(T2).ShouldBe(expectedT2);
             }
 
-            [Input(1, 'a', typeof(int), typeof(char))]
-            [Input(2, 'b', typeof(int), typeof(int))]
-            [Input(1, null, typeof(int), typeof(object))]
-            [Input(null, 2, typeof(object), typeof(int))]
-            public void ConstrainedArgs<T1, T2>(T1 a, T2 b, Type expectedT1, Type expectedT2)
-                where T1: struct
-                where T2: struct
-            {
-                WhereAmI();
-                typeof(T1).ShouldBe(expectedT1);
-                typeof(T2).ShouldBe(expectedT2);
-            }
-
-            [Input(1, 2, typeof(int), typeof(int))]
-            [Input('a', 3.0d, typeof(char), typeof(double))]
-            [Input(1, null, typeof(int), typeof(object))]
-            public void NullableValueTypeArgs<T1, T2>(T1 a, T2? b, Type expectedT1, Type expectedT2) where T2: struct
-            {
-                WhereAmI();
-                typeof(T1).ShouldBe(expectedT1);
-                typeof(T2).ShouldBe(expectedT2);
-            }
-        }
-
-        class AsyncTestClass
+        [Input(1, 'a', typeof(int), typeof(char))]
+        [Input(2, 'b', typeof(int), typeof(int))]
+        [Input(1, null, typeof(int), typeof(object))]
+        [Input(null, 2, typeof(object), typeof(int))]
+        public void ConstrainedArgs<T1, T2>(T1 a, T2 b, Type expectedT1, Type expectedT2)
+            where T1: struct
+            where T2: struct
         {
-            public async Task AwaitTaskThenPass()
-            {
+                WhereAmI();
+                typeof(T1).ShouldBe(expectedT1);
+                typeof(T2).ShouldBe(expectedT2);
+            }
+
+        [Input(1, 2, typeof(int), typeof(int))]
+        [Input('a', 3.0d, typeof(char), typeof(double))]
+        [Input(1, null, typeof(int), typeof(object))]
+        public void NullableValueTypeArgs<T1, T2>(T1 a, T2? b, Type expectedT1, Type expectedT2) where T2: struct
+        {
+                WhereAmI();
+                typeof(T1).ShouldBe(expectedT1);
+                typeof(T2).ShouldBe(expectedT2);
+            }
+    }
+
+    class AsyncTestClass
+    {
+        public async Task AwaitTaskThenPass()
+        {
                 WhereAmI();
 
                 var result = await DivideAsync(15, 5);
@@ -306,8 +306,8 @@
                 result.ShouldBe(3);
             }
 
-            public async ValueTask AwaitValueTaskThenPass()
-            {
+        public async ValueTask AwaitValueTaskThenPass()
+        {
                 WhereAmI();
 
                 var result = await DivideAsync(15, 5);
@@ -315,8 +315,8 @@
                 result.ShouldBe(3);
             }
 
-            public Task CompleteTaskThenPass()
-            {
+        public Task CompleteTaskThenPass()
+        {
                 WhereAmI();
 
                 var divide = DivideAsync(15, 5);
@@ -327,8 +327,8 @@
                 });
             }
 
-            public async Task FailAfterAwaitTask()
-            {
+        public async Task FailAfterAwaitTask()
+        {
                 WhereAmI();
 
                 var result = await DivideAsync(15, 5);
@@ -336,8 +336,8 @@
                 result.ShouldBe(0);
             }
 
-            public async ValueTask FailAfterAwaitValueTask()
-            {
+        public async ValueTask FailAfterAwaitValueTask()
+        {
                 WhereAmI();
 
                 var result = await DivideAsync(15, 5);
@@ -345,8 +345,8 @@
                 result.ShouldBe(0);
             }
 
-            public async Task FailBeforeAwaitTask()
-            {
+        public async Task FailBeforeAwaitTask()
+        {
                 WhereAmI();
 
                 ThrowException();
@@ -354,8 +354,8 @@
                 await DivideAsync(15, 5);
             }
 
-            public async ValueTask FailBeforeAwaitValueTask()
-            {
+        public async ValueTask FailBeforeAwaitValueTask()
+        {
                 WhereAmI();
 
                 ThrowException();
@@ -363,8 +363,8 @@
                 await DivideAsync(15, 5);
             }
 
-            public async Task FailDuringAwaitTask()
-            {
+        public async Task FailDuringAwaitTask()
+        {
                 WhereAmI();
 
                 await DivideAsync(15, 0);
@@ -372,8 +372,8 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            public async ValueTask FailDuringAwaitValueTask()
-            {
+        public async ValueTask FailDuringAwaitValueTask()
+        {
                 WhereAmI();
 
                 await DivideAsync(15, 0);
@@ -381,36 +381,36 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            public async Task<int> GenericAsyncTaskFail()
-            {
+        public async Task<int> GenericAsyncTaskFail()
+        {
                 WhereAmI();
 
                 return await DivideAsync(15, 0);
             }
 
-            public async Task<int> GenericAsyncTaskWithResult()
-            {
+        public async Task<int> GenericAsyncTaskWithResult()
+        {
                 WhereAmI();
 
                 return await DivideAsync(15, 5);
             }
 
-            public async ValueTask<int> GenericAsyncValueTaskWithResult()
-            {
+        public async ValueTask<int> GenericAsyncValueTaskWithResult()
+        {
                 WhereAmI();
 
                 return await DivideAsync(20, 5);
             }
 
-            public async ValueTask<int> GenericAsyncValueTaskFail()
-            {
+        public async ValueTask<int> GenericAsyncValueTaskFail()
+        {
                 WhereAmI();
 
                 return await DivideAsync(15, 0);
             }
 
-            public Task<bool> GenericTaskFail()
-            {
+        public Task<bool> GenericTaskFail()
+        {
                 WhereAmI();
 
                 var divide = DivideAsync(15, 0);
@@ -418,8 +418,8 @@
                 return divide.ContinueWith(division => division.Result == 42);
             }
 
-            public Task<bool> GenericTaskWithResult()
-            {
+        public Task<bool> GenericTaskWithResult()
+        {
                 WhereAmI();
 
                 var divide = DivideAsync(15, 5);
@@ -427,8 +427,8 @@
                 return divide.ContinueWith(division => division.Result == 3);
             }
 
-            public Task? NullTask()
-            {
+        public Task? NullTask()
+        {
                 WhereAmI();
 
                 // Although unlikely, we must ensure that
@@ -436,12 +436,12 @@
                 // is in fact null.
                 return null;
             }
-        }
+    }
 
-        class FSharpAsyncTestClass
+    class FSharpAsyncTestClass
+    {
+        public FSharpAsync<int> AsyncPass()
         {
-            public FSharpAsync<int> AsyncPass()
-            {
                 WhereAmI();
 
                 return new FSharpAsync<int>(() =>
@@ -454,8 +454,8 @@
                 });
             }
 
-            public FSharpAsync<int> FailBeforeAsync()
-            {
+        public FSharpAsync<int> FailBeforeAsync()
+        {
                 WhereAmI();
 
                 ThrowException();
@@ -463,8 +463,8 @@
                 return new FSharpAsync<int>(() => Divide(15, 5));
             }
 
-            public FSharpAsync<int> FailFromAsync()
-            {
+        public FSharpAsync<int> FailFromAsync()
+        {
                 WhereAmI();
 
                 return new FSharpAsync<int>(() =>
@@ -477,8 +477,8 @@
                 });
             }
 
-            public FSharpAsync<int>? NullAsync()
-            {
+        public FSharpAsync<int>? NullAsync()
+        {
                 WhereAmI();
 
                 // Although unlikely, we must ensure that
@@ -486,30 +486,30 @@
                 // is in fact null.
                 return null;
             }
-        }
+    }
 
-        class FailDueToNonStartedTaskTestClass
+    class FailDueToNonStartedTaskTestClass
+    {
+        public Task Test()
         {
-            public Task Test()
-            {
                 WhereAmI();
 
                 return new Task(() => throw new ShouldBeUnreachableException());
             }
-        }
+    }
 
-        class UnsupportedReturnTypeDeclarationsTestClass
+    class UnsupportedReturnTypeDeclarationsTestClass
+    {
+        public async void AsyncVoid()
         {
-            public async void AsyncVoid()
-            {
                 WhereAmI();
 
                 await DivideAsync(15, 5);
                 throw new ShouldBeUnreachableException();
             }
 
-            public async UntrustworthyAwaitable UntrustworthyAwaitable()
-            {
+        public async UntrustworthyAwaitable UntrustworthyAwaitable()
+        {
                 WhereAmI();
 
                 await DivideAsync(15, 0);
@@ -517,8 +517,8 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            public async IAsyncEnumerable<int> AsyncEnumerable()
-            {
+        public async IAsyncEnumerable<int> AsyncEnumerable()
+        {
                 WhereAmI();
 
                 yield return await DivideAsync(15, 5);
@@ -526,14 +526,13 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            public async IAsyncEnumerator<int> AsyncEnumerator()
-            {
+        public async IAsyncEnumerator<int> AsyncEnumerator()
+        {
                 WhereAmI();
 
                 yield return await DivideAsync(15, 5);
 
                 throw new ShouldBeUnreachableException();
             }
-        }
     }
 }

--- a/src/Fixie.Tests/ParameterizationTests.cs
+++ b/src/Fixie.Tests/ParameterizationTests.cs
@@ -17,10 +17,10 @@ public class ParameterizationTests : InstrumentedExecutionTests
 
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var test in testSuite.Tests)
-                    foreach (var parameters in parameterSource(test))
-                        await test.Run(parameters);
-            }
+            foreach (var test in testSuite.Tests)
+                foreach (var parameters in parameterSource(test))
+                    await test.Run(parameters);
+        }
     }
 
     class IsolatedParameterizedExecution : IExecution
@@ -32,265 +32,265 @@ public class ParameterizationTests : InstrumentedExecutionTests
 
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var test in testSuite.Tests)
+            foreach (var test in testSuite.Tests)
+            {
+                try
                 {
-                    try
-                    {
-                        foreach (var parameters in parameterSource(test))
-                            await test.Run(parameters);
-                    }
-                    catch (Exception exception)
-                    {
-                        await test.Fail(exception);
-                    }
+                    foreach (var parameters in parameterSource(test))
+                        await test.Run(parameters);
+                }
+                catch (Exception exception)
+                {
+                    await test.Fail(exception);
                 }
             }
+        }
     }
 
     public async Task ShouldAllowRunningTestsMultipleTimesWithVaryingInputParameters()
     {
-            var execution = new ParameterizedExecution(InputAttributeOrDefaultParameterSource);
-            var output = await Run<ParameterizedTestClass>(execution);
+        var execution = new ParameterizedExecution(InputAttributeOrDefaultParameterSource);
+        var output = await Run<ParameterizedTestClass>(execution);
 
-            output.ShouldHaveResults(
-                "ParameterizedTestClass.IntArg(0) passed",
-                "ParameterizedTestClass.Sum(1, 1, 2) passed",
-                "ParameterizedTestClass.Sum(1, 2, 3) passed",
-                "ParameterizedTestClass.Sum(5, 5, 11) failed: Expected sum of 11 but was 10.",
-                "ParameterizedTestClass.ZeroArgs passed");
+        output.ShouldHaveResults(
+            "ParameterizedTestClass.IntArg(0) passed",
+            "ParameterizedTestClass.Sum(1, 1, 2) passed",
+            "ParameterizedTestClass.Sum(1, 2, 3) passed",
+            "ParameterizedTestClass.Sum(5, 5, 11) failed: Expected sum of 11 but was 10.",
+            "ParameterizedTestClass.ZeroArgs passed");
 
-            output.ShouldHaveLifecycle("IntArg", "Sum", "Sum", "Sum", "ZeroArgs");
-        }
+        output.ShouldHaveLifecycle("IntArg", "Sum", "Sum", "Sum", "ZeroArgs");
+    }
 
     public async Task ShouldFailWithClearExplanationWhenParameterCountsAreMismatched()
     {
-            var execution = new ParameterizedExecution(method => new[]
-            {
-                new object[] { },
-                new object[] {0},
-                new object[] {0, 1},
-                new object[] {0, 1, 2},
-                new object[] {0, 1, 2, 3}
-            });
-            var output = await Run<ParameterizedTestClass>(execution);
+        var execution = new ParameterizedExecution(method => new[]
+        {
+            new object[] { },
+            new object[] {0},
+            new object[] {0, 1},
+            new object[] {0, 1, 2},
+            new object[] {0, 1, 2, 3}
+        });
+        var output = await Run<ParameterizedTestClass>(execution);
 
-            output.ShouldHaveResults(
-                "ParameterizedTestClass.IntArg failed: Parameter count mismatch.",
-                "ParameterizedTestClass.IntArg(0) passed",
-                "ParameterizedTestClass.IntArg(0, 1) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.IntArg(0, 1, 2) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.IntArg(0, 1, 2, 3) failed: Parameter count mismatch.",
+        output.ShouldHaveResults(
+            "ParameterizedTestClass.IntArg failed: Parameter count mismatch.",
+            "ParameterizedTestClass.IntArg(0) passed",
+            "ParameterizedTestClass.IntArg(0, 1) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.IntArg(0, 1, 2) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.IntArg(0, 1, 2, 3) failed: Parameter count mismatch.",
 
-                "ParameterizedTestClass.Sum failed: Parameter count mismatch.",
-                "ParameterizedTestClass.Sum(0) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.Sum(0, 1) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.Sum(0, 1, 2) failed: Expected sum of 2 but was 1.",
-                "ParameterizedTestClass.Sum(0, 1, 2, 3) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.Sum failed: Parameter count mismatch.",
+            "ParameterizedTestClass.Sum(0) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.Sum(0, 1) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.Sum(0, 1, 2) failed: Expected sum of 2 but was 1.",
+            "ParameterizedTestClass.Sum(0, 1, 2, 3) failed: Parameter count mismatch.",
 
-                "ParameterizedTestClass.ZeroArgs passed",
-                "ParameterizedTestClass.ZeroArgs(0) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.ZeroArgs(0, 1) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.ZeroArgs(0, 1, 2) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.ZeroArgs(0, 1, 2, 3) failed: Parameter count mismatch.");
+            "ParameterizedTestClass.ZeroArgs passed",
+            "ParameterizedTestClass.ZeroArgs(0) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.ZeroArgs(0, 1) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.ZeroArgs(0, 1, 2) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.ZeroArgs(0, 1, 2, 3) failed: Parameter count mismatch.");
 
-            output.ShouldHaveLifecycle("IntArg", "Sum", "ZeroArgs");
-        }
+        output.ShouldHaveLifecycle("IntArg", "Sum", "ZeroArgs");
+    }
 
     public async Task ShouldSupportEndingTheRunEarlyWhenParameterGenerationThrows()
     {
-            var execution = new ParameterizedExecution(BuggyParameterSource);
-            var output = await Run<ParameterizedTestClass>(execution);
+        var execution = new ParameterizedExecution(BuggyParameterSource);
+        var output = await Run<ParameterizedTestClass>(execution);
 
-            output.ShouldHaveResults(
-                "ParameterizedTestClass.IntArg(0) passed",
-                "ParameterizedTestClass.IntArg(1) failed: Expected 0, but was 1",
-                "ParameterizedTestClass.IntArg failed: Exception thrown while attempting to yield input parameters for method: IntArg",
+        output.ShouldHaveResults(
+            "ParameterizedTestClass.IntArg(0) passed",
+            "ParameterizedTestClass.IntArg(1) failed: Expected 0, but was 1",
+            "ParameterizedTestClass.IntArg failed: Exception thrown while attempting to yield input parameters for method: IntArg",
 
-                "ParameterizedTestClass.Sum failed: Exception thrown while attempting to yield input parameters for method: IntArg",
-                "ParameterizedTestClass.Sum skipped: This test did not run.",
+            "ParameterizedTestClass.Sum failed: Exception thrown while attempting to yield input parameters for method: IntArg",
+            "ParameterizedTestClass.Sum skipped: This test did not run.",
 
-                "ParameterizedTestClass.ZeroArgs failed: Exception thrown while attempting to yield input parameters for method: IntArg",
-                "ParameterizedTestClass.ZeroArgs skipped: This test did not run.");
+            "ParameterizedTestClass.ZeroArgs failed: Exception thrown while attempting to yield input parameters for method: IntArg",
+            "ParameterizedTestClass.ZeroArgs skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle("IntArg", "IntArg");
-        }
+        output.ShouldHaveLifecycle("IntArg", "IntArg");
+    }
 
     public async Task ShouldSupportIsolatingFailuresToTheAffectedTestMethodWhenParameterGenerationThrows()
     {
-            var execution = new IsolatedParameterizedExecution(BuggyParameterSource);
-            var output = await Run<ParameterizedTestClass>(execution);
+        var execution = new IsolatedParameterizedExecution(BuggyParameterSource);
+        var output = await Run<ParameterizedTestClass>(execution);
 
-            output.ShouldHaveResults(
-                "ParameterizedTestClass.IntArg(0) passed",
-                "ParameterizedTestClass.IntArg(1) failed: Expected 0, but was 1",
-                "ParameterizedTestClass.IntArg failed: Exception thrown while attempting to yield input parameters for method: IntArg",
+        output.ShouldHaveResults(
+            "ParameterizedTestClass.IntArg(0) passed",
+            "ParameterizedTestClass.IntArg(1) failed: Expected 0, but was 1",
+            "ParameterizedTestClass.IntArg failed: Exception thrown while attempting to yield input parameters for method: IntArg",
 
-                "ParameterizedTestClass.Sum(0) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.Sum(1) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.Sum failed: Exception thrown while attempting to yield input parameters for method: Sum",
+            "ParameterizedTestClass.Sum(0) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.Sum(1) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.Sum failed: Exception thrown while attempting to yield input parameters for method: Sum",
 
-                "ParameterizedTestClass.ZeroArgs(0) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.ZeroArgs(1) failed: Parameter count mismatch.",
-                "ParameterizedTestClass.ZeroArgs failed: Exception thrown while attempting to yield input parameters for method: ZeroArgs");
+            "ParameterizedTestClass.ZeroArgs(0) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.ZeroArgs(1) failed: Parameter count mismatch.",
+            "ParameterizedTestClass.ZeroArgs failed: Exception thrown while attempting to yield input parameters for method: ZeroArgs");
 
-            output.ShouldHaveLifecycle("IntArg", "IntArg");
-        }
+        output.ShouldHaveLifecycle("IntArg", "IntArg");
+    }
 
     public async Task ShouldFailWithGenericTestNameWhenGenericTypeParametersCannotBeResolved()
     {
-            var execution = new IsolatedParameterizedExecution(BuggyParameterSource);
-            var output = await Run<ConstrainedGenericTestClass>(execution);
+        var execution = new IsolatedParameterizedExecution(BuggyParameterSource);
+        var output = await Run<ConstrainedGenericTestClass>(execution);
 
-            output.ShouldHaveResults(
-                "ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(0) passed",
-                "ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
-                "ConstrainedGenericTestClass.ConstrainedGeneric<T> failed: Exception thrown while attempting to yield input parameters for method: ConstrainedGeneric",
-                "ConstrainedGenericTestClass.UnconstrainedGeneric<System.Int32>(0) passed",
-                "ConstrainedGenericTestClass.UnconstrainedGeneric<System.Int32>(1) passed",
-                "ConstrainedGenericTestClass.UnconstrainedGeneric<T> failed: Exception thrown while attempting to yield input parameters for method: UnconstrainedGeneric");
+        output.ShouldHaveResults(
+            "ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(0) passed",
+            "ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
+            "ConstrainedGenericTestClass.ConstrainedGeneric<T> failed: Exception thrown while attempting to yield input parameters for method: ConstrainedGeneric",
+            "ConstrainedGenericTestClass.UnconstrainedGeneric<System.Int32>(0) passed",
+            "ConstrainedGenericTestClass.UnconstrainedGeneric<System.Int32>(1) passed",
+            "ConstrainedGenericTestClass.UnconstrainedGeneric<T> failed: Exception thrown while attempting to yield input parameters for method: UnconstrainedGeneric");
 
-            output.ShouldHaveLifecycle(
-                "ConstrainedGeneric", "ConstrainedGeneric",
-                "UnconstrainedGeneric", "UnconstrainedGeneric");
-        }
+        output.ShouldHaveLifecycle(
+            "ConstrainedGeneric", "ConstrainedGeneric",
+            "UnconstrainedGeneric", "UnconstrainedGeneric");
+    }
 
     public async Task ShouldResolveGenericTypeParameters()
     {
-            var execution = new IsolatedParameterizedExecution(InputAttributeOrDefaultParameterSource);
-            var output = await Run<GenericTestClass>(execution);
+        var execution = new IsolatedParameterizedExecution(InputAttributeOrDefaultParameterSource);
+        var output = await Run<GenericTestClass>(execution);
 
-            output.ShouldHaveResults(
-                "GenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
-                "GenericTestClass.ConstrainedGeneric<T>(\"Oops\") failed: The type parameters for generic method ConstrainedGeneric could not be resolved.",
+        output.ShouldHaveResults(
+            "GenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
+            "GenericTestClass.ConstrainedGeneric<T>(\"Oops\") failed: The type parameters for generic method ConstrainedGeneric could not be resolved.",
 
-                "GenericTestClass.ConstrainedGenericMethodWithNoInputsProvided<T> failed: Cannot create an instance of T because Type.ContainsGenericParameters is true.",
+            "GenericTestClass.ConstrainedGenericMethodWithNoInputsProvided<T> failed: Cannot create an instance of T because Type.ContainsGenericParameters is true.",
 
-                "GenericTestClass.GenericMethodWithIncorrectParameterCountProvided<System.Int32>(123, 123) failed: Parameter count mismatch.",
+            "GenericTestClass.GenericMethodWithIncorrectParameterCountProvided<System.Int32>(123, 123) failed: Parameter count mismatch.",
 
-                "GenericTestClass.GenericMethodWithNoInputsProvided<T>(null) failed: The type parameters for generic method GenericMethodWithNoInputsProvided could not be resolved.",
+            "GenericTestClass.GenericMethodWithNoInputsProvided<T>(null) failed: The type parameters for generic method GenericMethodWithNoInputsProvided could not be resolved.",
 
-                "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(123, null, 456, System.Int32, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
-                "GenericTestClass.MultipleGenericArgumentsMultipleParameters<System.Int32, System.String>(123, \"stringArg1\", 456, System.Int32, System.String) passed",
-                "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg\", null, null, System.String, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
-                "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg1\", null, \"stringArg2\", System.String, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
-                "GenericTestClass.MultipleGenericArgumentsMultipleParameters<System.String, System.String>(null, \"stringArg1\", \"stringArg2\", System.String, System.String) passed",
+            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(123, null, 456, System.Int32, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
+            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<System.Int32, System.String>(123, \"stringArg1\", 456, System.Int32, System.String) passed",
+            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg\", null, null, System.String, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
+            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg1\", null, \"stringArg2\", System.String, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
+            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<System.String, System.String>(null, \"stringArg1\", \"stringArg2\", System.String, System.String) passed",
 
-                "GenericTestClass.SingleGenericArgument<System.Int32>(123, System.Int32) passed",
-                "GenericTestClass.SingleGenericArgument<T>(null, System.Object) failed: The type parameters for generic method SingleGenericArgument could not be resolved.",
-                "GenericTestClass.SingleGenericArgument<System.String>(\"stringArg\", System.String) passed",
+            "GenericTestClass.SingleGenericArgument<System.Int32>(123, System.Int32) passed",
+            "GenericTestClass.SingleGenericArgument<T>(null, System.Object) failed: The type parameters for generic method SingleGenericArgument could not be resolved.",
+            "GenericTestClass.SingleGenericArgument<System.String>(\"stringArg\", System.String) passed",
 
-                "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, 456, System.Int32) passed",
-                "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", 123, System.Object) failed: Object of type 'System.Int32' cannot be converted to type 'System.String'.",
-                "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, \"stringArg\", System.Object) failed: Object of type 'System.String' cannot be converted to type 'System.Int32'.",
-                "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, null, System.Int32) passed", //MethodInfo.Invoke converts nulls to default(T) for value types.
-                "GenericTestClass.SingleGenericArgumentMultipleParameters<T>(null, null, System.Object) failed: The type parameters for generic method SingleGenericArgumentMultipleParameters could not be resolved.",
-                "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", null, System.String) passed",
-                "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg1\", \"stringArg2\", System.String) passed",
-                "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(null, \"stringArg\", System.String) passed");
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, 456, System.Int32) passed",
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", 123, System.Object) failed: Object of type 'System.Int32' cannot be converted to type 'System.String'.",
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, \"stringArg\", System.Object) failed: Object of type 'System.String' cannot be converted to type 'System.Int32'.",
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, null, System.Int32) passed", //MethodInfo.Invoke converts nulls to default(T) for value types.
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<T>(null, null, System.Object) failed: The type parameters for generic method SingleGenericArgumentMultipleParameters could not be resolved.",
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", null, System.String) passed",
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg1\", \"stringArg2\", System.String) passed",
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(null, \"stringArg\", System.String) passed");
 
-            output.ShouldHaveLifecycle(
-                "ConstrainedGeneric",
+        output.ShouldHaveLifecycle(
+            "ConstrainedGeneric",
 
-                "MultipleGenericArgumentsMultipleParameters",
-                "MultipleGenericArgumentsMultipleParameters",
+            "MultipleGenericArgumentsMultipleParameters",
+            "MultipleGenericArgumentsMultipleParameters",
 
-                "SingleGenericArgument",
-                "SingleGenericArgument",
+            "SingleGenericArgument",
+            "SingleGenericArgument",
 
-                "SingleGenericArgumentMultipleParameters",
-                "SingleGenericArgumentMultipleParameters",
-                "SingleGenericArgumentMultipleParameters",
-                "SingleGenericArgumentMultipleParameters",
-                "SingleGenericArgumentMultipleParameters");
-        }
+            "SingleGenericArgumentMultipleParameters",
+            "SingleGenericArgumentMultipleParameters",
+            "SingleGenericArgumentMultipleParameters",
+            "SingleGenericArgumentMultipleParameters",
+            "SingleGenericArgumentMultipleParameters");
+    }
 
     public async Task ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
     {
-            var execution = new ParameterizedExecution(ComplexGenericParameterSource);
-            var output = await Run<ComplexGenericTestClass>(execution);
+        var execution = new ParameterizedExecution(ComplexGenericParameterSource);
+        var output = await Run<ComplexGenericTestClass>(execution);
 
-            output.ShouldHaveResults(
-                "ComplexGenericTestClass.CompoundGenericParameter<System.Int32, System.String>([1, A], \"System.Int32\", \"System.String\") passed",
-                "ComplexGenericTestClass.CompoundGenericParameter<System.String, System.Int32>([B, 2], \"System.String\", \"System.Int32\") passed",
+        output.ShouldHaveResults(
+            "ComplexGenericTestClass.CompoundGenericParameter<System.Int32, System.String>([1, A], \"System.Int32\", \"System.String\") passed",
+            "ComplexGenericTestClass.CompoundGenericParameter<System.String, System.Int32>([B, 2], \"System.String\", \"System.Int32\") passed",
 
-                "ComplexGenericTestClass.GenericFuncParameter<System.Int32>(5, System.Func`2[System.Int32,System.Int32], 10) passed",
-                "ComplexGenericTestClass.GenericFuncParameter<System.String>(5, System.Func`2[System.Int32,System.String], \"5\") passed",
+            "ComplexGenericTestClass.GenericFuncParameter<System.Int32>(5, System.Func`2[System.Int32,System.Int32], 10) passed",
+            "ComplexGenericTestClass.GenericFuncParameter<System.String>(5, System.Func`2[System.Int32,System.String], \"5\") passed",
 
-                "ComplexGenericTestClass.GenericFuncParameter<System.String>(5, System.Func`2[System.Int32,System.String], '5') failed: " +
-                "Object of type 'System.Char' cannot be converted to type 'System.String'.");
+            "ComplexGenericTestClass.GenericFuncParameter<System.String>(5, System.Func`2[System.Int32,System.String], '5') failed: " +
+            "Object of type 'System.Char' cannot be converted to type 'System.String'.");
 
-            output.ShouldHaveLifecycle(
-                "CompoundGenericParameter", "CompoundGenericParameter",
-                "GenericFuncParameter", "GenericFuncParameter");
-        }
+        output.ShouldHaveLifecycle(
+            "CompoundGenericParameter", "CompoundGenericParameter",
+            "GenericFuncParameter", "GenericFuncParameter");
+    }
 
     static IEnumerable<object?[]> InputAttributeOrDefaultParameterSource(Test test)
     {
-            var attributes = test.GetAll<InputAttribute>();
+        var attributes = test.GetAll<InputAttribute>();
 
-            if (attributes.Any())
-            {
-                foreach (var input in attributes)
-                    yield return input.Parameters;
-            }
-            else
-            {
-                yield return test.Parameters.Select(p => Default(p.ParameterType)).ToArray();
-            }
+        if (attributes.Any())
+        {
+            foreach (var input in attributes)
+                yield return input.Parameters;
         }
+        else
+        {
+            yield return test.Parameters.Select(p => Default(p.ParameterType)).ToArray();
+        }
+    }
 
     static IEnumerable<object[]> BuggyParameterSource(Test test)
     {
-            yield return new object[] { 0 };
-            yield return new object[] { 1 };
-            throw new Exception("Exception thrown while attempting to yield input parameters for method: " + test.Method.Name);
-        }
+        yield return new object[] { 0 };
+        yield return new object[] { 1 };
+        throw new Exception("Exception thrown while attempting to yield input parameters for method: " + test.Method.Name);
+    }
 
     static IEnumerable<object[]> ComplexGenericParameterSource(Test test)
     {
-            if (test.Name.EndsWith(".CompoundGenericParameter"))
-            {
-                yield return new object[] {new KeyValuePair<int, string>(1, "A"), "System.Int32", "System.String"};
-                yield return new object[] {new KeyValuePair<string, int>("B", 2), "System.String", "System.Int32"};
-            }
-            else if (test.Name.EndsWith(".GenericFuncParameter"))
-            {
-                yield return new object[] {5, new Func<int, int>(i => i * 2), 10};
-                yield return new object[] {5, new Func<int, string>(i => i.ToString()), "5"};
-                yield return new object[] {5, new Func<int, string>(i => i.ToString()), '5'};
-            }
+        if (test.Name.EndsWith(".CompoundGenericParameter"))
+        {
+            yield return new object[] {new KeyValuePair<int, string>(1, "A"), "System.Int32", "System.String"};
+            yield return new object[] {new KeyValuePair<string, int>("B", 2), "System.String", "System.Int32"};
         }
+        else if (test.Name.EndsWith(".GenericFuncParameter"))
+        {
+            yield return new object[] {5, new Func<int, int>(i => i * 2), 10};
+            yield return new object[] {5, new Func<int, string>(i => i.ToString()), "5"};
+            yield return new object[] {5, new Func<int, string>(i => i.ToString()), '5'};
+        }
+    }
 
     static object? Default(Type type)
     {
-            return type.IsValueType ? Activator.CreateInstance(type) : null;
-        }
+        return type.IsValueType ? Activator.CreateInstance(type) : null;
+    }
 
     class ParameterizedTestClass
     {
         public void IntArg(int i)
         {
-                WhereAmI();
+            WhereAmI();
 
-                if (i != 0)
-                    throw new Exception("Expected 0, but was " + i);
-            }
+            if (i != 0)
+                throw new Exception("Expected 0, but was " + i);
+        }
 
         [Input(1, 1, 2)]
         [Input(1, 2, 3)]
         [Input(5, 5, 11)]
         public void Sum(int a, int b, int expectedSum)
         {
-                WhereAmI();
+            WhereAmI();
 
-                if (a + b != expectedSum)
-                    throw new Exception($"Expected sum of {expectedSum} but was {a + b}.");
-            }
+            if (a + b != expectedSum)
+                throw new Exception($"Expected sum of {expectedSum} but was {a + b}.");
+        }
 
         public void ZeroArgs()
         {
-                WhereAmI();
-            }
+            WhereAmI();
+        }
     }
 
     class GenericTestClass
@@ -299,28 +299,28 @@ public class ParameterizationTests : InstrumentedExecutionTests
         [Input("Oops")]
         public void ConstrainedGeneric<T>(T input) where T : struct
         {
-                WhereAmI();
-                typeof(T).IsValueType.ShouldBe(true);
-            }
+            WhereAmI();
+            typeof(T).IsValueType.ShouldBe(true);
+        }
 
         public void ConstrainedGenericMethodWithNoInputsProvided<T>(T input) where T : struct
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
 
         [Input(123, 123)]
         public void GenericMethodWithIncorrectParameterCountProvided<T>(T genericArgument)
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
 
         public void GenericMethodWithNoInputsProvided<T>(T genericArgument)
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
 
         [Input(123, null, 456, typeof(int), typeof(object))]
         [Input(123, "stringArg1", 456, typeof(int), typeof(string))]
@@ -329,19 +329,19 @@ public class ParameterizationTests : InstrumentedExecutionTests
         [Input(null, "stringArg1", "stringArg2", typeof(string), typeof(string))]
         public void MultipleGenericArgumentsMultipleParameters<T1, T2>(T1 genericArgument1A, T2 genericArgument2, T1 genericArgument1B, Type expectedT1, Type expectedT2)
         {
-                WhereAmI();
-                typeof(T1).ShouldBe(expectedT1);
-                typeof(T2).ShouldBe(expectedT2);
-            }
+            WhereAmI();
+            typeof(T1).ShouldBe(expectedT1);
+            typeof(T2).ShouldBe(expectedT2);
+        }
 
         [Input(123, typeof(int))]
         [Input(null, typeof(object))]
         [Input("stringArg", typeof(string))]
         public void SingleGenericArgument<T>(T genericArgument, Type expectedT)
         {
-                WhereAmI();
-                typeof(T).ShouldBe(expectedT);
-            }
+            WhereAmI();
+            typeof(T).ShouldBe(expectedT);
+        }
 
         [Input(123, 456, typeof(int))]
         [Input("stringArg", 123, typeof(object))]
@@ -353,46 +353,46 @@ public class ParameterizationTests : InstrumentedExecutionTests
         [Input(null, "stringArg", typeof(string))]
         public void SingleGenericArgumentMultipleParameters<T>(T genericArgument1, T genericArgument2, Type expectedT)
         {
-                WhereAmI();
-                typeof(T).ShouldBe(expectedT);
-            }
+            WhereAmI();
+            typeof(T).ShouldBe(expectedT);
+        }
 
         static string Format(object? obj)
         {
-                return obj?.ToString() ?? "[null]";
-            }
+            return obj?.ToString() ?? "[null]";
+        }
     }
 
     class ComplexGenericTestClass
     {
         public void CompoundGenericParameter<TKey, TValue>(KeyValuePair<TKey, TValue> pair, string expectedKeyType, string expectedValueType)
         {
-                WhereAmI();
-                typeof(TKey).FullName.ShouldBe(expectedKeyType);
-                typeof(TValue).FullName.ShouldBe(expectedValueType);
-            }
+            WhereAmI();
+            typeof(TKey).FullName.ShouldBe(expectedKeyType);
+            typeof(TValue).FullName.ShouldBe(expectedValueType);
+        }
 
         public void GenericFuncParameter<TResult>(int input, Func<int, TResult> transform, TResult expectedResult)
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = transform(input);
+            var result = transform(input);
 
-                result.ShouldBe(expectedResult);
-            }
+            result.ShouldBe(expectedResult);
+        }
     }
 
     class ConstrainedGenericTestClass
     {
         public void ConstrainedGeneric<T>(T input) where T : struct
         {
-                WhereAmI();
-                typeof(T).IsValueType.ShouldBe(true);
-            }
+            WhereAmI();
+            typeof(T).IsValueType.ShouldBe(true);
+        }
 
         public void UnconstrainedGeneric<T>(T input)
         {
-                WhereAmI();
-            }
+            WhereAmI();
+        }
     }
 }

--- a/src/Fixie.Tests/RedirectedConsole.cs
+++ b/src/Fixie.Tests/RedirectedConsole.cs
@@ -1,26 +1,25 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+using System;
+using System.IO;
+
+class RedirectedConsole : IDisposable
 {
-    using System;
-    using System.IO;
+    readonly TextWriter original;
+    readonly StringWriter console;
 
-    class RedirectedConsole : IDisposable
+    public RedirectedConsole()
     {
-        readonly TextWriter original;
-        readonly StringWriter console;
+        console = new StringWriter();
+        original = System.Console.Out;
+        System.Console.SetOut(console);
+    }
 
-        public RedirectedConsole()
-        {
-            console = new StringWriter();
-            original = System.Console.Out;
-            System.Console.SetOut(console);
-        }
+    public string Output => console.ToString();
 
-        public string Output => console.ToString();
-
-        public void Dispose()
-        {
-            System.Console.SetOut(original);
-            console.Dispose();
-        }
+    public void Dispose()
+    {
+        System.Console.SetOut(original);
+        console.Dispose();
     }
 }

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -8,47 +8,47 @@ public class ReflectionExtensionsTests
 {
     public void CanDetectStaticTypes()
     {
-            typeof(StaticClass).IsStatic().ShouldBe(true);
-            typeof(AbstractClass).IsStatic().ShouldBe(false);
-            typeof(ConcreteClass).IsStatic().ShouldBe(false);
-            typeof(SealedConcreteClass).IsStatic().ShouldBe(false);
-        }
+        typeof(StaticClass).IsStatic().ShouldBe(true);
+        typeof(AbstractClass).IsStatic().ShouldBe(false);
+        typeof(ConcreteClass).IsStatic().ShouldBe(false);
+        typeof(SealedConcreteClass).IsStatic().ShouldBe(false);
+    }
 
     public void CanDetectAttributes()
     {
-            typeof(AttributeSample).Has<InheritedAttribute>().ShouldBe(true);
-            typeof(AttributeSample).Has<NonInheritedAttribute>().ShouldBe(true);
-            typeof(AttributeSample).Has<AttributeUsageAttribute>().ShouldBe(false);
+        typeof(AttributeSample).Has<InheritedAttribute>().ShouldBe(true);
+        typeof(AttributeSample).Has<NonInheritedAttribute>().ShouldBe(true);
+        typeof(AttributeSample).Has<AttributeUsageAttribute>().ShouldBe(false);
 
-            Method<AttributeSample>("AttributeOnBaseDeclaration").Has<SampleMethodAttribute>().ShouldBe(true);
-            Method<AttributeSample>("AttributeOnOverrideDeclaration").Has<SampleMethodAttribute>().ShouldBe(true);
-            Method<AttributeSample>("NoAttribute").Has<SampleMethodAttribute>().ShouldBe(false);
-        }
+        Method<AttributeSample>("AttributeOnBaseDeclaration").Has<SampleMethodAttribute>().ShouldBe(true);
+        Method<AttributeSample>("AttributeOnOverrideDeclaration").Has<SampleMethodAttribute>().ShouldBe(true);
+        Method<AttributeSample>("NoAttribute").Has<SampleMethodAttribute>().ShouldBe(false);
+    }
 
     public void CanDetectAndObtainAttributeWhenOneTimeUseAttributeIsPresent()
     {
-            //Zero Matches
-            var hasMissingAttribute =  typeof(AttributeSample).Has<AttributeUsageAttribute>(out var missingAttribute);
-            hasMissingAttribute.ShouldBe(false);
-            missingAttribute.ShouldBe(null);
+        //Zero Matches
+        var hasMissingAttribute =  typeof(AttributeSample).Has<AttributeUsageAttribute>(out var missingAttribute);
+        hasMissingAttribute.ShouldBe(false);
+        missingAttribute.ShouldBe(null);
 
-            //Single Match, Inherited
-            var hasInheritedAttribute = typeof(AttributeSample).Has<InheritedAttribute>(out var inheritedAttribute);
-            hasInheritedAttribute.ShouldBe(true);
-            inheritedAttribute.ShouldBe<InheritedAttribute>();
+        //Single Match, Inherited
+        var hasInheritedAttribute = typeof(AttributeSample).Has<InheritedAttribute>(out var inheritedAttribute);
+        hasInheritedAttribute.ShouldBe(true);
+        inheritedAttribute.ShouldBe<InheritedAttribute>();
 
-            //Single Match, Not Inherited
-            var hasNonInheritedAttribute = typeof(AttributeSample).Has<NonInheritedAttribute>(out var nonInheritedAttribute);
-            hasNonInheritedAttribute.ShouldBe(true);
-            nonInheritedAttribute.ShouldBe<NonInheritedAttribute>();
+        //Single Match, Not Inherited
+        var hasNonInheritedAttribute = typeof(AttributeSample).Has<NonInheritedAttribute>(out var nonInheritedAttribute);
+        hasNonInheritedAttribute.ShouldBe(true);
+        nonInheritedAttribute.ShouldBe<NonInheritedAttribute>();
 
-            //Ambiguous Match
-            Action attemptAmbiguousAttributeLookup = () => typeof(AttributeSample).Has<AmbiguouslyMultipleAttribute>(out _);
-            
-            var expectedExceptionMessage = "Multiple custom attributes of the same type 'Fixie.Tests.ReflectionExtensionsTests+AmbiguouslyMultipleAttribute' found.";
+        //Ambiguous Match
+        Action attemptAmbiguousAttributeLookup = () => typeof(AttributeSample).Has<AmbiguouslyMultipleAttribute>(out _);
+        
+        var expectedExceptionMessage = "Multiple custom attributes of the same type 'Fixie.Tests.ReflectionExtensionsTests+AmbiguouslyMultipleAttribute' found.";
 
-            attemptAmbiguousAttributeLookup.ShouldThrow<AmbiguousMatchException>(expectedExceptionMessage);
-        }
+        attemptAmbiguousAttributeLookup.ShouldThrow<AmbiguousMatchException>(expectedExceptionMessage);
+    }
 
     void ReturnsVoid() { }
     int ReturnsInt() { return 0; }

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -1,21 +1,21 @@
-﻿namespace Fixie.Tests
-{
-    using System;
-    using System.Reflection;
-    using Assertions;
+﻿namespace Fixie.Tests;
 
-    public class ReflectionExtensionsTests
+using System;
+using System.Reflection;
+using Assertions;
+
+public class ReflectionExtensionsTests
+{
+    public void CanDetectStaticTypes()
     {
-        public void CanDetectStaticTypes()
-        {
             typeof(StaticClass).IsStatic().ShouldBe(true);
             typeof(AbstractClass).IsStatic().ShouldBe(false);
             typeof(ConcreteClass).IsStatic().ShouldBe(false);
             typeof(SealedConcreteClass).IsStatic().ShouldBe(false);
         }
 
-        public void CanDetectAttributes()
-        {
+    public void CanDetectAttributes()
+    {
             typeof(AttributeSample).Has<InheritedAttribute>().ShouldBe(true);
             typeof(AttributeSample).Has<NonInheritedAttribute>().ShouldBe(true);
             typeof(AttributeSample).Has<AttributeUsageAttribute>().ShouldBe(false);
@@ -25,8 +25,8 @@
             Method<AttributeSample>("NoAttribute").Has<SampleMethodAttribute>().ShouldBe(false);
         }
 
-        public void CanDetectAndObtainAttributeWhenOneTimeUseAttributeIsPresent()
-        {
+    public void CanDetectAndObtainAttributeWhenOneTimeUseAttributeIsPresent()
+    {
             //Zero Matches
             var hasMissingAttribute =  typeof(AttributeSample).Has<AttributeUsageAttribute>(out var missingAttribute);
             hasMissingAttribute.ShouldBe(false);
@@ -50,45 +50,44 @@
             attemptAmbiguousAttributeLookup.ShouldThrow<AmbiguousMatchException>(expectedExceptionMessage);
         }
 
-        void ReturnsVoid() { }
-        int ReturnsInt() { return 0; }
+    void ReturnsVoid() { }
+    int ReturnsInt() { return 0; }
 
-        class SampleMethodAttribute : Attribute { }
-        class InheritedAttribute : Attribute { }
-        class NonInheritedAttribute : Attribute { }
+    class SampleMethodAttribute : Attribute { }
+    class InheritedAttribute : Attribute { }
+    class NonInheritedAttribute : Attribute { }
 
-        [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-        class AmbiguouslyMultipleAttribute : Attribute { }
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    class AmbiguouslyMultipleAttribute : Attribute { }
 
-        static class StaticClass { }
-        abstract class AbstractClass { }
-        class ConcreteClass { }
-        sealed class SealedConcreteClass { }
+    static class StaticClass { }
+    abstract class AbstractClass { }
+    class ConcreteClass { }
+    sealed class SealedConcreteClass { }
 
-        [Inherited]
-        [AmbiguouslyMultiple]
-        [AmbiguouslyMultiple]
-        abstract class AttributeSampleBase
-        {
-            [SampleMethod]
-            public virtual void AttributeOnBaseDeclaration() { }
-            public virtual void AttributeOnOverrideDeclaration() { }
-            public virtual void NoAttribute() { }
-        }
-
-        [NonInherited]
-        class AttributeSample : AttributeSampleBase
-        {
-            public override void AttributeOnBaseDeclaration() { }
-            [SampleMethod]
-            public override void AttributeOnOverrideDeclaration() { }
-            public override void NoAttribute() { }
-        }
-
-        static MethodInfo Method(string name)
-            => Method<ReflectionExtensionsTests>(name);
-
-        static MethodInfo Method<T>(string name)
-            => typeof(T).GetInstanceMethod(name);
+    [Inherited]
+    [AmbiguouslyMultiple]
+    [AmbiguouslyMultiple]
+    abstract class AttributeSampleBase
+    {
+        [SampleMethod]
+        public virtual void AttributeOnBaseDeclaration() { }
+        public virtual void AttributeOnOverrideDeclaration() { }
+        public virtual void NoAttribute() { }
     }
+
+    [NonInherited]
+    class AttributeSample : AttributeSampleBase
+    {
+        public override void AttributeOnBaseDeclaration() { }
+        [SampleMethod]
+        public override void AttributeOnOverrideDeclaration() { }
+        public override void NoAttribute() { }
+    }
+
+    static MethodInfo Method(string name)
+        => Method<ReflectionExtensionsTests>(name);
+
+    static MethodInfo Method<T>(string name)
+        => typeof(T).GetInstanceMethod(name);
 }

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -1,15 +1,15 @@
-﻿namespace Fixie.Tests.Reports
-{
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
-    using static Utility;
+﻿namespace Fixie.Tests.Reports;
 
-    public class AppVeyorReportTests : MessagingTests
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+using static Utility;
+
+public class AppVeyorReportTests : MessagingTests
+{
+    public async Task ShouldReportResultsToAppVeyorBuildWorkerApi()
     {
-        public async Task ShouldReportResultsToAppVeyorBuildWorkerApi()
-        {
             var results = new List<AppVeyorReport.Result>();
 
             var report = new AppVeyorReport(GetTestEnvironment(), "http://localhost:4567", (uri, content) =>
@@ -105,5 +105,4 @@
                 .ShouldBe("Fixie.Tests.Assertions.AssertException", At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
             shouldBeStringFail.StdOut.ShouldBe("");
         }
-    }
 }

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -10,99 +10,99 @@ public class AppVeyorReportTests : MessagingTests
 {
     public async Task ShouldReportResultsToAppVeyorBuildWorkerApi()
     {
-            var results = new List<AppVeyorReport.Result>();
+        var results = new List<AppVeyorReport.Result>();
 
-            var report = new AppVeyorReport(GetTestEnvironment(), "http://localhost:4567", (uri, content) =>
-            {
-                uri.ShouldBe("http://localhost:4567/api/tests");
-                results.Add(content);
-                return Task.CompletedTask;
-            });
+        var report = new AppVeyorReport(GetTestEnvironment(), "http://localhost:4567", (uri, content) =>
+        {
+            uri.ShouldBe("http://localhost:4567/api/tests");
+            results.Add(content);
+            return Task.CompletedTask;
+        });
 
-            var output = await Run(report);
+        var output = await Run(report);
 
-            output.Console
-                .ShouldBe(
-                    "Standard Out: Fail",
-                    "Standard Out: FailByAssertion",
-                    "Standard Out: Pass");
+        output.Console
+            .ShouldBe(
+                "Standard Out: Fail",
+                "Standard Out: FailByAssertion",
+                "Standard Out: Pass");
 
-            results.Count.ShouldBe(7);
+        results.Count.ShouldBe(7);
 
-            foreach (var result in results)
-            {
-                result.TestFramework.ShouldBe("Fixie");
-                result.FileName.ShouldBe($"Fixie.Tests (.NETCoreApp,Version=v{TargetFrameworkVersion})");
-            }
-
-            var fail = results[0];
-            var failByAssertion = results[1];
-            var pass = results[2];
-            var skip = results[3];
-            var shouldBeStringPassA = results[4];
-            var shouldBeStringPassB = results[5];
-            var shouldBeStringFail = results[6];
-
-            fail.TestName.ShouldBe(TestClass + ".Fail");
-            fail.Outcome.ShouldBe("Failed");
-            int.Parse(fail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            fail.ErrorMessage.ShouldBe("'Fail' failed!");
-            fail.ErrorStackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
-            fail.StdOut.Lines().ShouldBe("Standard Out: Fail");
-
-            failByAssertion.TestName.ShouldBe(TestClass + ".FailByAssertion");
-            failByAssertion.Outcome.ShouldBe("Failed");
-            int.Parse(failByAssertion.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            failByAssertion.ErrorMessage.Lines().ShouldBe(
-                "Expected: 2",
-                "Actual:   1");
-            failByAssertion.ErrorStackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
-            failByAssertion.StdOut.Lines().ShouldBe("Standard Out: FailByAssertion");
-
-            pass.TestName.ShouldBe(TestClass + ".Pass");
-            pass.Outcome.ShouldBe("Passed");
-            int.Parse(pass.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            pass.ErrorMessage.ShouldBe(null);
-            pass.ErrorStackTrace.ShouldBe(null);
-            pass.StdOut.Lines().ShouldBe("Standard Out: Pass");
-
-            skip.TestName.ShouldBe(TestClass + ".Skip");
-            skip.Outcome.ShouldBe("Skipped");
-            int.Parse(skip.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            skip.ErrorMessage.ShouldBe("⚠ Skipped with attribute.");
-            skip.ErrorStackTrace.ShouldBe(null);
-            skip.StdOut.ShouldBe("");
-
-            shouldBeStringPassA.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
-            shouldBeStringPassA.Outcome.ShouldBe("Passed");
-            int.Parse(shouldBeStringPassA.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            shouldBeStringPassA.ErrorMessage.ShouldBe(null);
-            shouldBeStringPassA.ErrorStackTrace.ShouldBe(null);
-            shouldBeStringPassA.StdOut.ShouldBe("");
-
-            shouldBeStringPassB.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
-            shouldBeStringPassB.Outcome.ShouldBe("Passed");
-            int.Parse(shouldBeStringPassB.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            shouldBeStringPassB.ErrorMessage.ShouldBe(null);
-            shouldBeStringPassB.ErrorStackTrace.ShouldBe(null);
-            shouldBeStringPassB.StdOut.ShouldBe("");
-
-            shouldBeStringFail.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
-            shouldBeStringFail.Outcome.ShouldBe("Failed");
-            int.Parse(shouldBeStringFail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-            shouldBeStringFail.ErrorMessage.Lines().ShouldBe(
-                "Expected: System.String",
-                "Actual:   System.Int32");
-            shouldBeStringFail.ErrorStackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe("Fixie.Tests.Assertions.AssertException", At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
-            shouldBeStringFail.StdOut.ShouldBe("");
+        foreach (var result in results)
+        {
+            result.TestFramework.ShouldBe("Fixie");
+            result.FileName.ShouldBe($"Fixie.Tests (.NETCoreApp,Version=v{TargetFrameworkVersion})");
         }
+
+        var fail = results[0];
+        var failByAssertion = results[1];
+        var pass = results[2];
+        var skip = results[3];
+        var shouldBeStringPassA = results[4];
+        var shouldBeStringPassB = results[5];
+        var shouldBeStringFail = results[6];
+
+        fail.TestName.ShouldBe(TestClass + ".Fail");
+        fail.Outcome.ShouldBe("Failed");
+        int.Parse(fail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        fail.ErrorMessage.ShouldBe("'Fail' failed!");
+        fail.ErrorStackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
+        fail.StdOut.Lines().ShouldBe("Standard Out: Fail");
+
+        failByAssertion.TestName.ShouldBe(TestClass + ".FailByAssertion");
+        failByAssertion.Outcome.ShouldBe("Failed");
+        int.Parse(failByAssertion.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        failByAssertion.ErrorMessage.Lines().ShouldBe(
+            "Expected: 2",
+            "Actual:   1");
+        failByAssertion.ErrorStackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
+        failByAssertion.StdOut.Lines().ShouldBe("Standard Out: FailByAssertion");
+
+        pass.TestName.ShouldBe(TestClass + ".Pass");
+        pass.Outcome.ShouldBe("Passed");
+        int.Parse(pass.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        pass.ErrorMessage.ShouldBe(null);
+        pass.ErrorStackTrace.ShouldBe(null);
+        pass.StdOut.Lines().ShouldBe("Standard Out: Pass");
+
+        skip.TestName.ShouldBe(TestClass + ".Skip");
+        skip.Outcome.ShouldBe("Skipped");
+        int.Parse(skip.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        skip.ErrorMessage.ShouldBe("⚠ Skipped with attribute.");
+        skip.ErrorStackTrace.ShouldBe(null);
+        skip.StdOut.ShouldBe("");
+
+        shouldBeStringPassA.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
+        shouldBeStringPassA.Outcome.ShouldBe("Passed");
+        int.Parse(shouldBeStringPassA.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringPassA.ErrorMessage.ShouldBe(null);
+        shouldBeStringPassA.ErrorStackTrace.ShouldBe(null);
+        shouldBeStringPassA.StdOut.ShouldBe("");
+
+        shouldBeStringPassB.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
+        shouldBeStringPassB.Outcome.ShouldBe("Passed");
+        int.Parse(shouldBeStringPassB.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringPassB.ErrorMessage.ShouldBe(null);
+        shouldBeStringPassB.ErrorStackTrace.ShouldBe(null);
+        shouldBeStringPassB.StdOut.ShouldBe("");
+
+        shouldBeStringFail.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
+        shouldBeStringFail.Outcome.ShouldBe("Failed");
+        int.Parse(shouldBeStringFail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringFail.ErrorMessage.Lines().ShouldBe(
+            "Expected: System.String",
+            "Actual:   System.Int32");
+        shouldBeStringFail.ErrorStackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe("Fixie.Tests.Assertions.AssertException", At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
+        shouldBeStringFail.StdOut.ShouldBe("");
+    }
 }

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -16,10 +16,10 @@ public class AzureReportTests : MessagingTests
     {
         public Request(HttpMethod method, string uri, TContent content)
         {
-                Method = method;
-                Uri = uri;
-                Content = content;
-            }
+            Method = method;
+            Uri = uri;
+            Content = content;
+        }
 
         public HttpMethod Method { get; }
         public string Uri { get; }
@@ -28,157 +28,157 @@ public class AzureReportTests : MessagingTests
 
     public async Task ShouldReportResultsToAzureDevOpsApi()
     {
-            var project = Guid.NewGuid().ToString();
-            var accessToken = Guid.NewGuid().ToString();
-            var buildId = Guid.NewGuid().ToString();
-            var runUrl = "http://localhost:4567/run/" + Guid.NewGuid();
-            var requests = new List<object>();
-            var batchSize = 3;
+        var project = Guid.NewGuid().ToString();
+        var accessToken = Guid.NewGuid().ToString();
+        var buildId = Guid.NewGuid().ToString();
+        var runUrl = "http://localhost:4567/run/" + Guid.NewGuid();
+        var requests = new List<object>();
+        var batchSize = 3;
 
-            Action<HttpClient> assertCommonHttpConcerns = client =>
-            {
-                var actualHeader = client.DefaultRequestHeaders.Accept.Single();
-                actualHeader.MediaType.ShouldBe("application/json");
+        Action<HttpClient> assertCommonHttpConcerns = client =>
+        {
+            var actualHeader = client.DefaultRequestHeaders.Accept.Single();
+            actualHeader.MediaType.ShouldBe("application/json");
 
-                var actualAuthorization = client.DefaultRequestHeaders.Authorization;
-                actualAuthorization.ShouldNotBeNull();
-                actualAuthorization.Scheme.ShouldBe("Bearer");
-                actualAuthorization.Parameter.ShouldBe(accessToken);
-            };
+            var actualAuthorization = client.DefaultRequestHeaders.Authorization;
+            actualAuthorization.ShouldNotBeNull();
+            actualAuthorization.Scheme.ShouldBe("Bearer");
+            actualAuthorization.Parameter.ShouldBe(accessToken);
+        };
 
-            var output = await Run(environment =>
-                new AzureReport(environment, "http://localhost:4567", project, accessToken, buildId,
-                    (client, method, uri, content) =>
-                    {
-                        assertCommonHttpConcerns(client);
-                        requests.Add(new Request<AzureReport.CreateRun>(method, uri, content));
-                        return Task.FromResult(Serialize(new AzureReport.TestRun {url = runUrl}));
-                    },
-                    (client, method, uri, content) =>
-                    {
-                        assertCommonHttpConcerns(client);
-                        requests.Add(new Request<IReadOnlyList<AzureReport.Result>>(method, uri, content));
-                        return Task.FromResult("");
-                    },
-                    (client, method, uri, content) =>
-                    {
-                        assertCommonHttpConcerns(client);
-                        requests.Add(new Request<AzureReport.CompleteRun>(method, uri, content));
-                        return Task.FromResult("");
-                    }, batchSize));
-
-            output.Console
-                .ShouldBe(
-                    "Standard Out: Fail",
-                    "Standard Out: FailByAssertion",
-                    "Standard Out: Pass");
-
-            var firstRequest = (Request<AzureReport.CreateRun>)requests.First();
-            firstRequest.Method.ShouldBe(HttpMethod.Post);
-            firstRequest.Uri.ShouldBe($"http://localhost:4567/{project}/_apis/test/runs?api-version=5.0");
-
-            var createRun = firstRequest.Content;
-            createRun.name.ShouldBe($"Fixie.Tests (.NETCoreApp,Version=v{TargetFrameworkVersion})");
-            createRun.build.id.ShouldBe(buildId);
-            createRun.isAutomated.ShouldBe(true);
-
-            var resultBatches = requests
-                .Skip(1)
-                .Take(requests.Count - 2)
-                .Cast<Request<IReadOnlyList<AzureReport.Result>>>()
-                .Select(request =>
+        var output = await Run(environment =>
+            new AzureReport(environment, "http://localhost:4567", project, accessToken, buildId,
+                (client, method, uri, content) =>
                 {
-                    request.Method.ShouldBe(HttpMethod.Post);
-                    request.Uri.ShouldBe($"{runUrl}/results?api-version=5.0");
+                    assertCommonHttpConcerns(client);
+                    requests.Add(new Request<AzureReport.CreateRun>(method, uri, content));
+                    return Task.FromResult(Serialize(new AzureReport.TestRun {url = runUrl}));
+                },
+                (client, method, uri, content) =>
+                {
+                    assertCommonHttpConcerns(client);
+                    requests.Add(new Request<IReadOnlyList<AzureReport.Result>>(method, uri, content));
+                    return Task.FromResult("");
+                },
+                (client, method, uri, content) =>
+                {
+                    assertCommonHttpConcerns(client);
+                    requests.Add(new Request<AzureReport.CompleteRun>(method, uri, content));
+                    return Task.FromResult("");
+                }, batchSize));
 
-                    return request.Content;
-                }).ToList();
+        output.Console
+            .ShouldBe(
+                "Standard Out: Fail",
+                "Standard Out: FailByAssertion",
+                "Standard Out: Pass");
 
-            resultBatches.Count.ShouldBe(3);
-            resultBatches[0].Count.ShouldBe(3);
-            resultBatches[1].Count.ShouldBe(3);
-            resultBatches[2].Count.ShouldBe(1);
+        var firstRequest = (Request<AzureReport.CreateRun>)requests.First();
+        firstRequest.Method.ShouldBe(HttpMethod.Post);
+        firstRequest.Uri.ShouldBe($"http://localhost:4567/{project}/_apis/test/runs?api-version=5.0");
 
-            var results = resultBatches.SelectMany(x => x).ToList();
-            results.Count.ShouldBe(7);
+        var createRun = firstRequest.Content;
+        createRun.name.ShouldBe($"Fixie.Tests (.NETCoreApp,Version=v{TargetFrameworkVersion})");
+        createRun.build.id.ShouldBe(buildId);
+        createRun.isAutomated.ShouldBe(true);
 
-            var fail = results[0];
-            var failByAssertion = results[1];
-            var pass = results[2];
-            var skip = results[3];
-            var shouldBeStringPassA = results[4];
-            var shouldBeStringPassB = results[5];
-            var shouldBeStringFail = results[6];
+        var resultBatches = requests
+            .Skip(1)
+            .Take(requests.Count - 2)
+            .Cast<Request<IReadOnlyList<AzureReport.Result>>>()
+            .Select(request =>
+            {
+                request.Method.ShouldBe(HttpMethod.Post);
+                request.Uri.ShouldBe($"{runUrl}/results?api-version=5.0");
 
-            fail.automatedTestName.ShouldBe(TestClass + ".Fail");
-            fail.testCaseTitle.ShouldBe(TestClass + ".Fail");
-            fail.outcome.ShouldBe("Failed");
-            fail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-            fail.errorMessage.ShouldBe("'Fail' failed!");
-            fail.stackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
+                return request.Content;
+            }).ToList();
 
-            failByAssertion.automatedTestName.ShouldBe(TestClass + ".FailByAssertion");
-            failByAssertion.testCaseTitle.ShouldBe(TestClass + ".FailByAssertion");
-            failByAssertion.outcome.ShouldBe("Failed");
-            failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-            failByAssertion.errorMessage.Lines().ShouldBe(
-                "Expected: 2",
-                "Actual:   1");
-            failByAssertion.stackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
+        resultBatches.Count.ShouldBe(3);
+        resultBatches[0].Count.ShouldBe(3);
+        resultBatches[1].Count.ShouldBe(3);
+        resultBatches[2].Count.ShouldBe(1);
 
-            pass.automatedTestName.ShouldBe(TestClass + ".Pass");
-            pass.testCaseTitle.ShouldBe(TestClass + ".Pass");
-            pass.outcome.ShouldBe("Passed");
-            pass.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-            pass.errorMessage.ShouldBe(null);
-            pass.stackTrace.ShouldBe(null);
+        var results = resultBatches.SelectMany(x => x).ToList();
+        results.Count.ShouldBe(7);
 
-            skip.automatedTestName.ShouldBe(TestClass + ".Skip");
-            skip.testCaseTitle.ShouldBe(TestClass + ".Skip");
-            skip.outcome.ShouldBe("Warning");
-            skip.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-            skip.errorMessage.ShouldBe("⚠ Skipped with attribute.");
-            skip.stackTrace.ShouldBe(null);
+        var fail = results[0];
+        var failByAssertion = results[1];
+        var pass = results[2];
+        var skip = results[3];
+        var shouldBeStringPassA = results[4];
+        var shouldBeStringPassB = results[5];
+        var shouldBeStringFail = results[6];
 
-            shouldBeStringPassA.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
-            shouldBeStringPassA.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
-            shouldBeStringPassA.outcome.ShouldBe("Passed");
-            shouldBeStringPassA.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-            shouldBeStringPassA.errorMessage.ShouldBe(null);
-            shouldBeStringPassA.stackTrace.ShouldBe(null);
+        fail.automatedTestName.ShouldBe(TestClass + ".Fail");
+        fail.testCaseTitle.ShouldBe(TestClass + ".Fail");
+        fail.outcome.ShouldBe("Failed");
+        fail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        fail.errorMessage.ShouldBe("'Fail' failed!");
+        fail.stackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
 
-            shouldBeStringPassB.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
-            shouldBeStringPassB.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
-            shouldBeStringPassB.outcome.ShouldBe("Passed");
-            shouldBeStringPassB.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-            shouldBeStringPassB.errorMessage.ShouldBe(null);
-            shouldBeStringPassB.stackTrace.ShouldBe(null);
+        failByAssertion.automatedTestName.ShouldBe(TestClass + ".FailByAssertion");
+        failByAssertion.testCaseTitle.ShouldBe(TestClass + ".FailByAssertion");
+        failByAssertion.outcome.ShouldBe("Failed");
+        failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        failByAssertion.errorMessage.Lines().ShouldBe(
+            "Expected: 2",
+            "Actual:   1");
+        failByAssertion.stackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
 
-            shouldBeStringFail.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
-            shouldBeStringFail.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
-            shouldBeStringFail.outcome.ShouldBe("Failed");
-            shouldBeStringFail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-            shouldBeStringFail.errorMessage.Lines().ShouldBe(
-                "Expected: System.String",
-                "Actual:   System.Int32");
-            shouldBeStringFail.stackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe(
-                    "Fixie.Tests.Assertions.AssertException",
-                    At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
+        pass.automatedTestName.ShouldBe(TestClass + ".Pass");
+        pass.testCaseTitle.ShouldBe(TestClass + ".Pass");
+        pass.outcome.ShouldBe("Passed");
+        pass.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        pass.errorMessage.ShouldBe(null);
+        pass.stackTrace.ShouldBe(null);
 
-            var lastRequest = (Request<AzureReport.CompleteRun>)requests.Last();
-            lastRequest.Method.ShouldBe(new HttpMethod("PATCH"));
-            lastRequest.Uri.ShouldBe($"{runUrl}?api-version=5.0");
+        skip.automatedTestName.ShouldBe(TestClass + ".Skip");
+        skip.testCaseTitle.ShouldBe(TestClass + ".Skip");
+        skip.outcome.ShouldBe("Warning");
+        skip.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        skip.errorMessage.ShouldBe("⚠ Skipped with attribute.");
+        skip.stackTrace.ShouldBe(null);
 
-            var updateRun = lastRequest.Content;
-            updateRun.state.ShouldBe("Completed");
-        }
+        shouldBeStringPassA.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
+        shouldBeStringPassA.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
+        shouldBeStringPassA.outcome.ShouldBe("Passed");
+        shouldBeStringPassA.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringPassA.errorMessage.ShouldBe(null);
+        shouldBeStringPassA.stackTrace.ShouldBe(null);
+
+        shouldBeStringPassB.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
+        shouldBeStringPassB.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
+        shouldBeStringPassB.outcome.ShouldBe("Passed");
+        shouldBeStringPassB.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringPassB.errorMessage.ShouldBe(null);
+        shouldBeStringPassB.stackTrace.ShouldBe(null);
+
+        shouldBeStringFail.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
+        shouldBeStringFail.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
+        shouldBeStringFail.outcome.ShouldBe("Failed");
+        shouldBeStringFail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringFail.errorMessage.Lines().ShouldBe(
+            "Expected: System.String",
+            "Actual:   System.Int32");
+        shouldBeStringFail.stackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe(
+                "Fixie.Tests.Assertions.AssertException",
+                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
+
+        var lastRequest = (Request<AzureReport.CompleteRun>)requests.Last();
+        lastRequest.Method.ShouldBe(new HttpMethod("PATCH"));
+        lastRequest.Uri.ShouldBe($"{runUrl}?api-version=5.0");
+
+        var updateRun = lastRequest.Content;
+        updateRun.state.ShouldBe("Completed");
+    }
 }

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -1,33 +1,33 @@
-﻿namespace Fixie.Tests.Reports
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Net.Http;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
-    using static Utility;
-    using static System.Text.Json.JsonSerializer;
+﻿namespace Fixie.Tests.Reports;
 
-    public class AzureReportTests : MessagingTests
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+using static Utility;
+using static System.Text.Json.JsonSerializer;
+
+public class AzureReportTests : MessagingTests
+{
+    class Request<TContent>
     {
-        class Request<TContent>
+        public Request(HttpMethod method, string uri, TContent content)
         {
-            public Request(HttpMethod method, string uri, TContent content)
-            {
                 Method = method;
                 Uri = uri;
                 Content = content;
             }
 
-            public HttpMethod Method { get; }
-            public string Uri { get; }
-            public TContent Content { get; }
-        }
+        public HttpMethod Method { get; }
+        public string Uri { get; }
+        public TContent Content { get; }
+    }
 
-        public async Task ShouldReportResultsToAzureDevOpsApi()
-        {
+    public async Task ShouldReportResultsToAzureDevOpsApi()
+    {
             var project = Guid.NewGuid().ToString();
             var accessToken = Guid.NewGuid().ToString();
             var buildId = Guid.NewGuid().ToString();
@@ -181,5 +181,4 @@
             var updateRun = lastRequest.Content;
             updateRun.state.ShouldBe("Completed");
         }
-    }
 }

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -11,99 +11,99 @@ public class ConsoleReportTests : MessagingTests
 {
     public async Task ShouldReportResults()
     {
-            var output = await Run(environment => new ConsoleReport(environment));
+        var output = await Run(environment => new ConsoleReport(environment));
 
-            output.Console
-                .NormalizeStackTraceLines()
-                .CleanDuration()
-                .ShouldBe(
-                    "Standard Out: Fail",
-                    "Test '" + TestClass + ".Fail' failed:",
-                    "",
-                    "'Fail' failed!",
-                    "",
-                    "Fixie.Tests.FailureException",
-                    At("Fail()"),
-                    "",
+        output.Console
+            .NormalizeStackTraceLines()
+            .CleanDuration()
+            .ShouldBe(
+                "Standard Out: Fail",
+                "Test '" + TestClass + ".Fail' failed:",
+                "",
+                "'Fail' failed!",
+                "",
+                "Fixie.Tests.FailureException",
+                At("Fail()"),
+                "",
 
-                    "Standard Out: FailByAssertion",
-                    "Test '" + TestClass + ".FailByAssertion' failed:",
-                    "",
-                    "Expected: 2",
-                    "Actual:   1",
-                    "",
-                    "Fixie.Tests.Assertions.AssertException",
-                    At("FailByAssertion()"),
-                    "",
+                "Standard Out: FailByAssertion",
+                "Test '" + TestClass + ".FailByAssertion' failed:",
+                "",
+                "Expected: 2",
+                "Actual:   1",
+                "",
+                "Fixie.Tests.Assertions.AssertException",
+                At("FailByAssertion()"),
+                "",
 
-                    "Standard Out: Pass",
+                "Standard Out: Pass",
 
-                    "Test '" + TestClass + ".Skip' skipped:",
-                    "⚠ Skipped with attribute.",
-                    "",
+                "Test '" + TestClass + ".Skip' skipped:",
+                "⚠ Skipped with attribute.",
+                "",
 
-                    "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
-                    "",
-                    "Expected: System.String",
-                    "Actual:   System.Int32",
-                    "",
-                    "Fixie.Tests.Assertions.AssertException",
-                    At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
-                    "",
+                "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
+                "",
+                "Expected: System.String",
+                "Actual:   System.Int32",
+                "",
+                "Fixie.Tests.Assertions.AssertException",
+                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
+                "",
 
-                    "3 passed, 3 failed, 1 skipped, took 1.23 seconds");
-        }
+                "3 passed, 3 failed, 1 skipped, took 1.23 seconds");
+    }
 
     public async Task ShouldIncludePassingResultsWhenFilteringByPattern()
     {
-            var output = await Run(console => new ConsoleReport(console, testPattern: "*"));
+        var output = await Run(console => new ConsoleReport(console, testPattern: "*"));
 
-            output.Console
-                .NormalizeStackTraceLines()
-                .CleanDuration()
-                .ShouldBe(
-                    "Standard Out: Fail",
-                    "Test '" + TestClass + ".Fail' failed:",
-                    "",
-                    "'Fail' failed!",
-                    "",
-                    "Fixie.Tests.FailureException",
-                    At("Fail()"),
-                    "",
+        output.Console
+            .NormalizeStackTraceLines()
+            .CleanDuration()
+            .ShouldBe(
+                "Standard Out: Fail",
+                "Test '" + TestClass + ".Fail' failed:",
+                "",
+                "'Fail' failed!",
+                "",
+                "Fixie.Tests.FailureException",
+                At("Fail()"),
+                "",
 
-                    "Standard Out: FailByAssertion",
-                    "Test '" + TestClass + ".FailByAssertion' failed:",
-                    "",
-                    "Expected: 2",
-                    "Actual:   1",
-                    "",
-                    "Fixie.Tests.Assertions.AssertException",
-                    At("FailByAssertion()"),
-                    "",
+                "Standard Out: FailByAssertion",
+                "Test '" + TestClass + ".FailByAssertion' failed:",
+                "",
+                "Expected: 2",
+                "Actual:   1",
+                "",
+                "Fixie.Tests.Assertions.AssertException",
+                At("FailByAssertion()"),
+                "",
 
-                    "Standard Out: Pass",
-                    "Test '" + TestClass + ".Pass' passed",
-                    "",
+                "Standard Out: Pass",
+                "Test '" + TestClass + ".Pass' passed",
+                "",
 
-                    "Test '" + TestClass + ".Skip' skipped:",
-                    "⚠ Skipped with attribute.",
-                    "",
+                "Test '" + TestClass + ".Skip' skipped:",
+                "⚠ Skipped with attribute.",
+                "",
 
-                    "Test '" + GenericTestClass + ".ShouldBeString<System.String>(\"A\")' passed",
-                    "Test '" + GenericTestClass + ".ShouldBeString<System.String>(\"B\")' passed",
-                    "",
+                "Test '" + GenericTestClass + ".ShouldBeString<System.String>(\"A\")' passed",
+                "Test '" + GenericTestClass + ".ShouldBeString<System.String>(\"B\")' passed",
+                "",
 
-                    "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
-                    "",
-                    "Expected: System.String",
-                    "Actual:   System.Int32",
-                    "",
-                    "Fixie.Tests.Assertions.AssertException",
-                    At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
-                    "",
+                "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
+                "",
+                "Expected: System.String",
+                "Actual:   System.Int32",
+                "",
+                "Fixie.Tests.Assertions.AssertException",
+                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
+                "",
 
-                    "3 passed, 3 failed, 1 skipped, took 1.23 seconds");
-        }
+                "3 passed, 3 failed, 1 skipped, took 1.23 seconds");
+    }
 
     class ZeroPassed : SelfTestDiscovery
     {
@@ -113,15 +113,15 @@ public class ConsoleReportTests : MessagingTests
 
     public async Task ShouldNotReportPassCountsWhenZeroTestsHavePassed()
     {
-            var discovery = new ZeroPassed();
+        var discovery = new ZeroPassed();
 
-            var output = await Run(console => new ConsoleReport(console), discovery);
+        var output = await Run(console => new ConsoleReport(console), discovery);
 
-            output.Console
-                .CleanDuration()
-                .Last()
-                .ShouldBe("2 failed, 1 skipped, took 1.23 seconds");
-        }
+        output.Console
+            .CleanDuration()
+            .Last()
+            .ShouldBe("2 failed, 1 skipped, took 1.23 seconds");
+    }
 
     class ZeroFailed : SelfTestDiscovery
     {
@@ -131,15 +131,15 @@ public class ConsoleReportTests : MessagingTests
 
     public async Task ShouldNotReportFailCountsWhenZeroTestsHaveFailed()
     {
-            var discovery = new ZeroFailed();
+        var discovery = new ZeroFailed();
 
-            var output = await Run(console => new ConsoleReport(console), discovery);
+        var output = await Run(console => new ConsoleReport(console), discovery);
 
-            output.Console
-                .CleanDuration()
-                .Last()
-                .ShouldBe("1 passed, 1 skipped, took 1.23 seconds");
-        }
+        output.Console
+            .CleanDuration()
+            .Last()
+            .ShouldBe("1 passed, 1 skipped, took 1.23 seconds");
+    }
 
     class ZeroSkipped : SelfTestDiscovery
     {
@@ -149,15 +149,15 @@ public class ConsoleReportTests : MessagingTests
 
     public async Task ShouldNotReportSkipCountsWhenZeroTestsHaveBeenSkipped()
     {
-            var discovery = new ZeroSkipped();
+        var discovery = new ZeroSkipped();
 
-            var output = await Run(console => new ConsoleReport(console), discovery);
+        var output = await Run(console => new ConsoleReport(console), discovery);
 
-            output.Console
-                .CleanDuration()
-                .Last()
-                .ShouldBe("1 passed, 2 failed, took 1.23 seconds");
-        }
+        output.Console
+            .CleanDuration()
+            .Last()
+            .ShouldBe("1 passed, 2 failed, took 1.23 seconds");
+    }
 
     class NoTestsFound : SelfTestDiscovery
     {
@@ -167,18 +167,18 @@ public class ConsoleReportTests : MessagingTests
 
     public async Task ShouldProvideDiagnosticDescriptionWhenNoTestsWereExecuted()
     {
-            var discovery = new NoTestsFound();
+        var discovery = new NoTestsFound();
 
-            var output = await Run(console => new ConsoleReport(console), discovery);
+        var output = await Run(console => new ConsoleReport(console), discovery);
 
-            output.Console
-                .Last()
-                .ShouldBe("No tests found.");
+        output.Console
+            .Last()
+            .ShouldBe("No tests found.");
 
-            output = await Run(console => new ConsoleReport(console, testPattern: "Ineffective*Pattern"), discovery);
+        output = await Run(console => new ConsoleReport(console, testPattern: "Ineffective*Pattern"), discovery);
 
-            output.Console
-                .Last()
-                .ShouldBe("No tests match the specified pattern: Ineffective*Pattern");
-        }
+        output.Console
+            .Last()
+            .ShouldBe("No tests match the specified pattern: Ineffective*Pattern");
+    }
 }

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -1,16 +1,16 @@
-﻿namespace Fixie.Tests.Reports
-{
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
+﻿namespace Fixie.Tests.Reports;
 
-    public class ConsoleReportTests : MessagingTests
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+
+public class ConsoleReportTests : MessagingTests
+{
+    public async Task ShouldReportResults()
     {
-        public async Task ShouldReportResults()
-        {
             var output = await Run(environment => new ConsoleReport(environment));
 
             output.Console
@@ -54,8 +54,8 @@
                     "3 passed, 3 failed, 1 skipped, took 1.23 seconds");
         }
 
-        public async Task ShouldIncludePassingResultsWhenFilteringByPattern()
-        {
+    public async Task ShouldIncludePassingResultsWhenFilteringByPattern()
+    {
             var output = await Run(console => new ConsoleReport(console, testPattern: "*"));
 
             output.Console
@@ -105,14 +105,14 @@
                     "3 passed, 3 failed, 1 skipped, took 1.23 seconds");
         }
 
-        class ZeroPassed : SelfTestDiscovery
-        {
-            public override IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-                => publicMethods.Where(x => !x.Name.StartsWith("Pass") && x.ReflectedType == TestClassType);
-        }
+    class ZeroPassed : SelfTestDiscovery
+    {
+        public override IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => publicMethods.Where(x => !x.Name.StartsWith("Pass") && x.ReflectedType == TestClassType);
+    }
 
-        public async Task ShouldNotReportPassCountsWhenZeroTestsHavePassed()
-        {
+    public async Task ShouldNotReportPassCountsWhenZeroTestsHavePassed()
+    {
             var discovery = new ZeroPassed();
 
             var output = await Run(console => new ConsoleReport(console), discovery);
@@ -123,14 +123,14 @@
                 .ShouldBe("2 failed, 1 skipped, took 1.23 seconds");
         }
 
-        class ZeroFailed : SelfTestDiscovery
-        {
-            public override IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-                => publicMethods.Where(x => !x.Name.StartsWith("Fail") && x.ReflectedType == TestClassType);
-        }
+    class ZeroFailed : SelfTestDiscovery
+    {
+        public override IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => publicMethods.Where(x => !x.Name.StartsWith("Fail") && x.ReflectedType == TestClassType);
+    }
 
-        public async Task ShouldNotReportFailCountsWhenZeroTestsHaveFailed()
-        {
+    public async Task ShouldNotReportFailCountsWhenZeroTestsHaveFailed()
+    {
             var discovery = new ZeroFailed();
 
             var output = await Run(console => new ConsoleReport(console), discovery);
@@ -141,14 +141,14 @@
                 .ShouldBe("1 passed, 1 skipped, took 1.23 seconds");
         }
 
-        class ZeroSkipped : SelfTestDiscovery
-        {
-            public override IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-                => publicMethods.Where(x => !x.Name.StartsWith("Skip") && x.ReflectedType == TestClassType);
-        }
+    class ZeroSkipped : SelfTestDiscovery
+    {
+        public override IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => publicMethods.Where(x => !x.Name.StartsWith("Skip") && x.ReflectedType == TestClassType);
+    }
 
-        public async Task ShouldNotReportSkipCountsWhenZeroTestsHaveBeenSkipped()
-        {
+    public async Task ShouldNotReportSkipCountsWhenZeroTestsHaveBeenSkipped()
+    {
             var discovery = new ZeroSkipped();
 
             var output = await Run(console => new ConsoleReport(console), discovery);
@@ -159,14 +159,14 @@
                 .ShouldBe("1 passed, 2 failed, took 1.23 seconds");
         }
 
-        class NoTestsFound : SelfTestDiscovery
-        {
-            public override IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-                => publicMethods.Where(x => false);
-        }
+    class NoTestsFound : SelfTestDiscovery
+    {
+        public override IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+            => publicMethods.Where(x => false);
+    }
 
-        public async Task ShouldProvideDiagnosticDescriptionWhenNoTestsWereExecuted()
-        {
+    public async Task ShouldProvideDiagnosticDescriptionWhenNoTestsWereExecuted()
+    {
             var discovery = new NoTestsFound();
 
             var output = await Run(console => new ConsoleReport(console), discovery);
@@ -181,5 +181,4 @@
                 .Last()
                 .ShouldBe("No tests match the specified pattern: Ineffective*Pattern");
         }
-    }
 }

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -1,15 +1,15 @@
-﻿namespace Fixie.Tests.Reports
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
+﻿namespace Fixie.Tests.Reports;
 
-    public class LifecycleMessageTests : MessagingTests
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+
+public class LifecycleMessageTests : MessagingTests
+{
+    public async Task ShouldDescribeTestLifecycleMessagesEmittedDuringExecution()
     {
-        public async Task ShouldDescribeTestLifecycleMessagesEmittedDuringExecution()
-        {
             var report = new StubTestCompletedReport();
 
             await Run(report);
@@ -111,37 +111,36 @@
             executionCompleted.Total.ShouldBe(7);
         }
 
-        public class StubTestCompletedReport :
-            IHandler<ExecutionStarted>,
-            IHandler<TestStarted>,
-            IHandler<TestCompleted>,
-            IHandler<ExecutionCompleted>
+    public class StubTestCompletedReport :
+        IHandler<ExecutionStarted>,
+        IHandler<TestStarted>,
+        IHandler<TestCompleted>,
+        IHandler<ExecutionCompleted>
+    {
+        public List<object> Messages { get; } = new List<object>();
+
+        public Task Handle(ExecutionStarted message)
         {
-            public List<object> Messages { get; } = new List<object>();
-
-            public Task Handle(ExecutionStarted message)
-            {
                 Messages.Add(message);
                 return Task.CompletedTask;
             }
 
-            public Task Handle(TestStarted message)
-            {
+        public Task Handle(TestStarted message)
+        {
                 Messages.Add(message);
                 return Task.CompletedTask;
             }
 
-            public Task Handle(TestCompleted message)
-            {
+        public Task Handle(TestCompleted message)
+        {
                 Messages.Add(message);
                 return Task.CompletedTask;
             }
 
-            public Task Handle(ExecutionCompleted message)
-            {
+        public Task Handle(ExecutionCompleted message)
+        {
                 Messages.Add(message);
                 return Task.CompletedTask;
             }
-        }
     }
 }

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -10,106 +10,106 @@ public class LifecycleMessageTests : MessagingTests
 {
     public async Task ShouldDescribeTestLifecycleMessagesEmittedDuringExecution()
     {
-            var report = new StubTestCompletedReport();
+        var report = new StubTestCompletedReport();
 
-            await Run(report);
+        await Run(report);
 
-            report.Messages.Count.ShouldBe(15);
-            
-            var executionStarted = (ExecutionStarted)report.Messages[0];
-            var failStarted = (TestStarted)report.Messages[1];
-            var fail = (TestFailed)report.Messages[2];
-            var failByAssertionStarted = (TestStarted)report.Messages[3];
-            var failByAssertion = (TestFailed)report.Messages[4];
-            var passStarted = (TestStarted)report.Messages[5];
-            var pass = (TestPassed)report.Messages[6];
-            var skip = (TestSkipped)report.Messages[7];
-            var shouldBeStringPassAStarted = (TestStarted)report.Messages[8];
-            var shouldBeStringPassA = (TestPassed)report.Messages[9];
-            var shouldBeStringPassBStarted = (TestStarted)report.Messages[10];
-            var shouldBeStringPassB = (TestPassed)report.Messages[11];
-            var shouldBeStringFailStarted = (TestStarted)report.Messages[12];
-            var shouldBeStringFail = (TestFailed)report.Messages[13];
-            var executionCompleted = (ExecutionCompleted)report.Messages[14];
+        report.Messages.Count.ShouldBe(15);
+        
+        var executionStarted = (ExecutionStarted)report.Messages[0];
+        var failStarted = (TestStarted)report.Messages[1];
+        var fail = (TestFailed)report.Messages[2];
+        var failByAssertionStarted = (TestStarted)report.Messages[3];
+        var failByAssertion = (TestFailed)report.Messages[4];
+        var passStarted = (TestStarted)report.Messages[5];
+        var pass = (TestPassed)report.Messages[6];
+        var skip = (TestSkipped)report.Messages[7];
+        var shouldBeStringPassAStarted = (TestStarted)report.Messages[8];
+        var shouldBeStringPassA = (TestPassed)report.Messages[9];
+        var shouldBeStringPassBStarted = (TestStarted)report.Messages[10];
+        var shouldBeStringPassB = (TestPassed)report.Messages[11];
+        var shouldBeStringFailStarted = (TestStarted)report.Messages[12];
+        var shouldBeStringFail = (TestFailed)report.Messages[13];
+        var executionCompleted = (ExecutionCompleted)report.Messages[14];
 
-            executionStarted.ShouldNotBeNull();
-            
-            passStarted.Test.ShouldBe(TestClass + ".Pass");
+        executionStarted.ShouldNotBeNull();
+        
+        passStarted.Test.ShouldBe(TestClass + ".Pass");
 
-            pass.Test.ShouldBe(TestClass + ".Pass");
-            pass.TestCase.ShouldBe(TestClass + ".Pass");
-            pass.Output.Lines().ShouldBe("Standard Out: Pass");
-            pass.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        pass.Test.ShouldBe(TestClass + ".Pass");
+        pass.TestCase.ShouldBe(TestClass + ".Pass");
+        pass.Output.Lines().ShouldBe("Standard Out: Pass");
+        pass.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
 
-            failStarted.Test.ShouldBe(TestClass + ".Fail");
+        failStarted.Test.ShouldBe(TestClass + ".Fail");
 
-            fail.Test.ShouldBe(TestClass + ".Fail");
-            fail.TestCase.ShouldBe(TestClass + ".Fail");
-            fail.Output.Lines().ShouldBe("Standard Out: Fail");
-            fail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-            fail.Reason.ShouldBe<FailureException>();
-            fail.Reason.StackTraceSummary()
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe(At("Fail()"));
-            fail.Reason.Message.ShouldBe("'Fail' failed!");
+        fail.Test.ShouldBe(TestClass + ".Fail");
+        fail.TestCase.ShouldBe(TestClass + ".Fail");
+        fail.Output.Lines().ShouldBe("Standard Out: Fail");
+        fail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        fail.Reason.ShouldBe<FailureException>();
+        fail.Reason.StackTraceSummary()
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe(At("Fail()"));
+        fail.Reason.Message.ShouldBe("'Fail' failed!");
 
-            failByAssertionStarted.Test.ShouldBe(TestClass + ".FailByAssertion");
+        failByAssertionStarted.Test.ShouldBe(TestClass + ".FailByAssertion");
 
-            failByAssertion.Test.ShouldBe(TestClass + ".FailByAssertion");
-            failByAssertion.TestCase.ShouldBe(TestClass + ".FailByAssertion");
-            failByAssertion.Output.Lines().ShouldBe("Standard Out: FailByAssertion");
-            failByAssertion.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-            failByAssertion.Reason.ShouldBe<AssertException>();
-            failByAssertion.Reason.StackTraceSummary()
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe(At("FailByAssertion()"));
-            failByAssertion.Reason.Message.Lines().ShouldBe(
-                "Expected: 2",
-                "Actual:   1");
+        failByAssertion.Test.ShouldBe(TestClass + ".FailByAssertion");
+        failByAssertion.TestCase.ShouldBe(TestClass + ".FailByAssertion");
+        failByAssertion.Output.Lines().ShouldBe("Standard Out: FailByAssertion");
+        failByAssertion.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        failByAssertion.Reason.ShouldBe<AssertException>();
+        failByAssertion.Reason.StackTraceSummary()
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe(At("FailByAssertion()"));
+        failByAssertion.Reason.Message.Lines().ShouldBe(
+            "Expected: 2",
+            "Actual:   1");
 
-            skip.Test.ShouldBe(TestClass + ".Skip");
-            skip.TestCase.ShouldBe(TestClass + ".Skip");
-            skip.Output.ShouldBe("");
-            skip.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-            skip.Reason.ShouldBe("⚠ Skipped with attribute.");
+        skip.Test.ShouldBe(TestClass + ".Skip");
+        skip.TestCase.ShouldBe(TestClass + ".Skip");
+        skip.Output.ShouldBe("");
+        skip.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        skip.Reason.ShouldBe("⚠ Skipped with attribute.");
 
-            shouldBeStringPassAStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
+        shouldBeStringPassAStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
 
-            shouldBeStringPassA.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
-            shouldBeStringPassA.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
-            shouldBeStringPassA.Output.ShouldBe("");
-            shouldBeStringPassA.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        shouldBeStringPassA.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
+        shouldBeStringPassA.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
+        shouldBeStringPassA.Output.ShouldBe("");
+        shouldBeStringPassA.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
 
-            shouldBeStringPassBStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
+        shouldBeStringPassBStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
 
-            shouldBeStringPassB.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
-            shouldBeStringPassB.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
-            shouldBeStringPassB.Output.ShouldBe("");
-            shouldBeStringPassB.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        shouldBeStringPassB.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
+        shouldBeStringPassB.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
+        shouldBeStringPassB.Output.ShouldBe("");
+        shouldBeStringPassB.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
 
-            shouldBeStringFailStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
+        shouldBeStringFailStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
 
-            shouldBeStringFail.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
-            shouldBeStringFail.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
-            shouldBeStringFail.Output.ShouldBe("");
-            shouldBeStringFail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-            shouldBeStringFail.Reason.ShouldBe<AssertException>();
-            shouldBeStringFail.Reason.StackTraceSummary()
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe(At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
-            shouldBeStringFail.Reason.Message.Lines().ShouldBe(
-                "Expected: System.String",
-                "Actual:   System.Int32");
+        shouldBeStringFail.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
+        shouldBeStringFail.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
+        shouldBeStringFail.Output.ShouldBe("");
+        shouldBeStringFail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        shouldBeStringFail.Reason.ShouldBe<AssertException>();
+        shouldBeStringFail.Reason.StackTraceSummary()
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe(At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
+        shouldBeStringFail.Reason.Message.Lines().ShouldBe(
+            "Expected: System.String",
+            "Actual:   System.Int32");
 
-            executionCompleted.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
-            executionCompleted.Failed.ShouldBe(3);
-            executionCompleted.Skipped.ShouldBe(1);
-            executionCompleted.Passed.ShouldBe(3);
-            executionCompleted.Total.ShouldBe(7);
-        }
+        executionCompleted.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        executionCompleted.Failed.ShouldBe(3);
+        executionCompleted.Skipped.ShouldBe(1);
+        executionCompleted.Passed.ShouldBe(3);
+        executionCompleted.Total.ShouldBe(7);
+    }
 
     public class StubTestCompletedReport :
         IHandler<ExecutionStarted>,
@@ -121,26 +121,26 @@ public class LifecycleMessageTests : MessagingTests
 
         public Task Handle(ExecutionStarted message)
         {
-                Messages.Add(message);
-                return Task.CompletedTask;
-            }
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
 
         public Task Handle(TestStarted message)
         {
-                Messages.Add(message);
-                return Task.CompletedTask;
-            }
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
 
         public Task Handle(TestCompleted message)
         {
-                Messages.Add(message);
-                return Task.CompletedTask;
-            }
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
 
         public Task Handle(ExecutionCompleted message)
         {
-                Messages.Add(message);
-                return Task.CompletedTask;
-            }
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Fixie.Tests/Reports/MessagingTests.cs
+++ b/src/Fixie.Tests/Reports/MessagingTests.cs
@@ -1,147 +1,146 @@
-﻿namespace Fixie.Tests.Reports
+﻿namespace Fixie.Tests.Reports;
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+using static Utility;
+
+public abstract class MessagingTests
 {
-    using System;
-    using System.Linq;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
-    using static Utility;
-
-    public abstract class MessagingTests
+    protected MessagingTests()
     {
-        protected MessagingTests()
-        {
-            TestClass = FullName<SampleTestClass>();
-            GenericTestClass = FullName<SampleGenericTestClass>();
-        }
-
-        protected string TestClass { get; }
-        protected string GenericTestClass { get; }
-        protected static Type TestClassType => typeof(SampleTestClass);
-
-        readonly Type[] candidateTypes =
-        {
-            typeof(SampleTestClass),
-            typeof(SampleGenericTestClass),
-            typeof(EmptyTestClass)
-        };
-
-        protected class Output
-        {
-            public Output(string[] console)
-                => Console = console;
-
-            public string[] Console { get; }
-        }
-
-        protected async Task Discover(IReport report)
-        {
-            var discovery = new SelfTestDiscovery();
-
-            using var console = new RedirectedConsole();
-
-            await Utility.Discover(report, discovery, candidateTypes);
-
-            console.Lines().ShouldBeEmpty();
-        }
-
-        protected Task<Output> Run(IReport report)
-        {
-            return Run(_ => report);
-        }
-
-        protected Task<Output> Run(IReport report, IDiscovery discovery)
-        {
-            return Run(_ => report, discovery);
-        }
-
-        protected Task<Output> Run(Func<TestEnvironment, IReport> getReport)
-        {
-            return Run(getReport, new SelfTestDiscovery());
-        }
-
-        protected async Task<Output> Run(Func<TestEnvironment, IReport> getReport, IDiscovery discovery)
-        {
-            var execution = new MessagingTestsExecution();
-
-            using var console = new RedirectedConsole();
-
-            await Utility.Run(getReport(GetTestEnvironment()), discovery, execution, candidateTypes);
-
-            return new Output(console.Lines().ToArray());
-        }
-
-        class MessagingTestsExecution : IExecution
-        {
-            public async Task Run(TestSuite testSuite)
-            {
-                foreach (var test in testSuite.Tests)
-                {
-                    if (test.Has<SkipAttribute>(out var skip))
-                    {
-                        await test.Skip(skip.Reason);
-                        continue;
-                    }
-
-                    foreach (var parameters in FromInputAttributes(test))
-                        await test.Run(parameters);
-                }
-            }
-        }
-
-        protected class Base
-        {
-            public void Pass()
-            {
-                WhereAmI();
-            }
-
-            protected static void WhereAmI([CallerMemberName] string member = default!)
-                => Console.WriteLine("Standard Out: " + member);
-        }
-
-        class SampleTestClass : Base
-        {
-            public void Fail()
-            {
-                WhereAmI();
-                throw new FailureException();
-            }
-
-            public void FailByAssertion()
-            {
-                WhereAmI();
-                1.ShouldBe(2);
-            }
-
-            const string alert = "\x26A0";
-            [Skip(alert + " Skipped with attribute.")]
-            public void Skip()
-            {
-                throw new ShouldBeUnreachableException();
-            }
-        }
-
-        protected class SampleGenericTestClass
-        {
-            [Input("A")]
-            [Input("B")]
-            [Input(123)]
-            public void ShouldBeString<T>(T genericArgument)
-            {
-                genericArgument.ShouldBe<string>();
-            }
-        }
-
-        class EmptyTestClass
-        {
-        }
-
-        protected static string At(string method)
-            => At<SampleTestClass>(method);
-
-        protected static string At<T>(string method)
-            => Utility.At<T>(method);
+        TestClass = FullName<SampleTestClass>();
+        GenericTestClass = FullName<SampleGenericTestClass>();
     }
+
+    protected string TestClass { get; }
+    protected string GenericTestClass { get; }
+    protected static Type TestClassType => typeof(SampleTestClass);
+
+    readonly Type[] candidateTypes =
+    {
+        typeof(SampleTestClass),
+        typeof(SampleGenericTestClass),
+        typeof(EmptyTestClass)
+    };
+
+    protected class Output
+    {
+        public Output(string[] console)
+            => Console = console;
+
+        public string[] Console { get; }
+    }
+
+    protected async Task Discover(IReport report)
+    {
+        var discovery = new SelfTestDiscovery();
+
+        using var console = new RedirectedConsole();
+
+        await Utility.Discover(report, discovery, candidateTypes);
+
+        console.Lines().ShouldBeEmpty();
+    }
+
+    protected Task<Output> Run(IReport report)
+    {
+        return Run(_ => report);
+    }
+
+    protected Task<Output> Run(IReport report, IDiscovery discovery)
+    {
+        return Run(_ => report, discovery);
+    }
+
+    protected Task<Output> Run(Func<TestEnvironment, IReport> getReport)
+    {
+        return Run(getReport, new SelfTestDiscovery());
+    }
+
+    protected async Task<Output> Run(Func<TestEnvironment, IReport> getReport, IDiscovery discovery)
+    {
+        var execution = new MessagingTestsExecution();
+
+        using var console = new RedirectedConsole();
+
+        await Utility.Run(getReport(GetTestEnvironment()), discovery, execution, candidateTypes);
+
+        return new Output(console.Lines().ToArray());
+    }
+
+    class MessagingTestsExecution : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
+        {
+            foreach (var test in testSuite.Tests)
+            {
+                if (test.Has<SkipAttribute>(out var skip))
+                {
+                    await test.Skip(skip.Reason);
+                    continue;
+                }
+
+                foreach (var parameters in FromInputAttributes(test))
+                    await test.Run(parameters);
+            }
+        }
+    }
+
+    protected class Base
+    {
+        public void Pass()
+        {
+            WhereAmI();
+        }
+
+        protected static void WhereAmI([CallerMemberName] string member = default!)
+            => Console.WriteLine("Standard Out: " + member);
+    }
+
+    class SampleTestClass : Base
+    {
+        public void Fail()
+        {
+            WhereAmI();
+            throw new FailureException();
+        }
+
+        public void FailByAssertion()
+        {
+            WhereAmI();
+            1.ShouldBe(2);
+        }
+
+        const string alert = "\x26A0";
+        [Skip(alert + " Skipped with attribute.")]
+        public void Skip()
+        {
+            throw new ShouldBeUnreachableException();
+        }
+    }
+
+    protected class SampleGenericTestClass
+    {
+        [Input("A")]
+        [Input("B")]
+        [Input(123)]
+        public void ShouldBeString<T>(T genericArgument)
+        {
+            genericArgument.ShouldBe<string>();
+        }
+    }
+
+    class EmptyTestClass
+    {
+    }
+
+    protected static string At(string method)
+        => At<SampleTestClass>(method);
+
+    protected static string At<T>(string method)
+        => Utility.At<T>(method);
 }

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -1,16 +1,16 @@
-﻿namespace Fixie.Tests.Reports
-{
-    using System;
-    using System.Linq;
-    using System.Text.RegularExpressions;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
+﻿namespace Fixie.Tests.Reports;
 
-    public class TeamCityReportTests : MessagingTests
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+
+public class TeamCityReportTests : MessagingTests
+{
+    public async Task ShouldReportResultsToTheConsoleInTeamCityFormat()
     {
-        public async Task ShouldReportResultsToTheConsoleInTeamCityFormat()
-        {
             var eol = Environment.NewLine == "\r\n" ? "|r|n" : "|n";
 
             var output = await Run(environment => new TeamCityReport(environment));
@@ -54,5 +54,4 @@
 
                     "##teamcity[testSuiteFinished name='Fixie.Tests']");
         }
-    }
 }

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -11,47 +11,47 @@ public class TeamCityReportTests : MessagingTests
 {
     public async Task ShouldReportResultsToTheConsoleInTeamCityFormat()
     {
-            var eol = Environment.NewLine == "\r\n" ? "|r|n" : "|n";
+        var eol = Environment.NewLine == "\r\n" ? "|r|n" : "|n";
 
-            var output = await Run(environment => new TeamCityReport(environment));
+        var output = await Run(environment => new TeamCityReport(environment));
 
-            output.Console
-                .NormalizeStackTraceLines()
-                .Select(x => Regex.Replace(x, @"duration='\d+'", "duration='#'"))
-                .ShouldBe(
-                    "##teamcity[testSuiteStarted name='Fixie.Tests']",
+        output.Console
+            .NormalizeStackTraceLines()
+            .Select(x => Regex.Replace(x, @"duration='\d+'", "duration='#'"))
+            .ShouldBe(
+                "##teamcity[testSuiteStarted name='Fixie.Tests']",
 
-                    "Standard Out: Fail",
-                    $"##teamcity[testStarted name='{TestClass}.Fail']",
-                    $"##teamcity[testStdOut name='{TestClass}.Fail' out='Standard Out: Fail{eol}']",
-                    $"##teamcity[testFailed name='{TestClass}.Fail' message='|'Fail|' failed!' details='Fixie.Tests.FailureException{eol}{At("Fail()")}']",
-                    $"##teamcity[testFinished name='{TestClass}.Fail' duration='#']",
+                "Standard Out: Fail",
+                $"##teamcity[testStarted name='{TestClass}.Fail']",
+                $"##teamcity[testStdOut name='{TestClass}.Fail' out='Standard Out: Fail{eol}']",
+                $"##teamcity[testFailed name='{TestClass}.Fail' message='|'Fail|' failed!' details='Fixie.Tests.FailureException{eol}{At("Fail()")}']",
+                $"##teamcity[testFinished name='{TestClass}.Fail' duration='#']",
 
-                    "Standard Out: FailByAssertion",
-                    $"##teamcity[testStarted name='{TestClass}.FailByAssertion']",
-                    $"##teamcity[testStdOut name='{TestClass}.FailByAssertion' out='Standard Out: FailByAssertion{eol}']",
-                    $"##teamcity[testFailed name='{TestClass}.FailByAssertion' message='Expected: 2{eol}Actual:   1' details='Fixie.Tests.Assertions.AssertException{eol}{At("FailByAssertion()")}']",
-                    $"##teamcity[testFinished name='{TestClass}.FailByAssertion' duration='#']",
+                "Standard Out: FailByAssertion",
+                $"##teamcity[testStarted name='{TestClass}.FailByAssertion']",
+                $"##teamcity[testStdOut name='{TestClass}.FailByAssertion' out='Standard Out: FailByAssertion{eol}']",
+                $"##teamcity[testFailed name='{TestClass}.FailByAssertion' message='Expected: 2{eol}Actual:   1' details='Fixie.Tests.Assertions.AssertException{eol}{At("FailByAssertion()")}']",
+                $"##teamcity[testFinished name='{TestClass}.FailByAssertion' duration='#']",
 
-                    "Standard Out: Pass",
-                    $"##teamcity[testStarted name='{TestClass}.Pass']",
-                    $"##teamcity[testStdOut name='{TestClass}.Pass' out='Standard Out: Pass{eol}']",
-                    $"##teamcity[testFinished name='{TestClass}.Pass' duration='#']",
-                    
-                    $"##teamcity[testStarted name='{TestClass}.Skip']",
-                    $"##teamcity[testIgnored name='{TestClass}.Skip' message='|0x26a0 Skipped with attribute.']",
-                    $"##teamcity[testFinished name='{TestClass}.Skip' duration='#']",
-                    
-                    $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>(\"A\")']",
-                    $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"A\")' duration='#']",
-                    
-                    $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")']",
-                    $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")' duration='#']",
+                "Standard Out: Pass",
+                $"##teamcity[testStarted name='{TestClass}.Pass']",
+                $"##teamcity[testStdOut name='{TestClass}.Pass' out='Standard Out: Pass{eol}']",
+                $"##teamcity[testFinished name='{TestClass}.Pass' duration='#']",
+                
+                $"##teamcity[testStarted name='{TestClass}.Skip']",
+                $"##teamcity[testIgnored name='{TestClass}.Skip' message='|0x26a0 Skipped with attribute.']",
+                $"##teamcity[testFinished name='{TestClass}.Skip' duration='#']",
+                
+                $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>(\"A\")']",
+                $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"A\")' duration='#']",
+                
+                $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")']",
+                $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")' duration='#']",
 
-                    $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.Int32>(123)']",
-                    $"##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='Expected: System.String{eol}Actual:   System.Int32' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']",
-                    $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' duration='#']",
+                $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.Int32>(123)']",
+                $"##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='Expected: System.String{eol}Actual:   System.Int32' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']",
+                $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' duration='#']",
 
-                    "##teamcity[testSuiteFinished name='Fixie.Tests']");
-        }
+                "##teamcity[testSuiteFinished name='Fixie.Tests']");
+    }
 }

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -1,18 +1,18 @@
-﻿namespace Fixie.Tests.Reports
-{
-    using System;
-    using System.Linq;
-    using System.Text.RegularExpressions;
-    using System.Threading.Tasks;
-    using System.Xml.Linq;
-    using Assertions;
-    using Fixie.Reports;
-    using static Utility;
+﻿namespace Fixie.Tests.Reports;
 
-    public class XmlReportTests : MessagingTests
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Assertions;
+using Fixie.Reports;
+using static Utility;
+
+public class XmlReportTests : MessagingTests
+{
+    public async Task ShouldProduceValidXmlDocument()
     {
-        public async Task ShouldProduceValidXmlDocument()
-        {
             var environment = GetTestEnvironment();
 
             XDocument? actual = null;
@@ -36,8 +36,8 @@
                 .ShouldBe(ExpectedReport.Lines().ToArray());
         }
 
-        static string CleanBrittleValues(string actualRawContent)
-        {
+    static string CleanBrittleValues(string actualRawContent)
+    {
             //Avoid brittle assertion introduced by system date.
             var cleaned = Regex.Replace(actualRawContent, @"run-date=""\d\d\d\d-\d\d-\d\d""", @"run-date=""YYYY-MM-DD""");
 
@@ -56,10 +56,10 @@
             return cleaned;
         }
 
-        string ExpectedReport
+    string ExpectedReport
+    {
+        get
         {
-            get
-            {
                 var assemblyLocation = GetType().Assembly.Location;
 
                 var expected = $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
@@ -100,6 +100,5 @@ Actual:   1]]></message>
 
                 return XDocument.Parse(expected).ToString();
             }
-        }
     }
 }

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -13,56 +13,56 @@ public class XmlReportTests : MessagingTests
 {
     public async Task ShouldProduceValidXmlDocument()
     {
-            var environment = GetTestEnvironment();
+        var environment = GetTestEnvironment();
 
-            XDocument? actual = null;
-            var report = new XmlReport(environment, document => actual = document);
+        XDocument? actual = null;
+        var report = new XmlReport(environment, document => actual = document);
 
-            var output = await Run(report);
+        var output = await Run(report);
 
-            output.Console
-                .ShouldBe(
-                    "Standard Out: Fail",
-                    "Standard Out: FailByAssertion",
-                    "Standard Out: Pass");
+        output.Console
+            .ShouldBe(
+                "Standard Out: Fail",
+                "Standard Out: FailByAssertion",
+                "Standard Out: Pass");
 
-            if (actual == null)
-                throw new Exception("Expected non-null XML report.");
+        if (actual == null)
+            throw new Exception("Expected non-null XML report.");
 
-            CleanBrittleValues(actual.ToString())
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ToArray()
-                .ShouldBe(ExpectedReport.Lines().ToArray());
-        }
+        CleanBrittleValues(actual.ToString())
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ToArray()
+            .ShouldBe(ExpectedReport.Lines().ToArray());
+    }
 
     static string CleanBrittleValues(string actualRawContent)
     {
-            //Avoid brittle assertion introduced by system date.
-            var cleaned = Regex.Replace(actualRawContent, @"run-date=""\d\d\d\d-\d\d-\d\d""", @"run-date=""YYYY-MM-DD""");
+        //Avoid brittle assertion introduced by system date.
+        var cleaned = Regex.Replace(actualRawContent, @"run-date=""\d\d\d\d-\d\d-\d\d""", @"run-date=""YYYY-MM-DD""");
 
-            //Avoid brittle assertion introduced by system time.
-            cleaned = Regex.Replace(cleaned, @"run-time=""\d\d:\d\d:\d\d""", @"run-time=""HH:MM:SS""");
+        //Avoid brittle assertion introduced by system time.
+        cleaned = Regex.Replace(cleaned, @"run-time=""\d\d:\d\d:\d\d""", @"run-time=""HH:MM:SS""");
 
-            //Avoid brittle assertion introduced by .NET version.
-            cleaned = cleaned.Replace($@"environment=""{IntPtr.Size * 8}-bit .NETCoreApp,Version=v{TargetFrameworkVersion}""", @"environment=""00-bit .NETCoreApp,Version=vX.Y""");
+        //Avoid brittle assertion introduced by .NET version.
+        cleaned = cleaned.Replace($@"environment=""{IntPtr.Size * 8}-bit .NETCoreApp,Version=v{TargetFrameworkVersion}""", @"environment=""00-bit .NETCoreApp,Version=vX.Y""");
 
-            //Avoid brittle assertion introduced by fixie version.
-            cleaned = cleaned.Replace($@"test-framework=""{Fixie.Internal.Framework.Version}""", @"test-framework=""Fixie 1.2.3.4""");
+        //Avoid brittle assertion introduced by fixie version.
+        cleaned = cleaned.Replace($@"test-framework=""{Fixie.Internal.Framework.Version}""", @"test-framework=""Fixie 1.2.3.4""");
 
-            //Avoid brittle assertion introduced by test duration.
-            cleaned = Regex.Replace(cleaned, @"time=""\d+\.\d\d\d""", @"time=""1.234""");
+        //Avoid brittle assertion introduced by test duration.
+        cleaned = Regex.Replace(cleaned, @"time=""\d+\.\d\d\d""", @"time=""1.234""");
 
-            return cleaned;
-        }
+        return cleaned;
+    }
 
     string ExpectedReport
     {
         get
         {
-                var assemblyLocation = GetType().Assembly.Location;
+            var assemblyLocation = GetType().Assembly.Location;
 
-                var expected = $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+            var expected = $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
 <assemblies>
 <assembly name=""{assemblyLocation}"" run-date=""YYYY-MM-DD"" run-time=""HH:MM:SS"" time=""1.234"" total=""7"" passed=""3"" failed=""3"" skipped=""1"" environment=""00-bit .NETCoreApp,Version=vX.Y"" test-framework=""Fixie 1.2.3.4"">
   <collection time=""1.234"" name=""{GenericTestClass}"" total=""3"" passed=""2"" failed=""1"" skipped=""0"">
@@ -98,7 +98,7 @@ Actual:   1]]></message>
 </assembly>
 </assemblies>";
 
-                return XDocument.Parse(expected).ToString();
-            }
+            return XDocument.Parse(expected).ToString();
+        }
     }
 }

--- a/src/Fixie.Tests/ResultEmittingTests.cs
+++ b/src/Fixie.Tests/ResultEmittingTests.cs
@@ -1,21 +1,21 @@
-namespace Fixie.Tests
+namespace Fixie.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class ResultEmittingTests : InstrumentedExecutionTests
 {
-    using System;
-    using System.Linq;
-    using System.Threading.Tasks;
-
-    public class ResultEmittingTests : InstrumentedExecutionTests
+    class SampleTestClass
     {
-        class SampleTestClass
-        {
-            public void Test0() { throw new ShouldBeUnreachableException(); }
-            public void Test1() { throw new ShouldBeUnreachableException(); }
-        }
+        public void Test0() { throw new ShouldBeUnreachableException(); }
+        public void Test1() { throw new ShouldBeUnreachableException(); }
+    }
 
-        class ResultEmittingExecution : IExecution
+    class ResultEmittingExecution : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 var exception = new Exception("Non-invocation Failure");
 
                 foreach (var test in testSuite.Tests.Where(x => x.Name.EndsWith("Test0")))
@@ -29,10 +29,10 @@ namespace Fixie.Tests
                     await test.Skip(new object[] {2, 'C'}, reason: "");
                 }
             }
-        }
+    }
 
-        public async Task ShouldSupportExplicitlyEmittingResultsWithoutNecessarilyInvokingTestMethods()
-        {
+    public async Task ShouldSupportExplicitlyEmittingResultsWithoutNecessarilyInvokingTestMethods()
+    {
             var output = await Run<SampleTestClass, ResultEmittingExecution>();
 
             output.ShouldHaveResults(
@@ -46,5 +46,4 @@ namespace Fixie.Tests
                 
                 "SampleTestClass.Test1 skipped: This test did not run.");
         }
-    }
 }

--- a/src/Fixie.Tests/ResultEmittingTests.cs
+++ b/src/Fixie.Tests/ResultEmittingTests.cs
@@ -16,34 +16,34 @@ public class ResultEmittingTests : InstrumentedExecutionTests
     {
         public async Task Run(TestSuite testSuite)
         {
-                var exception = new Exception("Non-invocation Failure");
+            var exception = new Exception("Non-invocation Failure");
 
-                foreach (var test in testSuite.Tests.Where(x => x.Name.EndsWith("Test0")))
-                {
-                    await test.Pass();
-                    await test.Fail(exception);
-                    await test.Skip("Explicit skip reason.");
+            foreach (var test in testSuite.Tests.Where(x => x.Name.EndsWith("Test0")))
+            {
+                await test.Pass();
+                await test.Fail(exception);
+                await test.Skip("Explicit skip reason.");
 
-                    await test.Pass(new object[] {0, 'A'});
-                    await test.Fail(new object[] {1, 'B'}, exception);
-                    await test.Skip(new object[] {2, 'C'}, reason: "");
-                }
+                await test.Pass(new object[] {0, 'A'});
+                await test.Fail(new object[] {1, 'B'}, exception);
+                await test.Skip(new object[] {2, 'C'}, reason: "");
             }
+        }
     }
 
     public async Task ShouldSupportExplicitlyEmittingResultsWithoutNecessarilyInvokingTestMethods()
     {
-            var output = await Run<SampleTestClass, ResultEmittingExecution>();
+        var output = await Run<SampleTestClass, ResultEmittingExecution>();
 
-            output.ShouldHaveResults(
-                "SampleTestClass.Test0 passed",
-                "SampleTestClass.Test0 failed: Non-invocation Failure",
-                "SampleTestClass.Test0 skipped: Explicit skip reason.",
-                
-                "SampleTestClass.Test0(0, 'A') passed",
-                "SampleTestClass.Test0(1, 'B') failed: Non-invocation Failure",
-                "SampleTestClass.Test0(2, 'C') skipped: This test was explicitly skipped, but no reason was provided.",
-                
-                "SampleTestClass.Test1 skipped: This test did not run.");
-        }
+        output.ShouldHaveResults(
+            "SampleTestClass.Test0 passed",
+            "SampleTestClass.Test0 failed: Non-invocation Failure",
+            "SampleTestClass.Test0 skipped: Explicit skip reason.",
+            
+            "SampleTestClass.Test0(0, 'A') passed",
+            "SampleTestClass.Test0(1, 'B') failed: Non-invocation Failure",
+            "SampleTestClass.Test0(2, 'C') skipped: This test was explicitly skipped, but no reason was provided.",
+            
+            "SampleTestClass.Test1 skipped: This test did not run.");
+    }
 }

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -11,168 +11,168 @@ public class ReturnTypeTests : InstrumentedExecutionTests
 {
     public async Task ShouldInvokeSynchronousTestsDiscardingReturnedValues()
     {
-            var output = await Run<SyncTestClass>();
+        var output = await Run<SyncTestClass>();
 
-            output.ShouldHaveResults(
-                "SyncTestClass.ReturnsInteger passed",
-                "SyncTestClass.ReturnsNull passed",
-                "SyncTestClass.ReturnsObject passed",
-                "SyncTestClass.ReturnsString passed");
+        output.ShouldHaveResults(
+            "SyncTestClass.ReturnsInteger passed",
+            "SyncTestClass.ReturnsNull passed",
+            "SyncTestClass.ReturnsObject passed",
+            "SyncTestClass.ReturnsString passed");
 
-            output.ShouldHaveLifecycle(
-                "ReturnsInteger",
-                "ReturnsNull",
-                "ReturnsObject",
-                "ReturnsString");
-        }
+        output.ShouldHaveLifecycle(
+            "ReturnsInteger",
+            "ReturnsNull",
+            "ReturnsObject",
+            "ReturnsString");
+    }
 
     public async Task ShouldAwaitAsynchronousTestsToEnsureCompleteExecution()
     {
-            var output = await Run<AsyncTestClass>();
+        var output = await Run<AsyncTestClass>();
 
-            output.ShouldHaveResults(
-                "AsyncTestClass.AwaitTaskThenPass passed",
-                "AsyncTestClass.AwaitValueTaskThenPass passed",
-                "AsyncTestClass.CompleteTaskThenPass passed",
-                "AsyncTestClass.FailAfterAwaitTask failed: Expected: 0" + NewLine + "Actual:   3",
-                "AsyncTestClass.FailAfterAwaitValueTask failed: Expected: 0" + NewLine + "Actual:   3",
-                "AsyncTestClass.FailBeforeAwaitTask failed: 'FailBeforeAwaitTask' failed!",
-                "AsyncTestClass.FailBeforeAwaitValueTask failed: 'FailBeforeAwaitValueTask' failed!",
-                "AsyncTestClass.FailDuringAwaitTask failed: Attempted to divide by zero.",
-                "AsyncTestClass.FailDuringAwaitValueTask failed: Attempted to divide by zero.",
-                "AsyncTestClass.GenericAsyncTaskFail failed: Attempted to divide by zero.",
-                "AsyncTestClass.GenericAsyncTaskWithResult passed",
-                "AsyncTestClass.GenericAsyncValueTaskFail failed: Attempted to divide by zero.",
-                "AsyncTestClass.GenericAsyncValueTaskWithResult passed",
-                "AsyncTestClass.GenericTaskFail failed: One or more errors occurred. (Attempted to divide by zero.)",
-                "AsyncTestClass.GenericTaskWithResult passed",
-                "AsyncTestClass.NullTask failed: The asynchronous method NullTask returned null, " +
-                "but a non-null awaitable object was expected.");
+        output.ShouldHaveResults(
+            "AsyncTestClass.AwaitTaskThenPass passed",
+            "AsyncTestClass.AwaitValueTaskThenPass passed",
+            "AsyncTestClass.CompleteTaskThenPass passed",
+            "AsyncTestClass.FailAfterAwaitTask failed: Expected: 0" + NewLine + "Actual:   3",
+            "AsyncTestClass.FailAfterAwaitValueTask failed: Expected: 0" + NewLine + "Actual:   3",
+            "AsyncTestClass.FailBeforeAwaitTask failed: 'FailBeforeAwaitTask' failed!",
+            "AsyncTestClass.FailBeforeAwaitValueTask failed: 'FailBeforeAwaitValueTask' failed!",
+            "AsyncTestClass.FailDuringAwaitTask failed: Attempted to divide by zero.",
+            "AsyncTestClass.FailDuringAwaitValueTask failed: Attempted to divide by zero.",
+            "AsyncTestClass.GenericAsyncTaskFail failed: Attempted to divide by zero.",
+            "AsyncTestClass.GenericAsyncTaskWithResult passed",
+            "AsyncTestClass.GenericAsyncValueTaskFail failed: Attempted to divide by zero.",
+            "AsyncTestClass.GenericAsyncValueTaskWithResult passed",
+            "AsyncTestClass.GenericTaskFail failed: One or more errors occurred. (Attempted to divide by zero.)",
+            "AsyncTestClass.GenericTaskWithResult passed",
+            "AsyncTestClass.NullTask failed: The asynchronous method NullTask returned null, " +
+            "but a non-null awaitable object was expected.");
 
-            output.ShouldHaveLifecycle(
-                "AwaitTaskThenPass",
-                "AwaitValueTaskThenPass",
-                "CompleteTaskThenPass",
-                "FailAfterAwaitTask",
-                "FailAfterAwaitValueTask",
-                "FailBeforeAwaitTask",
-                "FailBeforeAwaitValueTask",
-                "FailDuringAwaitTask",
-                "FailDuringAwaitValueTask",
-                "GenericAsyncTaskFail",
-                "GenericAsyncTaskWithResult",
-                "GenericAsyncValueTaskFail",
-                "GenericAsyncValueTaskWithResult",
-                "GenericTaskFail",
-                "GenericTaskWithResult",
-                "NullTask");
-        }
+        output.ShouldHaveLifecycle(
+            "AwaitTaskThenPass",
+            "AwaitValueTaskThenPass",
+            "CompleteTaskThenPass",
+            "FailAfterAwaitTask",
+            "FailAfterAwaitValueTask",
+            "FailBeforeAwaitTask",
+            "FailBeforeAwaitValueTask",
+            "FailDuringAwaitTask",
+            "FailDuringAwaitValueTask",
+            "GenericAsyncTaskFail",
+            "GenericAsyncTaskWithResult",
+            "GenericAsyncValueTaskFail",
+            "GenericAsyncValueTaskWithResult",
+            "GenericTaskFail",
+            "GenericTaskWithResult",
+            "NullTask");
+    }
 
     public async Task ShouldRunFSharpAsyncResultsToEnsureCompleteExecution()
     {
-            var output = await Run<FSharpAsyncTestClass>();
+        var output = await Run<FSharpAsyncTestClass>();
 
-            output.ShouldHaveResults(
-                "FSharpAsyncTestClass.AsyncPass passed",
-                "FSharpAsyncTestClass.FailBeforeAsync failed: 'FailBeforeAsync' failed!",
-                "FSharpAsyncTestClass.FailFromAsync failed: Expected: 0" + NewLine + "Actual:   3",
-                "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync returned null, " +
-                "but a non-null awaitable object was expected.");
+        output.ShouldHaveResults(
+            "FSharpAsyncTestClass.AsyncPass passed",
+            "FSharpAsyncTestClass.FailBeforeAsync failed: 'FailBeforeAsync' failed!",
+            "FSharpAsyncTestClass.FailFromAsync failed: Expected: 0" + NewLine + "Actual:   3",
+            "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync returned null, " +
+            "but a non-null awaitable object was expected.");
 
-            output.ShouldHaveLifecycle(
-                "AsyncPass",
-                "FailBeforeAsync",
-                "FailFromAsync",
-                "NullAsync");
-        }
+        output.ShouldHaveLifecycle(
+            "AsyncPass",
+            "FailBeforeAsync",
+            "FailFromAsync",
+            "NullAsync");
+    }
 
     public async Task ShouldFailWithClearExplanationWhenAsyncTestReturnsNonStartedTask()
     {
-            var output = await Run<FailDueToNonStartedTaskTestClass>();
+        var output = await Run<FailDueToNonStartedTaskTestClass>();
 
-            output.ShouldHaveResults(
-                "FailDueToNonStartedTaskTestClass.Test failed: The method Test returned a non-started task, which cannot " +
-                "be awaited. Consider using Task.Run or Task.Factory.StartNew.");
+        output.ShouldHaveResults(
+            "FailDueToNonStartedTaskTestClass.Test failed: The method Test returned a non-started task, which cannot " +
+            "be awaited. Consider using Task.Run or Task.Factory.StartNew.");
 
-            output.ShouldHaveLifecycle("Test");
-        }
+        output.ShouldHaveLifecycle("Test");
+    }
 
     public async Task ShouldFailUnsupportedReturnTypeDeclarationsRatherThanAttemptExecution()
     {
-            var output = await Run<UnsupportedReturnTypeDeclarationsTestClass>();
+        var output = await Run<UnsupportedReturnTypeDeclarationsTestClass>();
 
-            output.ShouldHaveResults(
-                "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerable failed: " +
-                "The return type of method AsyncEnumerable is an unsupported awaitable type. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
-                "or `ValueTask<T>`.",
+        output.ShouldHaveResults(
+            "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerable failed: " +
+            "The return type of method AsyncEnumerable is an unsupported awaitable type. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
+            "or `ValueTask<T>`.",
 
-                "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerator failed: " +
-                "The return type of method AsyncEnumerator is an unsupported awaitable type. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
-                "or `ValueTask<T>`.",
+            "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerator failed: " +
+            "The return type of method AsyncEnumerator is an unsupported awaitable type. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
+            "or `ValueTask<T>`.",
 
-                "UnsupportedReturnTypeDeclarationsTestClass.AsyncVoid failed: " +
-                "The method AsyncVoid is declared as `async void`, which is not supported. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method as `async Task`.",
+            "UnsupportedReturnTypeDeclarationsTestClass.AsyncVoid failed: " +
+            "The method AsyncVoid is declared as `async void`, which is not supported. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method as `async Task`.",
 
-                "UnsupportedReturnTypeDeclarationsTestClass.UntrustworthyAwaitable failed: " +
-                "The return type of method UntrustworthyAwaitable is an unsupported awaitable type. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
-                "or `ValueTask<T>`."
-            );
+            "UnsupportedReturnTypeDeclarationsTestClass.UntrustworthyAwaitable failed: " +
+            "The return type of method UntrustworthyAwaitable is an unsupported awaitable type. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
+            "or `ValueTask<T>`."
+        );
 
-            output.ShouldHaveLifecycle();
-        }
+        output.ShouldHaveLifecycle();
+    }
 
     static void ThrowException([CallerMemberName] string member = default!)
     {
-            throw new FailureException(member);
-        }
+        throw new FailureException(member);
+    }
 
     static Task<int> DivideAsync(int numerator, int denominator)
     {
-            return Task.Run(() => numerator/denominator);
-        }
+        return Task.Run(() => numerator/denominator);
+    }
 
     static int Divide(int numerator, int denominator)
     {
-            return numerator/denominator;
-        }
+        return numerator/denominator;
+    }
 
     class SyncTestClass
     {
         public int ReturnsInteger()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return 42;
-            }
+            return 42;
+        }
 
         public object? ReturnsNull()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return null;
-            }
+            return null;
+        }
 
         public object ReturnsObject()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return new Example("example");
-            }
+            return new Example("example");
+        }
 
         public string ReturnsString()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return "ABC";
-            }
+            return "ABC";
+        }
     }
 
     public class Example
@@ -188,240 +188,240 @@ public class ReturnTypeTests : InstrumentedExecutionTests
     {
         public async Task AwaitTaskThenPass()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = await DivideAsync(15, 5);
+            var result = await DivideAsync(15, 5);
 
-                result.ShouldBe(3);
-            }
+            result.ShouldBe(3);
+        }
 
         public async ValueTask AwaitValueTaskThenPass()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = await DivideAsync(15, 5);
+            var result = await DivideAsync(15, 5);
 
-                result.ShouldBe(3);
-            }
+            result.ShouldBe(3);
+        }
 
         public Task CompleteTaskThenPass()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var divide = DivideAsync(15, 5);
+            var divide = DivideAsync(15, 5);
 
-                return divide.ContinueWith(division =>
-                {
-                    division.Result.ShouldBe(3);
-                });
-            }
+            return divide.ContinueWith(division =>
+            {
+                division.Result.ShouldBe(3);
+            });
+        }
 
         public async Task FailAfterAwaitTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = await DivideAsync(15, 5);
+            var result = await DivideAsync(15, 5);
 
-                result.ShouldBe(0);
-            }
+            result.ShouldBe(0);
+        }
 
         public async ValueTask FailAfterAwaitValueTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var result = await DivideAsync(15, 5);
+            var result = await DivideAsync(15, 5);
 
-                result.ShouldBe(0);
-            }
+            result.ShouldBe(0);
+        }
 
         public async Task FailBeforeAwaitTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                ThrowException();
+            ThrowException();
 
-                await DivideAsync(15, 5);
-            }
+            await DivideAsync(15, 5);
+        }
 
         public async ValueTask FailBeforeAwaitValueTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                ThrowException();
+            ThrowException();
 
-                await DivideAsync(15, 5);
-            }
+            await DivideAsync(15, 5);
+        }
 
         public async Task FailDuringAwaitTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                await DivideAsync(15, 0);
+            await DivideAsync(15, 0);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
 
         public async ValueTask FailDuringAwaitValueTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                await DivideAsync(15, 0);
+            await DivideAsync(15, 0);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
 
         public async Task<int> GenericAsyncTaskFail()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return await DivideAsync(15, 0);
-            }
+            return await DivideAsync(15, 0);
+        }
 
         public async Task<int> GenericAsyncTaskWithResult()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return await DivideAsync(15, 5);
-            }
+            return await DivideAsync(15, 5);
+        }
 
         public async ValueTask<int> GenericAsyncValueTaskWithResult()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return await DivideAsync(20, 5);
-            }
+            return await DivideAsync(20, 5);
+        }
 
         public async ValueTask<int> GenericAsyncValueTaskFail()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return await DivideAsync(15, 0);
-            }
+            return await DivideAsync(15, 0);
+        }
 
         public Task<bool> GenericTaskFail()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var divide = DivideAsync(15, 0);
+            var divide = DivideAsync(15, 0);
 
-                return divide.ContinueWith(division => division.Result == 42);
-            }
+            return divide.ContinueWith(division => division.Result == 42);
+        }
 
         public Task<bool> GenericTaskWithResult()
         {
-                WhereAmI();
+            WhereAmI();
 
-                var divide = DivideAsync(15, 5);
+            var divide = DivideAsync(15, 5);
 
-                return divide.ContinueWith(division => division.Result == 3);
-            }
+            return divide.ContinueWith(division => division.Result == 3);
+        }
 
         public Task? NullTask()
         {
-                WhereAmI();
+            WhereAmI();
 
-                // Although unlikely, we must ensure that
-                // we don't attempt to wait on a Task that
-                // is in fact null.
-                return null;
-            }
+            // Although unlikely, we must ensure that
+            // we don't attempt to wait on a Task that
+            // is in fact null.
+            return null;
+        }
     }
 
     class FSharpAsyncTestClass
     {
         public FSharpAsync<int> AsyncPass()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return new FSharpAsync<int>(() =>
-                {
-                    var result = Divide(15, 5);
+            return new FSharpAsync<int>(() =>
+            {
+                var result = Divide(15, 5);
 
-                    result.ShouldBe(3);
+                result.ShouldBe(3);
 
-                    return result;
-                });
-            }
+                return result;
+            });
+        }
 
         public FSharpAsync<int> FailBeforeAsync()
         {
-                WhereAmI();
+            WhereAmI();
 
-                ThrowException();
+            ThrowException();
 
-                return new FSharpAsync<int>(() => Divide(15, 5));
-            }
+            return new FSharpAsync<int>(() => Divide(15, 5));
+        }
 
         public FSharpAsync<int> FailFromAsync()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return new FSharpAsync<int>(() =>
-                {
-                    var result = Divide(15, 5);
+            return new FSharpAsync<int>(() =>
+            {
+                var result = Divide(15, 5);
 
-                    result.ShouldBe(0);
+                result.ShouldBe(0);
 
-                    return result;
-                });
-            }
+                return result;
+            });
+        }
 
         public FSharpAsync<int>? NullAsync()
         {
-                WhereAmI();
+            WhereAmI();
 
-                // Although unlikely, we must ensure that
-                // we don't attempt to wait on an FSharpAsync that
-                // is in fact null.
-                return null;
-            }
+            // Although unlikely, we must ensure that
+            // we don't attempt to wait on an FSharpAsync that
+            // is in fact null.
+            return null;
+        }
     }
 
     class FailDueToNonStartedTaskTestClass
     {
         public Task Test()
         {
-                WhereAmI();
+            WhereAmI();
 
-                return new Task(() => throw new ShouldBeUnreachableException());
-            }
+            return new Task(() => throw new ShouldBeUnreachableException());
+        }
     }
 
     class UnsupportedReturnTypeDeclarationsTestClass
     {
         public async void AsyncVoid()
         {
-                WhereAmI();
+            WhereAmI();
 
-                await DivideAsync(15, 5);
-                throw new ShouldBeUnreachableException();
-            }
+            await DivideAsync(15, 5);
+            throw new ShouldBeUnreachableException();
+        }
 
         public async UntrustworthyAwaitable UntrustworthyAwaitable()
         {
-                WhereAmI();
+            WhereAmI();
 
-                await DivideAsync(15, 0);
+            await DivideAsync(15, 0);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
 
         public async IAsyncEnumerable<int> AsyncEnumerable()
         {
-                WhereAmI();
+            WhereAmI();
 
-                yield return await DivideAsync(15, 5);
+            yield return await DivideAsync(15, 5);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
 
         public async IAsyncEnumerator<int> AsyncEnumerator()
         {
-                WhereAmI();
+            WhereAmI();
 
-                yield return await DivideAsync(15, 5);
+            yield return await DivideAsync(15, 5);
 
-                throw new ShouldBeUnreachableException();
-            }
+            throw new ShouldBeUnreachableException();
+        }
     }
 }

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -1,16 +1,16 @@
-﻿namespace Fixie.Tests
-{
-    using System.Collections.Generic;
-    using System.Runtime.CompilerServices;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Microsoft.FSharp.Control;
-    using static System.Environment;
+﻿namespace Fixie.Tests;
 
-    public class ReturnTypeTests : InstrumentedExecutionTests
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Assertions;
+using Microsoft.FSharp.Control;
+using static System.Environment;
+
+public class ReturnTypeTests : InstrumentedExecutionTests
+{
+    public async Task ShouldInvokeSynchronousTestsDiscardingReturnedValues()
     {
-        public async Task ShouldInvokeSynchronousTestsDiscardingReturnedValues()
-        {
             var output = await Run<SyncTestClass>();
 
             output.ShouldHaveResults(
@@ -26,8 +26,8 @@
                 "ReturnsString");
         }
 
-        public async Task ShouldAwaitAsynchronousTestsToEnsureCompleteExecution()
-        {
+    public async Task ShouldAwaitAsynchronousTestsToEnsureCompleteExecution()
+    {
             var output = await Run<AsyncTestClass>();
 
             output.ShouldHaveResults(
@@ -68,8 +68,8 @@
                 "NullTask");
         }
 
-        public async Task ShouldRunFSharpAsyncResultsToEnsureCompleteExecution()
-        {
+    public async Task ShouldRunFSharpAsyncResultsToEnsureCompleteExecution()
+    {
             var output = await Run<FSharpAsyncTestClass>();
 
             output.ShouldHaveResults(
@@ -86,8 +86,8 @@
                 "NullAsync");
         }
 
-        public async Task ShouldFailWithClearExplanationWhenAsyncTestReturnsNonStartedTask()
-        {
+    public async Task ShouldFailWithClearExplanationWhenAsyncTestReturnsNonStartedTask()
+    {
             var output = await Run<FailDueToNonStartedTaskTestClass>();
 
             output.ShouldHaveResults(
@@ -97,8 +97,8 @@
             output.ShouldHaveLifecycle("Test");
         }
 
-        public async Task ShouldFailUnsupportedReturnTypeDeclarationsRatherThanAttemptExecution()
-        {
+    public async Task ShouldFailUnsupportedReturnTypeDeclarationsRatherThanAttemptExecution()
+    {
             var output = await Run<UnsupportedReturnTypeDeclarationsTestClass>();
 
             output.ShouldHaveResults(
@@ -129,65 +129,65 @@
             output.ShouldHaveLifecycle();
         }
 
-        static void ThrowException([CallerMemberName] string member = default!)
-        {
+    static void ThrowException([CallerMemberName] string member = default!)
+    {
             throw new FailureException(member);
         }
 
-        static Task<int> DivideAsync(int numerator, int denominator)
-        {
+    static Task<int> DivideAsync(int numerator, int denominator)
+    {
             return Task.Run(() => numerator/denominator);
         }
 
-        static int Divide(int numerator, int denominator)
-        {
+    static int Divide(int numerator, int denominator)
+    {
             return numerator/denominator;
         }
 
-        class SyncTestClass
+    class SyncTestClass
+    {
+        public int ReturnsInteger()
         {
-            public int ReturnsInteger()
-            {
                 WhereAmI();
 
                 return 42;
             }
 
-            public object? ReturnsNull()
-            {
+        public object? ReturnsNull()
+        {
                 WhereAmI();
 
                 return null;
             }
 
-            public object ReturnsObject()
-            {
+        public object ReturnsObject()
+        {
                 WhereAmI();
 
                 return new Example("example");
             }
 
-            public string ReturnsString()
-            {
+        public string ReturnsString()
+        {
                 WhereAmI();
 
                 return "ABC";
             }
-        }
+    }
 
-        public class Example
-        {
-            readonly string name;
+    public class Example
+    {
+        readonly string name;
 
-            public Example(string name) => this.name = name;
+        public Example(string name) => this.name = name;
             
-            public override string ToString() => $"<{name}>";
-        }
+        public override string ToString() => $"<{name}>";
+    }
 
-        class AsyncTestClass
+    class AsyncTestClass
+    {
+        public async Task AwaitTaskThenPass()
         {
-            public async Task AwaitTaskThenPass()
-            {
                 WhereAmI();
 
                 var result = await DivideAsync(15, 5);
@@ -195,8 +195,8 @@
                 result.ShouldBe(3);
             }
 
-            public async ValueTask AwaitValueTaskThenPass()
-            {
+        public async ValueTask AwaitValueTaskThenPass()
+        {
                 WhereAmI();
 
                 var result = await DivideAsync(15, 5);
@@ -204,8 +204,8 @@
                 result.ShouldBe(3);
             }
 
-            public Task CompleteTaskThenPass()
-            {
+        public Task CompleteTaskThenPass()
+        {
                 WhereAmI();
 
                 var divide = DivideAsync(15, 5);
@@ -216,8 +216,8 @@
                 });
             }
 
-            public async Task FailAfterAwaitTask()
-            {
+        public async Task FailAfterAwaitTask()
+        {
                 WhereAmI();
 
                 var result = await DivideAsync(15, 5);
@@ -225,8 +225,8 @@
                 result.ShouldBe(0);
             }
 
-            public async ValueTask FailAfterAwaitValueTask()
-            {
+        public async ValueTask FailAfterAwaitValueTask()
+        {
                 WhereAmI();
 
                 var result = await DivideAsync(15, 5);
@@ -234,8 +234,8 @@
                 result.ShouldBe(0);
             }
 
-            public async Task FailBeforeAwaitTask()
-            {
+        public async Task FailBeforeAwaitTask()
+        {
                 WhereAmI();
 
                 ThrowException();
@@ -243,8 +243,8 @@
                 await DivideAsync(15, 5);
             }
 
-            public async ValueTask FailBeforeAwaitValueTask()
-            {
+        public async ValueTask FailBeforeAwaitValueTask()
+        {
                 WhereAmI();
 
                 ThrowException();
@@ -252,8 +252,8 @@
                 await DivideAsync(15, 5);
             }
 
-            public async Task FailDuringAwaitTask()
-            {
+        public async Task FailDuringAwaitTask()
+        {
                 WhereAmI();
 
                 await DivideAsync(15, 0);
@@ -261,8 +261,8 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            public async ValueTask FailDuringAwaitValueTask()
-            {
+        public async ValueTask FailDuringAwaitValueTask()
+        {
                 WhereAmI();
 
                 await DivideAsync(15, 0);
@@ -270,36 +270,36 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            public async Task<int> GenericAsyncTaskFail()
-            {
+        public async Task<int> GenericAsyncTaskFail()
+        {
                 WhereAmI();
 
                 return await DivideAsync(15, 0);
             }
 
-            public async Task<int> GenericAsyncTaskWithResult()
-            {
+        public async Task<int> GenericAsyncTaskWithResult()
+        {
                 WhereAmI();
 
                 return await DivideAsync(15, 5);
             }
 
-            public async ValueTask<int> GenericAsyncValueTaskWithResult()
-            {
+        public async ValueTask<int> GenericAsyncValueTaskWithResult()
+        {
                 WhereAmI();
 
                 return await DivideAsync(20, 5);
             }
 
-            public async ValueTask<int> GenericAsyncValueTaskFail()
-            {
+        public async ValueTask<int> GenericAsyncValueTaskFail()
+        {
                 WhereAmI();
 
                 return await DivideAsync(15, 0);
             }
 
-            public Task<bool> GenericTaskFail()
-            {
+        public Task<bool> GenericTaskFail()
+        {
                 WhereAmI();
 
                 var divide = DivideAsync(15, 0);
@@ -307,8 +307,8 @@
                 return divide.ContinueWith(division => division.Result == 42);
             }
 
-            public Task<bool> GenericTaskWithResult()
-            {
+        public Task<bool> GenericTaskWithResult()
+        {
                 WhereAmI();
 
                 var divide = DivideAsync(15, 5);
@@ -316,8 +316,8 @@
                 return divide.ContinueWith(division => division.Result == 3);
             }
 
-            public Task? NullTask()
-            {
+        public Task? NullTask()
+        {
                 WhereAmI();
 
                 // Although unlikely, we must ensure that
@@ -325,12 +325,12 @@
                 // is in fact null.
                 return null;
             }
-        }
+    }
 
-        class FSharpAsyncTestClass
+    class FSharpAsyncTestClass
+    {
+        public FSharpAsync<int> AsyncPass()
         {
-            public FSharpAsync<int> AsyncPass()
-            {
                 WhereAmI();
 
                 return new FSharpAsync<int>(() =>
@@ -343,8 +343,8 @@
                 });
             }
 
-            public FSharpAsync<int> FailBeforeAsync()
-            {
+        public FSharpAsync<int> FailBeforeAsync()
+        {
                 WhereAmI();
 
                 ThrowException();
@@ -352,8 +352,8 @@
                 return new FSharpAsync<int>(() => Divide(15, 5));
             }
 
-            public FSharpAsync<int> FailFromAsync()
-            {
+        public FSharpAsync<int> FailFromAsync()
+        {
                 WhereAmI();
 
                 return new FSharpAsync<int>(() =>
@@ -366,8 +366,8 @@
                 });
             }
 
-            public FSharpAsync<int>? NullAsync()
-            {
+        public FSharpAsync<int>? NullAsync()
+        {
                 WhereAmI();
 
                 // Although unlikely, we must ensure that
@@ -375,30 +375,30 @@
                 // is in fact null.
                 return null;
             }
-        }
+    }
 
-        class FailDueToNonStartedTaskTestClass
+    class FailDueToNonStartedTaskTestClass
+    {
+        public Task Test()
         {
-            public Task Test()
-            {
                 WhereAmI();
 
                 return new Task(() => throw new ShouldBeUnreachableException());
             }
-        }
+    }
 
-        class UnsupportedReturnTypeDeclarationsTestClass
+    class UnsupportedReturnTypeDeclarationsTestClass
+    {
+        public async void AsyncVoid()
         {
-            public async void AsyncVoid()
-            {
                 WhereAmI();
 
                 await DivideAsync(15, 5);
                 throw new ShouldBeUnreachableException();
             }
 
-            public async UntrustworthyAwaitable UntrustworthyAwaitable()
-            {
+        public async UntrustworthyAwaitable UntrustworthyAwaitable()
+        {
                 WhereAmI();
 
                 await DivideAsync(15, 0);
@@ -406,8 +406,8 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            public async IAsyncEnumerable<int> AsyncEnumerable()
-            {
+        public async IAsyncEnumerable<int> AsyncEnumerable()
+        {
                 WhereAmI();
 
                 yield return await DivideAsync(15, 5);
@@ -415,14 +415,13 @@
                 throw new ShouldBeUnreachableException();
             }
 
-            public async IAsyncEnumerator<int> AsyncEnumerator()
-            {
+        public async IAsyncEnumerator<int> AsyncEnumerator()
+        {
                 WhereAmI();
 
                 yield return await DivideAsync(15, 5);
 
                 throw new ShouldBeUnreachableException();
             }
-        }
     }
 }

--- a/src/Fixie.Tests/SelfTestDiscovery.cs
+++ b/src/Fixie.Tests/SelfTestDiscovery.cs
@@ -1,20 +1,19 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+public class SelfTestDiscovery : IDiscovery
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-
-    public class SelfTestDiscovery : IDiscovery
+    public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
     {
-        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-        {
-            return concreteClasses
-                .Where(x => x.IsNestedPrivate || x.IsNestedFamily)
-                .Where(x => x.Name.EndsWith("TestClass"));
-        }
-
-        public virtual IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-            => publicMethods.OrderBy(x => x.Name, StringComparer.Ordinal);
+        return concreteClasses
+            .Where(x => x.IsNestedPrivate || x.IsNestedFamily)
+            .Where(x => x.Name.EndsWith("TestClass"));
     }
+
+    public virtual IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+        => publicMethods.OrderBy(x => x.Name, StringComparer.Ordinal);
 }

--- a/src/Fixie.Tests/ShouldBeUnreachableException.cs
+++ b/src/Fixie.Tests/ShouldBeUnreachableException.cs
@@ -1,11 +1,10 @@
-﻿namespace Fixie.Tests
-{
-    using System;
-    using System.Runtime.CompilerServices;
+﻿namespace Fixie.Tests;
 
-    public class ShouldBeUnreachableException : Exception
-    {
-        public ShouldBeUnreachableException([CallerMemberName] string member = default!)
-            : base($"'{member}' reached a line of code thought to be unreachable.") { }
-    }
+using System;
+using System.Runtime.CompilerServices;
+
+public class ShouldBeUnreachableException : Exception
+{
+    public ShouldBeUnreachableException([CallerMemberName] string member = default!)
+        : base($"'{member}' reached a line of code thought to be unreachable.") { }
 }

--- a/src/Fixie.Tests/ShuffleExtensionsTests.cs
+++ b/src/Fixie.Tests/ShuffleExtensionsTests.cs
@@ -1,14 +1,14 @@
-namespace Fixie.Tests
+namespace Fixie.Tests;
+
+using System;
+using Assertions;
+
+public class ShuffleExtensionsTests
 {
-    using System;
-    using Assertions;
+    const int Seed = 42;
 
-    public class ShuffleExtensionsTests
+    public void ShouldProvideCollectionItemsInRandomOrder()
     {
-        const int Seed = 42;
-
-        public void ShouldProvideCollectionItemsInRandomOrder()
-        {
             new[] {1, 2, 3, 4, 5}
                 .Shuffle(new Random(Seed))
                 .ShouldBe(3, 2, 5, 1, 4);
@@ -17,5 +17,4 @@ namespace Fixie.Tests
                 .Shuffle(new Random(Seed))
                 .ShouldBe('d', ' ', 'H', 'l', 'l', 'W', 'r', 'o', 'l', 'e', 'o');
         }
-    }
 }

--- a/src/Fixie.Tests/ShuffleExtensionsTests.cs
+++ b/src/Fixie.Tests/ShuffleExtensionsTests.cs
@@ -9,12 +9,12 @@ public class ShuffleExtensionsTests
 
     public void ShouldProvideCollectionItemsInRandomOrder()
     {
-            new[] {1, 2, 3, 4, 5}
-                .Shuffle(new Random(Seed))
-                .ShouldBe(3, 2, 5, 1, 4);
+        new[] {1, 2, 3, 4, 5}
+            .Shuffle(new Random(Seed))
+            .ShouldBe(3, 2, 5, 1, 4);
 
-            "Hello World"
-                .Shuffle(new Random(Seed))
-                .ShouldBe('d', ' ', 'H', 'l', 'l', 'W', 'r', 'o', 'l', 'e', 'o');
-        }
+        "Hello World"
+            .Shuffle(new Random(Seed))
+            .ShouldBe('d', ' ', 'H', 'l', 'l', 'W', 'r', 'o', 'l', 'e', 'o');
+    }
 }

--- a/src/Fixie.Tests/SkipAttribute.cs
+++ b/src/Fixie.Tests/SkipAttribute.cs
@@ -1,12 +1,11 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+using System;
+
+[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+public class SkipAttribute : Attribute
 {
-    using System;
+    public SkipAttribute(string reason) => Reason = reason;
 
-    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-    public class SkipAttribute : Attribute
-    {
-        public SkipAttribute(string reason) => Reason = reason;
-
-        public string Reason { get; }
-    }
+    public string Reason { get; }
 }

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -13,182 +13,182 @@ public class StackTracePresentationTests
 {
     public async Task ShouldProvideCleanStackTraceForImplicitTestClassConstructionFailures()
     {
-            (await Run<ConstructionFailureTestClass, ImplicitExceptionHandling>())
-                .ShouldBe(
-                    "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
-                    "",
-                    "'.ctor' failed!",
-                    "",
-                    "Fixie.Tests.FailureException",
-                    At<ConstructionFailureTestClass>(".ctor()"),
-                    "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
-                    "",
-                    "1 failed, took 1.23 seconds");
-        }
+        (await Run<ConstructionFailureTestClass, ImplicitExceptionHandling>())
+            .ShouldBe(
+                "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
+                "",
+                "'.ctor' failed!",
+                "",
+                "Fixie.Tests.FailureException",
+                At<ConstructionFailureTestClass>(".ctor()"),
+                "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
+                "",
+                "1 failed, took 1.23 seconds");
+    }
         
     public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestClassConstructionFailures()
     {
-            (await Run<ConstructionFailureTestClass, ExplicitExceptionHandling>())
-                .ShouldBe(
-                    "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
-                    "",
-                    "'.ctor' failed!",
-                    "",
-                    "Fixie.Tests.FailureException",
-                    At<ConstructionFailureTestClass>(".ctor()"),
-                    "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
-                    "--- End of stack trace from previous location where exception was thrown ---",
-                    At(typeof(TestClass), "Construct(Object[] parameters)", Path.Join("...", "src", "Fixie", "TestClass.cs")),
-                    At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
-                    "",
-                    "1 failed, took 1.23 seconds");
-        }
+        (await Run<ConstructionFailureTestClass, ExplicitExceptionHandling>())
+            .ShouldBe(
+                "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
+                "",
+                "'.ctor' failed!",
+                "",
+                "Fixie.Tests.FailureException",
+                At<ConstructionFailureTestClass>(".ctor()"),
+                "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
+                "--- End of stack trace from previous location where exception was thrown ---",
+                At(typeof(TestClass), "Construct(Object[] parameters)", Path.Join("...", "src", "Fixie", "TestClass.cs")),
+                At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
+                "",
+                "1 failed, took 1.23 seconds");
+    }
 
     public async Task ShouldProvideCleanStackTraceTestMethodFailures()
     {
-            (await Run<FailureTestClass, ImplicitExceptionHandling>())
-                .ShouldBe(
-                    "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
-                    "",
-                    "'Asynchronous' failed!",
-                    "",
-                    "Fixie.Tests.FailureException",
-                    At<FailureTestClass>("Asynchronous()"),
-                    "",
-                    "Test '" + FullName<FailureTestClass>() + ".Synchronous' failed:",
-                    "",
-                    "'Synchronous' failed!",
-                    "",
-                    "Fixie.Tests.FailureException",
-                    At<FailureTestClass>("Synchronous()"),
-                    "",
-                    "2 failed, took 1.23 seconds");
-        }
+        (await Run<FailureTestClass, ImplicitExceptionHandling>())
+            .ShouldBe(
+                "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
+                "",
+                "'Asynchronous' failed!",
+                "",
+                "Fixie.Tests.FailureException",
+                At<FailureTestClass>("Asynchronous()"),
+                "",
+                "Test '" + FullName<FailureTestClass>() + ".Synchronous' failed:",
+                "",
+                "'Synchronous' failed!",
+                "",
+                "Fixie.Tests.FailureException",
+                At<FailureTestClass>("Synchronous()"),
+                "",
+                "2 failed, took 1.23 seconds");
+    }
 
     public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestMethodInvocationFailures()
     {
-            var output = (await Run<FailureTestClass, ExplicitExceptionHandling>()).ToArray();
+        var output = (await Run<FailureTestClass, ExplicitExceptionHandling>()).ToArray();
 
-            const string optimizedInvoker = "   at InvokeStub_FailureTestClass.Synchronous(Object, Object, IntPtr*)";
-            const string initialInvoker = "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
+        const string optimizedInvoker = "   at InvokeStub_FailureTestClass.Synchronous(Object, Object, IntPtr*)";
+        const string initialInvoker = "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
 
-            output
-                .ShouldBe(
-                    "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
-                    "",
-                    "'Asynchronous' failed!",
-                    "",
-                    "Fixie.Tests.FailureException",
-                    At<FailureTestClass>("Asynchronous()"),
-                    At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                    At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                    At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
-                    "",
-                    "Test '" + FullName<FailureTestClass>() + ".Synchronous' failed:",
-                    "",
-                    "'Synchronous' failed!",
-                    "",
-                    "Fixie.Tests.FailureException",
-                    At<FailureTestClass>("Synchronous()"),
-                    output.Contains(optimizedInvoker)
-                        ? optimizedInvoker
-                        : initialInvoker,
-                    "   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)",
-                    "--- End of stack trace from previous location where exception was thrown ---",
-                    At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                    At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                    At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
-                    "",
-                    "2 failed, took 1.23 seconds");
-        }
+        output
+            .ShouldBe(
+                "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
+                "",
+                "'Asynchronous' failed!",
+                "",
+                "Fixie.Tests.FailureException",
+                At<FailureTestClass>("Asynchronous()"),
+                At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
+                At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
+                At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
+                "",
+                "Test '" + FullName<FailureTestClass>() + ".Synchronous' failed:",
+                "",
+                "'Synchronous' failed!",
+                "",
+                "Fixie.Tests.FailureException",
+                At<FailureTestClass>("Synchronous()"),
+                output.Contains(optimizedInvoker)
+                    ? optimizedInvoker
+                    : initialInvoker,
+                "   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)",
+                "--- End of stack trace from previous location where exception was thrown ---",
+                At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
+                At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
+                At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
+                "",
+                "2 failed, took 1.23 seconds");
+    }
 
     public async Task ShouldProvideLiterateStackTraceIncludingAllNestedExceptions()
     {
-            (await Run<NestedFailureTestClass, ImplicitExceptionHandling>())
-                .ShouldBe(
-                    "Test '" + FullName<NestedFailureTestClass>() + ".Asynchronous' failed:",
-                    "",
-                    "Primary Exception!",
-                    "",
-                    FullName<PrimaryException>(),
-                    At<StackTracePresentationTests>("ThrowNestedException()"),
-                    At<NestedFailureTestClass>("Asynchronous()"),
-                    "",
-                    "------- Inner Exception: System.AggregateException -------",
-                    "One or more errors occurred. (Divide by Zero Exception!)",
-                    At<StackTracePresentationTests>("ThrowNestedException()"),
-                    "",
-                    "------- Inner Exception: System.DivideByZeroException -------",
-                    "Divide by Zero Exception!",
-                    At<StackTracePresentationTests>("ThrowNestedException()"),
-                    "",
-                    "Test '" + FullName<NestedFailureTestClass>() + ".Synchronous' failed:",
-                    "",
-                    "Primary Exception!",
-                    "",
-                    FullName<PrimaryException>(),
-                    At<StackTracePresentationTests>("ThrowNestedException()"),
-                    At<NestedFailureTestClass>("Synchronous()"),
-                    "",
-                    "------- Inner Exception: System.AggregateException -------",
-                    "One or more errors occurred. (Divide by Zero Exception!)",
-                    At<StackTracePresentationTests>("ThrowNestedException()"),
-                    "",
-                    "------- Inner Exception: System.DivideByZeroException -------",
-                    "Divide by Zero Exception!",
-                    At<StackTracePresentationTests>("ThrowNestedException()"),
-                    "",
-                    "2 failed, took 1.23 seconds");
-        }
+        (await Run<NestedFailureTestClass, ImplicitExceptionHandling>())
+            .ShouldBe(
+                "Test '" + FullName<NestedFailureTestClass>() + ".Asynchronous' failed:",
+                "",
+                "Primary Exception!",
+                "",
+                FullName<PrimaryException>(),
+                At<StackTracePresentationTests>("ThrowNestedException()"),
+                At<NestedFailureTestClass>("Asynchronous()"),
+                "",
+                "------- Inner Exception: System.AggregateException -------",
+                "One or more errors occurred. (Divide by Zero Exception!)",
+                At<StackTracePresentationTests>("ThrowNestedException()"),
+                "",
+                "------- Inner Exception: System.DivideByZeroException -------",
+                "Divide by Zero Exception!",
+                At<StackTracePresentationTests>("ThrowNestedException()"),
+                "",
+                "Test '" + FullName<NestedFailureTestClass>() + ".Synchronous' failed:",
+                "",
+                "Primary Exception!",
+                "",
+                FullName<PrimaryException>(),
+                At<StackTracePresentationTests>("ThrowNestedException()"),
+                At<NestedFailureTestClass>("Synchronous()"),
+                "",
+                "------- Inner Exception: System.AggregateException -------",
+                "One or more errors occurred. (Divide by Zero Exception!)",
+                At<StackTracePresentationTests>("ThrowNestedException()"),
+                "",
+                "------- Inner Exception: System.DivideByZeroException -------",
+                "Divide by Zero Exception!",
+                At<StackTracePresentationTests>("ThrowNestedException()"),
+                "",
+                "2 failed, took 1.23 seconds");
+    }
 
     static async Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : IExecution, new()
     {
-            var discovery = new SelfTestDiscovery();
-            var execution = new TExecution();
+        var discovery = new SelfTestDiscovery();
+        var execution = new TExecution();
 
-            using var console = new RedirectedConsole();
+        using var console = new RedirectedConsole();
 
-            var report = new ConsoleReport(GetTestEnvironment());
-            
-            await Utility.Run(report, discovery, execution, typeof(TSampleTestClass));
+        var report = new ConsoleReport(GetTestEnvironment());
+        
+        await Utility.Run(report, discovery, execution, typeof(TSampleTestClass));
 
-            return console.Lines()
-                .NormalizeStackTraceLines()
-                .CleanDuration();
-        }
+        return console.Lines()
+            .NormalizeStackTraceLines()
+            .CleanDuration();
+    }
 
     class ImplicitExceptionHandling : IExecution
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var test in testSuite.Tests)
-                    await test.Run();
-            }
+            foreach (var test in testSuite.Tests)
+                await test.Run();
+        }
     }
 
     class ExplicitExceptionHandling : IExecution
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var testClass in testSuite.TestClasses)
+            foreach (var testClass in testSuite.TestClasses)
+            {
+                foreach (var test in testClass.Tests)
                 {
-                    foreach (var test in testClass.Tests)
+                    try
                     {
-                        try
-                        {
-                            var instance = testClass.Construct();
+                        var instance = testClass.Construct();
 
-                            await test.Method.Call(instance);
+                        await test.Method.Call(instance);
 
-                            await test.Pass();
-                        }
-                        catch (Exception exception)
-                        {
-                            await test.Fail(exception);
-                        }
+                        await test.Pass();
+                    }
+                    catch (Exception exception)
+                    {
+                        await test.Fail(exception);
                     }
                 }
             }
+        }
     }
 
     class ConstructionFailureTestClass
@@ -201,48 +201,48 @@ public class StackTracePresentationTests
     {
         public void Synchronous()
         {
-                throw new FailureException();
-            }
+            throw new FailureException();
+        }
 
         public async Task Asynchronous()
         {
-                await Task.Yield();
-                throw new FailureException();
-            }
+            await Task.Yield();
+            throw new FailureException();
+        }
     }
 
     class NestedFailureTestClass
     {
         public void Synchronous()
         {
-                ThrowNestedException();
-            }
+            ThrowNestedException();
+        }
 
         public async Task Asynchronous()
         {
-                await Task.Yield();
-                ThrowNestedException();
-            }
+            await Task.Yield();
+            ThrowNestedException();
+        }
     }
 
     static void ThrowNestedException()
     {
+        try
+        {
             try
             {
-                try
-                {
-                    throw new DivideByZeroException("Divide by Zero Exception!");
-                }
-                catch (Exception exception)
-                {
-                    throw new AggregateException(exception);
-                }
+                throw new DivideByZeroException("Divide by Zero Exception!");
             }
             catch (Exception exception)
             {
-                throw new PrimaryException(exception);
+                throw new AggregateException(exception);
             }
         }
+        catch (Exception exception)
+        {
+            throw new PrimaryException(exception);
+        }
+    }
 
     class PrimaryException : Exception
     {

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -1,18 +1,18 @@
-﻿namespace Fixie.Tests
-{
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Assertions;
-    using Fixie.Reports;
-    using static Utility;
+﻿namespace Fixie.Tests;
 
-    public class StackTracePresentationTests
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Assertions;
+using Fixie.Reports;
+using static Utility;
+
+public class StackTracePresentationTests
+{
+    public async Task ShouldProvideCleanStackTraceForImplicitTestClassConstructionFailures()
     {
-        public async Task ShouldProvideCleanStackTraceForImplicitTestClassConstructionFailures()
-        {
             (await Run<ConstructionFailureTestClass, ImplicitExceptionHandling>())
                 .ShouldBe(
                     "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
@@ -26,8 +26,8 @@
                     "1 failed, took 1.23 seconds");
         }
         
-        public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestClassConstructionFailures()
-        {
+    public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestClassConstructionFailures()
+    {
             (await Run<ConstructionFailureTestClass, ExplicitExceptionHandling>())
                 .ShouldBe(
                     "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
@@ -44,8 +44,8 @@
                     "1 failed, took 1.23 seconds");
         }
 
-        public async Task ShouldProvideCleanStackTraceTestMethodFailures()
-        {
+    public async Task ShouldProvideCleanStackTraceTestMethodFailures()
+    {
             (await Run<FailureTestClass, ImplicitExceptionHandling>())
                 .ShouldBe(
                     "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
@@ -65,8 +65,8 @@
                     "2 failed, took 1.23 seconds");
         }
 
-        public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestMethodInvocationFailures()
-        {
+    public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestMethodInvocationFailures()
+    {
             var output = (await Run<FailureTestClass, ExplicitExceptionHandling>()).ToArray();
 
             const string optimizedInvoker = "   at InvokeStub_FailureTestClass.Synchronous(Object, Object, IntPtr*)";
@@ -102,8 +102,8 @@
                     "2 failed, took 1.23 seconds");
         }
 
-        public async Task ShouldProvideLiterateStackTraceIncludingAllNestedExceptions()
-        {
+    public async Task ShouldProvideLiterateStackTraceIncludingAllNestedExceptions()
+    {
             (await Run<NestedFailureTestClass, ImplicitExceptionHandling>())
                 .ShouldBe(
                     "Test '" + FullName<NestedFailureTestClass>() + ".Asynchronous' failed:",
@@ -141,8 +141,8 @@
                     "2 failed, took 1.23 seconds");
         }
 
-        static async Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : IExecution, new()
-        {
+    static async Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : IExecution, new()
+    {
             var discovery = new SelfTestDiscovery();
             var execution = new TExecution();
 
@@ -157,19 +157,19 @@
                 .CleanDuration();
         }
 
-        class ImplicitExceptionHandling : IExecution
+    class ImplicitExceptionHandling : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var test in testSuite.Tests)
                     await test.Run();
             }
-        }
+    }
 
-        class ExplicitExceptionHandling : IExecution
+    class ExplicitExceptionHandling : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var testClass in testSuite.TestClasses)
                 {
                     foreach (var test in testClass.Tests)
@@ -189,44 +189,44 @@
                     }
                 }
             }
-        }
+    }
 
-        class ConstructionFailureTestClass
-        {
-            public ConstructionFailureTestClass() => throw new FailureException();
-            public void UnreachableTest() => throw new ShouldBeUnreachableException();
-        }
+    class ConstructionFailureTestClass
+    {
+        public ConstructionFailureTestClass() => throw new FailureException();
+        public void UnreachableTest() => throw new ShouldBeUnreachableException();
+    }
 
-        class FailureTestClass
+    class FailureTestClass
+    {
+        public void Synchronous()
         {
-            public void Synchronous()
-            {
                 throw new FailureException();
             }
 
-            public async Task Asynchronous()
-            {
+        public async Task Asynchronous()
+        {
                 await Task.Yield();
                 throw new FailureException();
             }
-        }
+    }
 
-        class NestedFailureTestClass
+    class NestedFailureTestClass
+    {
+        public void Synchronous()
         {
-            public void Synchronous()
-            {
                 ThrowNestedException();
             }
 
-            public async Task Asynchronous()
-            {
+        public async Task Asynchronous()
+        {
                 await Task.Yield();
                 ThrowNestedException();
             }
-        }
+    }
 
-        static void ThrowNestedException()
-        {
+    static void ThrowNestedException()
+    {
             try
             {
                 try
@@ -244,10 +244,9 @@
             }
         }
 
-        class PrimaryException : Exception
-        {
-            public PrimaryException(Exception innerException)
-                : base("Primary Exception!", innerException) { }
-        }
+    class PrimaryException : Exception
+    {
+        public PrimaryException(Exception innerException)
+            : base("Primary Exception!", innerException) { }
     }
 }

--- a/src/Fixie.Tests/StubReport.cs
+++ b/src/Fixie.Tests/StubReport.cs
@@ -1,41 +1,40 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Fixie.Reports;
+
+public class StubReport :
+    IHandler<TestDiscovered>,
+    IHandler<TestSkipped>,
+    IHandler<TestPassed>,
+    IHandler<TestFailed>
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Fixie.Reports;
+    readonly List<string> log = new List<string>();
 
-    public class StubReport :
-        IHandler<TestDiscovered>,
-        IHandler<TestSkipped>,
-        IHandler<TestPassed>,
-        IHandler<TestFailed>
+    public Task Handle(TestDiscovered message)
     {
-        readonly List<string> log = new List<string>();
-
-        public Task Handle(TestDiscovered message)
-        {
-            log.Add($"{message.Test} discovered");
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestSkipped message)
-        {
-            log.Add($"{message.TestCase} skipped: {message.Reason}");
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestPassed message)
-        {
-            log.Add($"{message.TestCase} passed");
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestFailed message)
-        {
-            log.Add($"{message.TestCase} failed: {message.Reason.Message}");
-            return Task.CompletedTask;
-        }
-
-        public IEnumerable<string> Entries => log;
+        log.Add($"{message.Test} discovered");
+        return Task.CompletedTask;
     }
+
+    public Task Handle(TestSkipped message)
+    {
+        log.Add($"{message.TestCase} skipped: {message.Reason}");
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestPassed message)
+    {
+        log.Add($"{message.TestCase} passed");
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestFailed message)
+    {
+        log.Add($"{message.TestCase} failed: {message.Reason.Message}");
+        return Task.CompletedTask;
+    }
+
+    public IEnumerable<string> Entries => log;
 }

--- a/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
@@ -22,72 +22,72 @@ public class SourceLocationProviderTests
 
     public void ShouldSafelyFailForUnknownMethods()
     {
-            AssertNoLineNumber("NonExistentClass.NonExistentMethod");
-            AssertNoLineNumber(FullName<SourceLocationSamples>() + ".NonExistentMethod");
-        }
+        AssertNoLineNumber("NonExistentClass.NonExistentMethod");
+        AssertNoLineNumber(FullName<SourceLocationSamples>() + ".NonExistentMethod");
+    }
 
     public void ShouldFailForUnparsableTestNames()
     {
-            AssertNoLineNumber("TestNameUnparsableAsFullyQualifiedMethodName");
-            AssertNoLineNumber("TestNameUnparsableAsFullyQualifiedMethodNameEndingWithDot.");
-            AssertNoLineNumber(".TestNameUnparsableAsFullyQualifiedMethodNameStartingWithDot");
-        }
+        AssertNoLineNumber("TestNameUnparsableAsFullyQualifiedMethodName");
+        AssertNoLineNumber("TestNameUnparsableAsFullyQualifiedMethodNameEndingWithDot.");
+        AssertNoLineNumber(".TestNameUnparsableAsFullyQualifiedMethodNameStartingWithDot");
+    }
 
     public void ShouldDetectLineNumbersOfEmptyMethods()
     {
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_OneLine", 8, 8);
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_TwoLines", 11, 12);
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_ThreeLines", 15, 17);
-        }
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_OneLine", 8, 8);
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_TwoLines", 11, 12);
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_ThreeLines", 15, 17);
+    }
 
     public void ShouldDetectLineNumbersOfSynchronousMethods()
     {
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".Simple", 20, 21);
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".Generic", 26, 27);
-        }
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".Simple", 20, 21);
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".Generic", 26, 27);
+    }
 
     public void ShouldDetectLineNumbersOfAsyncMethods()
     {
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_Void", 31, 32);
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_Task", 38, 39);
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_TaskOfT", 45, 46);
-        }
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_Void", 31, 32);
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_Task", 38, 39);
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_TaskOfT", 45, 46);
+    }
 
     public void ShouldDetectLineNumbersOfMethodsWithinNestedClasses()
     {
-            AssertLineNumber(FullName<SourceLocationSamples.NestedClass>() + ".NestedMethod", 54, 55);
-        }
+        AssertLineNumber(FullName<SourceLocationSamples.NestedClass>() + ".NestedMethod", 54, 55);
+    }
 
     public void ShouldSafelyFailForUnknownLineNumbers()
     {
-            AssertNoLineNumber(FullName<SourceLocationSamples>() + ".Hidden");
-        }
+        AssertNoLineNumber(FullName<SourceLocationSamples>() + ".Hidden");
+    }
 
     public void ShouldDetectLineNumberOfFirstOccurrenceOfOverloadedMethods()
     {
-            // VsTest's test running infrastructure is incapable of distinguishing
-            // overloads, even if we were to report accurate line numbers for each individually.
-            // The compromise that all major .NET test frameworks have to make is to report
-            // the line number of *one* of the overload occurrences.
+        // VsTest's test running infrastructure is incapable of distinguishing
+        // overloads, even if we were to report accurate line numbers for each individually.
+        // The compromise that all major .NET test frameworks have to make is to report
+        // the line number of *one* of the overload occurrences.
 
-            AssertLineNumber(FullName<SourceLocationSamples>() + ".Overloaded", 66, 66);
-        }
+        AssertLineNumber(FullName<SourceLocationSamples>() + ".Overloaded", 66, 66);
+    }
 
     public void ShouldSafelyFailForInheritedMethodsBecauseTheRequestIsAmbiguous()
     {
-            AssertLineNumber(FullName<SourceLocationSamples.BaseClass>() + ".Inherited", 72, 72);
-            AssertNoLineNumber(FullName<SourceLocationSamples.ChildClass>() + ".Inherited");
-        }
+        AssertLineNumber(FullName<SourceLocationSamples.BaseClass>() + ".Inherited", 72, 72);
+        AssertNoLineNumber(FullName<SourceLocationSamples.ChildClass>() + ".Inherited");
+    }
 
     static void AssertNoLineNumber(string test)
     {
-            var sourceLocationProvider = new SourceLocationProvider(TestAssemblyPath);
+        var sourceLocationProvider = new SourceLocationProvider(TestAssemblyPath);
 
-            var success = sourceLocationProvider.TryGetSourceLocation(test, out var location);
+        var success = sourceLocationProvider.TryGetSourceLocation(test, out var location);
 
-            success.ShouldBe(false);
-            location.ShouldBe(null);
-        }
+        success.ShouldBe(false);
+        location.ShouldBe(null);
+    }
 
     static void AssertLineNumber(string test, int debugLine, int releaseLine)
     {
@@ -101,7 +101,7 @@ public class SourceLocationProviderTests
 #if DEBUG
         location.LineNumber.ShouldBe(debugLine);
 #else
-            location.LineNumber.ShouldBe(releaseLine);
+        location.LineNumber.ShouldBe(releaseLine);
 #endif
     }
 }

--- a/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
@@ -1,70 +1,70 @@
-﻿namespace Fixie.Tests.TestAdapter
+﻿namespace Fixie.Tests.TestAdapter;
+
+using System;
+using Fixie.TestAdapter;
+using Assertions;
+using static Utility;
+
+public class SourceLocationProviderTests
 {
-    using System;
-    using Fixie.TestAdapter;
-    using Assertions;
-    using static Utility;
+    // Ensure that during the assembly-wide scan of types, methods with no possible
+    // body definition are present. This way, we can be sure that method source location
+    // scanning safely bypasses these irrelevant methods.
+    interface SampleInterface { void MethodWithNoBody(); }
+    abstract class SampleAbstractClass { public abstract void MethodWithNoBody(); }
 
-    public class SourceLocationProviderTests
+    // Line numbers vary slightly between Debug and Release modes.
+    //
+    //      Debug: opening curly brace.
+    //      Release: first non-comment code line or closing curly brace if the method is empty.
+
+    static readonly string TestAssemblyPath = typeof(SourceLocationSamples).Assembly.Location;
+
+    public void ShouldSafelyFailForUnknownMethods()
     {
-        // Ensure that during the assembly-wide scan of types, methods with no possible
-        // body definition are present. This way, we can be sure that method source location
-        // scanning safely bypasses these irrelevant methods.
-        interface SampleInterface { void MethodWithNoBody(); }
-        abstract class SampleAbstractClass { public abstract void MethodWithNoBody(); }
-
-        // Line numbers vary slightly between Debug and Release modes.
-        //
-        //      Debug: opening curly brace.
-        //      Release: first non-comment code line or closing curly brace if the method is empty.
-
-        static readonly string TestAssemblyPath = typeof(SourceLocationSamples).Assembly.Location;
-
-        public void ShouldSafelyFailForUnknownMethods()
-        {
             AssertNoLineNumber("NonExistentClass.NonExistentMethod");
             AssertNoLineNumber(FullName<SourceLocationSamples>() + ".NonExistentMethod");
         }
 
-        public void ShouldFailForUnparsableTestNames()
-        {
+    public void ShouldFailForUnparsableTestNames()
+    {
             AssertNoLineNumber("TestNameUnparsableAsFullyQualifiedMethodName");
             AssertNoLineNumber("TestNameUnparsableAsFullyQualifiedMethodNameEndingWithDot.");
             AssertNoLineNumber(".TestNameUnparsableAsFullyQualifiedMethodNameStartingWithDot");
         }
 
-        public void ShouldDetectLineNumbersOfEmptyMethods()
-        {
+    public void ShouldDetectLineNumbersOfEmptyMethods()
+    {
             AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_OneLine", 8, 8);
             AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_TwoLines", 11, 12);
             AssertLineNumber(FullName<SourceLocationSamples>() + ".Empty_ThreeLines", 15, 17);
         }
 
-        public void ShouldDetectLineNumbersOfSynchronousMethods()
-        {
+    public void ShouldDetectLineNumbersOfSynchronousMethods()
+    {
             AssertLineNumber(FullName<SourceLocationSamples>() + ".Simple", 20, 21);
             AssertLineNumber(FullName<SourceLocationSamples>() + ".Generic", 26, 27);
         }
 
-        public void ShouldDetectLineNumbersOfAsyncMethods()
-        {
+    public void ShouldDetectLineNumbersOfAsyncMethods()
+    {
             AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_Void", 31, 32);
             AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_Task", 38, 39);
             AssertLineNumber(FullName<SourceLocationSamples>() + ".AsyncMethod_TaskOfT", 45, 46);
         }
 
-        public void ShouldDetectLineNumbersOfMethodsWithinNestedClasses()
-        {
+    public void ShouldDetectLineNumbersOfMethodsWithinNestedClasses()
+    {
             AssertLineNumber(FullName<SourceLocationSamples.NestedClass>() + ".NestedMethod", 54, 55);
         }
 
-        public void ShouldSafelyFailForUnknownLineNumbers()
-        {
+    public void ShouldSafelyFailForUnknownLineNumbers()
+    {
             AssertNoLineNumber(FullName<SourceLocationSamples>() + ".Hidden");
         }
 
-        public void ShouldDetectLineNumberOfFirstOccurrenceOfOverloadedMethods()
-        {
+    public void ShouldDetectLineNumberOfFirstOccurrenceOfOverloadedMethods()
+    {
             // VsTest's test running infrastructure is incapable of distinguishing
             // overloads, even if we were to report accurate line numbers for each individually.
             // The compromise that all major .NET test frameworks have to make is to report
@@ -73,14 +73,14 @@
             AssertLineNumber(FullName<SourceLocationSamples>() + ".Overloaded", 66, 66);
         }
 
-        public void ShouldSafelyFailForInheritedMethodsBecauseTheRequestIsAmbiguous()
-        {
+    public void ShouldSafelyFailForInheritedMethodsBecauseTheRequestIsAmbiguous()
+    {
             AssertLineNumber(FullName<SourceLocationSamples.BaseClass>() + ".Inherited", 72, 72);
             AssertNoLineNumber(FullName<SourceLocationSamples.ChildClass>() + ".Inherited");
         }
 
-        static void AssertNoLineNumber(string test)
-        {
+    static void AssertNoLineNumber(string test)
+    {
             var sourceLocationProvider = new SourceLocationProvider(TestAssemblyPath);
 
             var success = sourceLocationProvider.TryGetSourceLocation(test, out var location);
@@ -89,20 +89,19 @@
             location.ShouldBe(null);
         }
 
-        static void AssertLineNumber(string test, int debugLine, int releaseLine)
-        {
-            var sourceLocationProvider = new SourceLocationProvider(TestAssemblyPath);
+    static void AssertLineNumber(string test, int debugLine, int releaseLine)
+    {
+        var sourceLocationProvider = new SourceLocationProvider(TestAssemblyPath);
 
-            if (!sourceLocationProvider.TryGetSourceLocation(test, out var location))
-                throw new Exception($"Expected to find a SourceLocation for method {test}.");
+        if (!sourceLocationProvider.TryGetSourceLocation(test, out var location))
+            throw new Exception($"Expected to find a SourceLocation for method {test}.");
 
-            location.CodeFilePath.EndsWith("SourceLocationSamples.cs").ShouldBe(true);
+        location.CodeFilePath.EndsWith("SourceLocationSamples.cs").ShouldBe(true);
             
-            #if DEBUG
-            location.LineNumber.ShouldBe(debugLine);
-            #else
+#if DEBUG
+        location.LineNumber.ShouldBe(debugLine);
+#else
             location.LineNumber.ShouldBe(releaseLine);
-            #endif
-        }
+#endif
     }
 }

--- a/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
@@ -9,58 +9,58 @@ public class SourceLocationSamples
 
     public void Empty_TwoLines()
     { // Debug = 11
-        } // Release = 12
+    } // Release = 12
 
     public void Empty_ThreeLines()
     { // Debug = 15
 
-        } // Release = 17
+    } // Release = 17
 
     public void Simple()
     { // Debug = 20
-            int answer = 42; // Release = 21
-            Console.Write(answer);
-        }
+        int answer = 42; // Release = 21
+        Console.Write(answer);
+    }
 
     public void Generic<T>(T x)
     { // Debug = 26
-            Console.WriteLine(); // Release = 27
-        }
+        Console.WriteLine(); // Release = 27
+    }
 
     public async void AsyncMethod_Void()
     { // Debug = 31
-            int answer = 42; // Release = 32
-            await Task.Delay(0);
-            Console.Write(answer);
-        }
+        int answer = 42; // Release = 32
+        await Task.Delay(0);
+        Console.Write(answer);
+    }
 
     public async Task AsyncMethod_Task()
     { // Debug = 38
-            int answer = 42; // Release = 39
-            await Task.Delay(0);
-            Console.Write(answer);
-        }
+        int answer = 42; // Release = 39
+        await Task.Delay(0);
+        Console.Write(answer);
+    }
 
     public async Task<int> AsyncMethod_TaskOfT()
     { // Debug = 45
-            int answer = 42; // Release = 46
-            await Task.Delay(0);
-            return answer;
-        }
+        int answer = 42; // Release = 46
+        await Task.Delay(0);
+        return answer;
+    }
 
     public class NestedClass
     {
         public void NestedMethod()
         { // Debug = 54
-                int answer = 42; // Release = 55
-                Console.Write(answer);
-            }
+            int answer = 42; // Release = 55
+            Console.Write(answer);
+        }
     }
 
 #line hidden
     public void Hidden()
     {
-        }
+    }
 #line default
 
     public void Overloaded() { } // Debug = Release = 66

--- a/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
@@ -1,79 +1,78 @@
-﻿namespace Fixie.Tests.TestAdapter
+﻿namespace Fixie.Tests.TestAdapter;
+
+using System;
+using System.Threading.Tasks;
+
+public class SourceLocationSamples
 {
-    using System;
-    using System.Threading.Tasks;
+    public void Empty_OneLine() { } // Debug = Release = 8
 
-    public class SourceLocationSamples
-    {
-        public void Empty_OneLine() { } // Debug = Release = 8
-
-        public void Empty_TwoLines()
-        { // Debug = 11
+    public void Empty_TwoLines()
+    { // Debug = 11
         } // Release = 12
 
-        public void Empty_ThreeLines()
-        { // Debug = 15
+    public void Empty_ThreeLines()
+    { // Debug = 15
 
         } // Release = 17
 
-        public void Simple()
-        { // Debug = 20
+    public void Simple()
+    { // Debug = 20
             int answer = 42; // Release = 21
             Console.Write(answer);
         }
 
-        public void Generic<T>(T x)
-        { // Debug = 26
+    public void Generic<T>(T x)
+    { // Debug = 26
             Console.WriteLine(); // Release = 27
         }
 
-        public async void AsyncMethod_Void()
-        { // Debug = 31
+    public async void AsyncMethod_Void()
+    { // Debug = 31
             int answer = 42; // Release = 32
             await Task.Delay(0);
             Console.Write(answer);
         }
 
-        public async Task AsyncMethod_Task()
-        { // Debug = 38
+    public async Task AsyncMethod_Task()
+    { // Debug = 38
             int answer = 42; // Release = 39
             await Task.Delay(0);
             Console.Write(answer);
         }
 
-        public async Task<int> AsyncMethod_TaskOfT()
-        { // Debug = 45
+    public async Task<int> AsyncMethod_TaskOfT()
+    { // Debug = 45
             int answer = 42; // Release = 46
             await Task.Delay(0);
             return answer;
         }
 
-        public class NestedClass
-        {
-            public void NestedMethod()
-            { // Debug = 54
+    public class NestedClass
+    {
+        public void NestedMethod()
+        { // Debug = 54
                 int answer = 42; // Release = 55
                 Console.Write(answer);
             }
-        }
+    }
 
 #line hidden
-        public void Hidden()
-        {
+    public void Hidden()
+    {
         }
 #line default
 
-        public void Overloaded() { } // Debug = Release = 66
+    public void Overloaded() { } // Debug = Release = 66
 
-        public void Overloaded(int y) { } // Debug = Release = 68
+    public void Overloaded(int y) { } // Debug = Release = 68
 
-        public class BaseClass
-        {
-            public void Inherited() { } // Debug = Release = 72
-        }
+    public class BaseClass
+    {
+        public void Inherited() { } // Debug = Release = 72
+    }
 
-        public class ChildClass : BaseClass
-        {
-        }
+    public class ChildClass : BaseClass
+    {
     }
 }

--- a/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
+++ b/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
@@ -1,62 +1,61 @@
-﻿namespace Fixie.Tests.TestAdapter
+﻿namespace Fixie.Tests.TestAdapter;
+
+using Assertions;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+public static class TestCaseMappingAssertions
 {
-    using Assertions;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-
-    public static class TestCaseMappingAssertions
+    public static void ShouldBeDiscoveryTimeTest(this TestCase test, string expectedFullyQualifiedName, string expectedSource)
     {
-        public static void ShouldBeDiscoveryTimeTest(this TestCase test, string expectedFullyQualifiedName, string expectedSource)
-        {
-            ShouldHaveIdentity(test, expectedFullyQualifiedName, expectedSource);
+        ShouldHaveIdentity(test, expectedFullyQualifiedName, expectedSource);
 
-            ShouldUseDefaultsForUnmappedProperties(test);
+        ShouldUseDefaultsForUnmappedProperties(test);
 
-            ShouldHaveSourceLocation(test);
-        }
+        ShouldHaveSourceLocation(test);
+    }
 
-        public static void ShouldBeDiscoveryTimeTestMissingSourceLocation(this TestCase test, string expectedFullyQualifiedName, string expectedSource)
-        {
-            ShouldHaveIdentity(test, expectedFullyQualifiedName, expectedSource);
+    public static void ShouldBeDiscoveryTimeTestMissingSourceLocation(this TestCase test, string expectedFullyQualifiedName, string expectedSource)
+    {
+        ShouldHaveIdentity(test, expectedFullyQualifiedName, expectedSource);
 
-            ShouldUseDefaultsForUnmappedProperties(test);
+        ShouldUseDefaultsForUnmappedProperties(test);
 
-            ShouldNotHaveSourceLocation(test);
-        }
+        ShouldNotHaveSourceLocation(test);
+    }
 
-        public static void ShouldBeExecutionTimeTest(this TestCase test, string expectedFullyQualifiedName, string expectedSource)
-        {
-            ShouldHaveIdentity(test, expectedFullyQualifiedName, expectedSource);
+    public static void ShouldBeExecutionTimeTest(this TestCase test, string expectedFullyQualifiedName, string expectedSource)
+    {
+        ShouldHaveIdentity(test, expectedFullyQualifiedName, expectedSource);
 
-            ShouldUseDefaultsForUnmappedProperties(test);
+        ShouldUseDefaultsForUnmappedProperties(test);
 
-            //Source locations are a discovery-time concern.
-            ShouldNotHaveSourceLocation(test);
-        }
+        //Source locations are a discovery-time concern.
+        ShouldNotHaveSourceLocation(test);
+    }
 
-        static void ShouldHaveIdentity(TestCase test, string expectedFullyQualifiedName, string expectedSource)
-        {
-            test.FullyQualifiedName.ShouldBe(expectedFullyQualifiedName);
-            test.DisplayName.ShouldBe(test.FullyQualifiedName);
-            test.Source.ShouldBe(expectedSource);
-        }
+    static void ShouldHaveIdentity(TestCase test, string expectedFullyQualifiedName, string expectedSource)
+    {
+        test.FullyQualifiedName.ShouldBe(expectedFullyQualifiedName);
+        test.DisplayName.ShouldBe(test.FullyQualifiedName);
+        test.Source.ShouldBe(expectedSource);
+    }
 
-        static void ShouldUseDefaultsForUnmappedProperties(TestCase test)
-        {
-            test.Traits.ShouldBeEmpty();
-            test.ExecutorUri.ToString().ShouldBe("executor://fixie.testadapter/");
-        }
+    static void ShouldUseDefaultsForUnmappedProperties(TestCase test)
+    {
+        test.Traits.ShouldBeEmpty();
+        test.ExecutorUri.ToString().ShouldBe("executor://fixie.testadapter/");
+    }
 
-        static void ShouldHaveSourceLocation(TestCase test)
-        {
-            test.CodeFilePath.ShouldNotBeNull();
-            test.CodeFilePath.EndsWith("MessagingTests.cs").ShouldBe(true);
-            test.LineNumber.ShouldBeGreaterThan(0);
-        }
+    static void ShouldHaveSourceLocation(TestCase test)
+    {
+        test.CodeFilePath.ShouldNotBeNull();
+        test.CodeFilePath.EndsWith("MessagingTests.cs").ShouldBe(true);
+        test.LineNumber.ShouldBeGreaterThan(0);
+    }
 
-        static void ShouldNotHaveSourceLocation(TestCase test)
-        {
-            test.CodeFilePath.ShouldBe(null);
-            test.LineNumber.ShouldBe(-1);
-        }
+    static void ShouldNotHaveSourceLocation(TestCase test)
+    {
+        test.CodeFilePath.ShouldBe(null);
+        test.LineNumber.ShouldBe(-1);
     }
 }

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -1,20 +1,20 @@
-﻿namespace Fixie.Tests.TestAdapter
-{
-    using System.Collections.Generic;
-    using System.IO;
-    using Assertions;
-    using Fixie.Internal;
-    using Fixie.TestAdapter;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-    using Reports;
-    using static System.IO.Directory;
+﻿namespace Fixie.Tests.TestAdapter;
 
-    public class VsDiscoveryRecorderTests : MessagingTests
+using System.Collections.Generic;
+using System.IO;
+using Assertions;
+using Fixie.Internal;
+using Fixie.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Reports;
+using static System.IO.Directory;
+
+public class VsDiscoveryRecorderTests : MessagingTests
+{
+    public void ShouldMapDiscoveredTestsToVsTestDiscoverySink()
     {
-        public void ShouldMapDiscoveredTestsToVsTestDiscoverySink()
-        {
             var assemblyPath = typeof(MessagingTests).Assembly.Location;
 
             var log = new StubMessageLogger();
@@ -34,8 +34,8 @@
                 x => x.ShouldBeDiscoveryTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath));
         }
 
-        public void ShouldDefaultSourceLocationPropertiesWhenSourceInspectionThrows()
-        {
+    public void ShouldDefaultSourceLocationPropertiesWhenSourceInspectionThrows()
+    {
             const string invalidAssemblyPath = "assembly.path.dll";
 
             var log = new StubMessageLogger();
@@ -63,8 +63,8 @@
                 x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(GenericTestClass + ".ShouldBeString", invalidAssemblyPath));
         }
 
-        void RecordAnticipatedPipeMessages(VsDiscoveryRecorder vsDiscoveryRecorder)
-        {
+    void RecordAnticipatedPipeMessages(VsDiscoveryRecorder vsDiscoveryRecorder)
+    {
             vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
             {
                 Test = TestClass + ".Fail"
@@ -91,20 +91,19 @@
             });
         }
 
-        class StubMessageLogger : IMessageLogger
-        {
-            public List<string> Messages { get; } = new List<string>();
+    class StubMessageLogger : IMessageLogger
+    {
+        public List<string> Messages { get; } = new List<string>();
 
-            public void SendMessage(TestMessageLevel testMessageLevel, string message)
-                => Messages.Add($"{testMessageLevel}: {message}");
-        }
+        public void SendMessage(TestMessageLevel testMessageLevel, string message)
+            => Messages.Add($"{testMessageLevel}: {message}");
+    }
 
-        class StubTestCaseDiscoverySink : ITestCaseDiscoverySink
-        {
-            public List<TestCase> TestCases { get; } = new List<TestCase>();
+    class StubTestCaseDiscoverySink : ITestCaseDiscoverySink
+    {
+        public List<TestCase> TestCases { get; } = new List<TestCase>();
 
-            public void SendTestCase(TestCase discoveredTest)
-                => TestCases.Add(discoveredTest);
-        }
+        public void SendTestCase(TestCase discoveredTest)
+            => TestCases.Add(discoveredTest);
     }
 }

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -15,81 +15,81 @@ public class VsDiscoveryRecorderTests : MessagingTests
 {
     public void ShouldMapDiscoveredTestsToVsTestDiscoverySink()
     {
-            var assemblyPath = typeof(MessagingTests).Assembly.Location;
+        var assemblyPath = typeof(MessagingTests).Assembly.Location;
 
-            var log = new StubMessageLogger();
-            var discoverySink = new StubTestCaseDiscoverySink();
+        var log = new StubMessageLogger();
+        var discoverySink = new StubTestCaseDiscoverySink();
 
-            var vsDiscoveryRecorder = new VsDiscoveryRecorder(log, discoverySink, assemblyPath);
+        var vsDiscoveryRecorder = new VsDiscoveryRecorder(log, discoverySink, assemblyPath);
 
-            RecordAnticipatedPipeMessages(vsDiscoveryRecorder);
+        RecordAnticipatedPipeMessages(vsDiscoveryRecorder);
 
-            log.Messages.ShouldBeEmpty();
+        log.Messages.ShouldBeEmpty();
 
-            discoverySink.TestCases.ShouldSatisfy(
-                x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Fail", assemblyPath),
-                x => x.ShouldBeDiscoveryTimeTest(TestClass + ".FailByAssertion", assemblyPath),
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", assemblyPath),
-                x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Skip", assemblyPath),
-                x => x.ShouldBeDiscoveryTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath));
-        }
+        discoverySink.TestCases.ShouldSatisfy(
+            x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Fail", assemblyPath),
+            x => x.ShouldBeDiscoveryTimeTest(TestClass + ".FailByAssertion", assemblyPath),
+            x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", assemblyPath),
+            x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Skip", assemblyPath),
+            x => x.ShouldBeDiscoveryTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath));
+    }
 
     public void ShouldDefaultSourceLocationPropertiesWhenSourceInspectionThrows()
     {
-            const string invalidAssemblyPath = "assembly.path.dll";
+        const string invalidAssemblyPath = "assembly.path.dll";
 
-            var log = new StubMessageLogger();
-            var discoverySink = new StubTestCaseDiscoverySink();
+        var log = new StubMessageLogger();
+        var discoverySink = new StubTestCaseDiscoverySink();
 
-            var discoveryRecorder = new VsDiscoveryRecorder(log, discoverySink, invalidAssemblyPath);
+        var discoveryRecorder = new VsDiscoveryRecorder(log, discoverySink, invalidAssemblyPath);
 
-            RecordAnticipatedPipeMessages(discoveryRecorder);
+        RecordAnticipatedPipeMessages(discoveryRecorder);
 
-            var expectedError =
-                $"Error: {typeof(FileNotFoundException).FullName}: " +
-                $"Could not find file '{Path.Combine(GetCurrentDirectory(), invalidAssemblyPath)}'.";
-            log.Messages.ShouldSatisfy(
-                x => x.Contains(expectedError).ShouldBe(true),
-                x => x.Contains(expectedError).ShouldBe(true),
-                x => x.Contains(expectedError).ShouldBe(true),
-                x => x.Contains(expectedError).ShouldBe(true),
-                x => x.Contains(expectedError).ShouldBe(true));
+        var expectedError =
+            $"Error: {typeof(FileNotFoundException).FullName}: " +
+            $"Could not find file '{Path.Combine(GetCurrentDirectory(), invalidAssemblyPath)}'.";
+        log.Messages.ShouldSatisfy(
+            x => x.Contains(expectedError).ShouldBe(true),
+            x => x.Contains(expectedError).ShouldBe(true),
+            x => x.Contains(expectedError).ShouldBe(true),
+            x => x.Contains(expectedError).ShouldBe(true),
+            x => x.Contains(expectedError).ShouldBe(true));
 
-            discoverySink.TestCases.ShouldSatisfy(
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Fail", invalidAssemblyPath),
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".FailByAssertion", invalidAssemblyPath),
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", invalidAssemblyPath),
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Skip", invalidAssemblyPath),
-                x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(GenericTestClass + ".ShouldBeString", invalidAssemblyPath));
-        }
+        discoverySink.TestCases.ShouldSatisfy(
+            x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Fail", invalidAssemblyPath),
+            x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".FailByAssertion", invalidAssemblyPath),
+            x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", invalidAssemblyPath),
+            x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Skip", invalidAssemblyPath),
+            x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(GenericTestClass + ".ShouldBeString", invalidAssemblyPath));
+    }
 
     void RecordAnticipatedPipeMessages(VsDiscoveryRecorder vsDiscoveryRecorder)
     {
-            vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
-            {
-                Test = TestClass + ".Fail"
-            });
+        vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
+        {
+            Test = TestClass + ".Fail"
+        });
 
-            vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
-            {
-                Test = TestClass + ".FailByAssertion"
-            });
+        vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
+        {
+            Test = TestClass + ".FailByAssertion"
+        });
 
-            vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
-            {
-                Test = TestClass + ".Pass"
-            });
+        vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
+        {
+            Test = TestClass + ".Pass"
+        });
 
-            vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
-            {
-                Test = TestClass + ".Skip"
-            });
+        vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
+        {
+            Test = TestClass + ".Skip"
+        });
 
-            vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
-            {
-                Test = GenericTestClass + ".ShouldBeString"
-            });
-        }
+        vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
+        {
+            Test = GenericTestClass + ".ShouldBeString"
+        });
+    }
 
     class StubMessageLogger : IMessageLogger
     {

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -16,262 +16,262 @@ public class VsExecutionRecorderTests : MessagingTests
 {
     public void ShouldMapMessagesToVsTestExecutionRecorder()
     {
-            const string assemblyPath = "assembly.path.dll";
-            var recorder = new StubExecutionRecorder();
+        const string assemblyPath = "assembly.path.dll";
+        var recorder = new StubExecutionRecorder();
 
-            var vsExecutionRecorder = new VsExecutionRecorder(recorder, assemblyPath);
+        var vsExecutionRecorder = new VsExecutionRecorder(recorder, assemblyPath);
 
-            RecordAnticipatedPipeMessages(vsExecutionRecorder);
+        RecordAnticipatedPipeMessages(vsExecutionRecorder);
 
-            var messages = recorder.Messages;
+        var messages = recorder.Messages;
 
-            messages.Count.ShouldBe(13);
+        messages.Count.ShouldBe(13);
 
-            foreach (var message in messages)
+        foreach (var message in messages)
+        {
+            if (message is TestResult result)
             {
-                if (message is TestResult result)
-                {
-                    result.Traits.ShouldBeEmpty();
-                    result.Attachments.ShouldBeEmpty();
-                    result.ComputerName.ShouldBe(MachineName);
-                }
+                result.Traits.ShouldBeEmpty();
+                result.Attachments.ShouldBeEmpty();
+                result.ComputerName.ShouldBe(MachineName);
             }
-
-            var failStart = (TestCase)messages[0];
-            var fail = (TestResult)messages[1];
-            
-            var failByAssertionStart = (TestCase)messages[2];
-            var failByAssertion = (TestResult)messages[3];
-            
-            var passStart = (TestCase)messages[4];
-            var pass = (TestResult)messages[5];
-            
-            var skip = (TestResult)messages[6];
-            
-            var shouldBeStringPassAStart = (TestCase)messages[7];
-            var shouldBeStringPassA = (TestResult)messages[8];
-            
-            var shouldBeStringPassBStart = (TestCase)messages[9];
-            var shouldBeStringPassB = (TestResult)messages[10];
-            
-            var shouldBeStringFailStart = (TestCase)messages[11];
-            var shouldBeStringFail = (TestResult)messages[12];
-
-            failStart.ShouldBeExecutionTimeTest(TestClass + ".Fail", assemblyPath);
-
-            fail.TestCase.ShouldBeExecutionTimeTest(TestClass+".Fail", assemblyPath);
-            fail.TestCase.DisplayName.ShouldBe(TestClass+".Fail");
-            fail.Outcome.ShouldBe(TestOutcome.Failed);
-            fail.ErrorMessage.ShouldBe("'Fail' failed!");
-            fail.ErrorStackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
-            fail.DisplayName.ShouldBe(TestClass+".Fail");
-            fail.Messages.Count.ShouldBe(1);
-            fail.Messages[0].Category.ShouldBe(TestResultMessage.StandardOutCategory);
-            fail.Messages[0].Text.Lines().ShouldBe("Standard Out: Fail");
-            fail.Duration.ShouldBe(TimeSpan.FromMilliseconds(102));
-
-            failByAssertionStart.ShouldBeExecutionTimeTest(TestClass + ".FailByAssertion", assemblyPath);
-
-            failByAssertion.TestCase.ShouldBeExecutionTimeTest(TestClass+".FailByAssertion", assemblyPath);
-            failByAssertion.TestCase.DisplayName.ShouldBe(TestClass+".FailByAssertion");
-            failByAssertion.Outcome.ShouldBe(TestOutcome.Failed);
-            failByAssertion.ErrorMessage.Lines().ShouldBe(
-                "Expected: 2",
-                "Actual:   1");
-            failByAssertion.ErrorStackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
-            failByAssertion.DisplayName.ShouldBe(TestClass+".FailByAssertion");
-            failByAssertion.Messages.Count.ShouldBe(1);
-            failByAssertion.Messages[0].Category.ShouldBe(TestResultMessage.StandardOutCategory);
-            failByAssertion.Messages[0].Text.Lines().ShouldBe("Standard Out: FailByAssertion");
-            failByAssertion.Duration.ShouldBe(TimeSpan.FromMilliseconds(103));
-
-            passStart.ShouldBeExecutionTimeTest(TestClass + ".Pass", assemblyPath);
-
-            pass.TestCase.ShouldBeExecutionTimeTest(TestClass+".Pass", assemblyPath);
-            pass.TestCase.DisplayName.ShouldBe(TestClass+".Pass");
-            pass.Outcome.ShouldBe(TestOutcome.Passed);
-            pass.ErrorMessage.ShouldBe(null);
-            pass.ErrorStackTrace.ShouldBe(null);
-            pass.DisplayName.ShouldBe(TestClass+".Pass");
-            pass.Messages.Count.ShouldBe(1);
-            pass.Messages[0].Category.ShouldBe(TestResultMessage.StandardOutCategory);
-            pass.Messages[0].Text.Lines().ShouldBe("Standard Out: Pass");
-            pass.Duration.ShouldBe(TimeSpan.FromMilliseconds(104));
-
-            skip.TestCase.ShouldBeExecutionTimeTest(TestClass+".Skip", assemblyPath);
-            skip.TestCase.DisplayName.ShouldBe(TestClass+".Skip");
-            skip.Outcome.ShouldBe(TestOutcome.Skipped);
-            skip.ErrorMessage.ShouldBe("⚠ Skipped with attribute.");
-            skip.ErrorStackTrace.ShouldBe(null);
-            skip.DisplayName.ShouldBe(TestClass+".Skip");
-            skip.Messages.ShouldBeEmpty();
-            skip.Duration.ShouldBe(TimeSpan.Zero);
-
-            shouldBeStringPassAStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
-
-            shouldBeStringPassA.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
-            shouldBeStringPassA.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
-            shouldBeStringPassA.Outcome.ShouldBe(TestOutcome.Passed);
-            shouldBeStringPassA.ErrorMessage.ShouldBe(null);
-            shouldBeStringPassA.ErrorStackTrace.ShouldBe(null);
-            shouldBeStringPassA.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.String>(\"A\")");
-            shouldBeStringPassA.Messages.ShouldBeEmpty();
-            shouldBeStringPassA.Duration.ShouldBe(TimeSpan.FromMilliseconds(105));
-
-            shouldBeStringPassBStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
-
-            shouldBeStringPassB.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
-            shouldBeStringPassB.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
-            shouldBeStringPassB.Outcome.ShouldBe(TestOutcome.Passed);
-            shouldBeStringPassB.ErrorMessage.ShouldBe(null);
-            shouldBeStringPassB.ErrorStackTrace.ShouldBe(null);
-            shouldBeStringPassB.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.String>(\"B\")");
-            shouldBeStringPassB.Messages.ShouldBeEmpty();
-            shouldBeStringPassB.Duration.ShouldBe(TimeSpan.FromMilliseconds(106));
-
-
-            shouldBeStringFailStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
-
-            shouldBeStringFail.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
-            shouldBeStringFail.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
-            shouldBeStringFail.Outcome.ShouldBe(TestOutcome.Failed);
-            shouldBeStringFail.ErrorMessage.Lines().ShouldBe(
-                "Expected: System.String",
-                "Actual:   System.Int32");
-            shouldBeStringFail.ErrorStackTrace
-                .Lines()
-                .NormalizeStackTraceLines()
-                .ShouldBe(
-                    "Fixie.Tests.Assertions.AssertException",
-                    At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
-            shouldBeStringFail.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.Int32>(123)");
-            shouldBeStringFail.Messages.ShouldBeEmpty();
-            shouldBeStringFail.Duration.ShouldBe(TimeSpan.FromMilliseconds(107));
         }
+
+        var failStart = (TestCase)messages[0];
+        var fail = (TestResult)messages[1];
+        
+        var failByAssertionStart = (TestCase)messages[2];
+        var failByAssertion = (TestResult)messages[3];
+        
+        var passStart = (TestCase)messages[4];
+        var pass = (TestResult)messages[5];
+        
+        var skip = (TestResult)messages[6];
+        
+        var shouldBeStringPassAStart = (TestCase)messages[7];
+        var shouldBeStringPassA = (TestResult)messages[8];
+        
+        var shouldBeStringPassBStart = (TestCase)messages[9];
+        var shouldBeStringPassB = (TestResult)messages[10];
+        
+        var shouldBeStringFailStart = (TestCase)messages[11];
+        var shouldBeStringFail = (TestResult)messages[12];
+
+        failStart.ShouldBeExecutionTimeTest(TestClass + ".Fail", assemblyPath);
+
+        fail.TestCase.ShouldBeExecutionTimeTest(TestClass+".Fail", assemblyPath);
+        fail.TestCase.DisplayName.ShouldBe(TestClass+".Fail");
+        fail.Outcome.ShouldBe(TestOutcome.Failed);
+        fail.ErrorMessage.ShouldBe("'Fail' failed!");
+        fail.ErrorStackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
+        fail.DisplayName.ShouldBe(TestClass+".Fail");
+        fail.Messages.Count.ShouldBe(1);
+        fail.Messages[0].Category.ShouldBe(TestResultMessage.StandardOutCategory);
+        fail.Messages[0].Text.Lines().ShouldBe("Standard Out: Fail");
+        fail.Duration.ShouldBe(TimeSpan.FromMilliseconds(102));
+
+        failByAssertionStart.ShouldBeExecutionTimeTest(TestClass + ".FailByAssertion", assemblyPath);
+
+        failByAssertion.TestCase.ShouldBeExecutionTimeTest(TestClass+".FailByAssertion", assemblyPath);
+        failByAssertion.TestCase.DisplayName.ShouldBe(TestClass+".FailByAssertion");
+        failByAssertion.Outcome.ShouldBe(TestOutcome.Failed);
+        failByAssertion.ErrorMessage.Lines().ShouldBe(
+            "Expected: 2",
+            "Actual:   1");
+        failByAssertion.ErrorStackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
+        failByAssertion.DisplayName.ShouldBe(TestClass+".FailByAssertion");
+        failByAssertion.Messages.Count.ShouldBe(1);
+        failByAssertion.Messages[0].Category.ShouldBe(TestResultMessage.StandardOutCategory);
+        failByAssertion.Messages[0].Text.Lines().ShouldBe("Standard Out: FailByAssertion");
+        failByAssertion.Duration.ShouldBe(TimeSpan.FromMilliseconds(103));
+
+        passStart.ShouldBeExecutionTimeTest(TestClass + ".Pass", assemblyPath);
+
+        pass.TestCase.ShouldBeExecutionTimeTest(TestClass+".Pass", assemblyPath);
+        pass.TestCase.DisplayName.ShouldBe(TestClass+".Pass");
+        pass.Outcome.ShouldBe(TestOutcome.Passed);
+        pass.ErrorMessage.ShouldBe(null);
+        pass.ErrorStackTrace.ShouldBe(null);
+        pass.DisplayName.ShouldBe(TestClass+".Pass");
+        pass.Messages.Count.ShouldBe(1);
+        pass.Messages[0].Category.ShouldBe(TestResultMessage.StandardOutCategory);
+        pass.Messages[0].Text.Lines().ShouldBe("Standard Out: Pass");
+        pass.Duration.ShouldBe(TimeSpan.FromMilliseconds(104));
+
+        skip.TestCase.ShouldBeExecutionTimeTest(TestClass+".Skip", assemblyPath);
+        skip.TestCase.DisplayName.ShouldBe(TestClass+".Skip");
+        skip.Outcome.ShouldBe(TestOutcome.Skipped);
+        skip.ErrorMessage.ShouldBe("⚠ Skipped with attribute.");
+        skip.ErrorStackTrace.ShouldBe(null);
+        skip.DisplayName.ShouldBe(TestClass+".Skip");
+        skip.Messages.ShouldBeEmpty();
+        skip.Duration.ShouldBe(TimeSpan.Zero);
+
+        shouldBeStringPassAStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
+
+        shouldBeStringPassA.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
+        shouldBeStringPassA.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
+        shouldBeStringPassA.Outcome.ShouldBe(TestOutcome.Passed);
+        shouldBeStringPassA.ErrorMessage.ShouldBe(null);
+        shouldBeStringPassA.ErrorStackTrace.ShouldBe(null);
+        shouldBeStringPassA.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.String>(\"A\")");
+        shouldBeStringPassA.Messages.ShouldBeEmpty();
+        shouldBeStringPassA.Duration.ShouldBe(TimeSpan.FromMilliseconds(105));
+
+        shouldBeStringPassBStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
+
+        shouldBeStringPassB.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
+        shouldBeStringPassB.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
+        shouldBeStringPassB.Outcome.ShouldBe(TestOutcome.Passed);
+        shouldBeStringPassB.ErrorMessage.ShouldBe(null);
+        shouldBeStringPassB.ErrorStackTrace.ShouldBe(null);
+        shouldBeStringPassB.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.String>(\"B\")");
+        shouldBeStringPassB.Messages.ShouldBeEmpty();
+        shouldBeStringPassB.Duration.ShouldBe(TimeSpan.FromMilliseconds(106));
+
+
+        shouldBeStringFailStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
+
+        shouldBeStringFail.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
+        shouldBeStringFail.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
+        shouldBeStringFail.Outcome.ShouldBe(TestOutcome.Failed);
+        shouldBeStringFail.ErrorMessage.Lines().ShouldBe(
+            "Expected: System.String",
+            "Actual:   System.Int32");
+        shouldBeStringFail.ErrorStackTrace
+            .Lines()
+            .NormalizeStackTraceLines()
+            .ShouldBe(
+                "Fixie.Tests.Assertions.AssertException",
+                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
+        shouldBeStringFail.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.Int32>(123)");
+        shouldBeStringFail.Messages.ShouldBeEmpty();
+        shouldBeStringFail.Duration.ShouldBe(TimeSpan.FromMilliseconds(107));
+    }
 
     void RecordAnticipatedPipeMessages(VsExecutionRecorder vsExecutionRecorder)
     {
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
-            {
-                Test = TestClass + ".Fail"
-            }));
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
+        {
+            Test = TestClass + ".Fail"
+        }));
 
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestFailed
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestFailed
+        {
+            Test = TestClass + ".Fail",
+            TestCase = TestClass + ".Fail",
+            DurationInMilliseconds = 102,
+            Output = "Standard Out: Fail",
+            Reason = new PipeMessage.Exception
             {
-                Test = TestClass + ".Fail",
-                TestCase = TestClass + ".Fail",
-                DurationInMilliseconds = 102,
-                Output = "Standard Out: Fail",
-                Reason = new PipeMessage.Exception
-                {
-                    Type = "Fixie.Tests.FailureException",
-                    Message = "'Fail' failed!",
-                    StackTrace = At("Fail()")
-                }
-            }));
+                Type = "Fixie.Tests.FailureException",
+                Message = "'Fail' failed!",
+                StackTrace = At("Fail()")
+            }
+        }));
 
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
-            {
-                Test = TestClass + ".FailByAssertion"
-            }));
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
+        {
+            Test = TestClass + ".FailByAssertion"
+        }));
 
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestFailed
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestFailed
+        {
+            Test = TestClass + ".FailByAssertion",
+            TestCase = TestClass + ".FailByAssertion",
+            DurationInMilliseconds = 103,
+            Output = "Standard Out: FailByAssertion",
+            Reason = new PipeMessage.Exception
             {
-                Test = TestClass + ".FailByAssertion",
-                TestCase = TestClass + ".FailByAssertion",
-                DurationInMilliseconds = 103,
-                Output = "Standard Out: FailByAssertion",
-                Reason = new PipeMessage.Exception
-                {
-                    Type = "Fixie.Tests.Assertions.AssertException",
-                    Message = "Expected: 2" + NewLine + "Actual:   1",
-                    StackTrace = At("FailByAssertion()")
-                }
-            }));
-            
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
-            {
-                Test = TestClass + ".Pass"
-            }));
-            
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestPassed
-            {
-                Test = TestClass+".Pass",
-                TestCase = TestClass+".Pass",
-                DurationInMilliseconds = 104,
-                Output = "Standard Out: Pass"
-            }));
+                Type = "Fixie.Tests.Assertions.AssertException",
+                Message = "Expected: 2" + NewLine + "Actual:   1",
+                StackTrace = At("FailByAssertion()")
+            }
+        }));
+        
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
+        {
+            Test = TestClass + ".Pass"
+        }));
+        
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestPassed
+        {
+            Test = TestClass+".Pass",
+            TestCase = TestClass+".Pass",
+            DurationInMilliseconds = 104,
+            Output = "Standard Out: Pass"
+        }));
 
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestSkipped
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestSkipped
+        {
+            Test =TestClass+".Skip",
+            TestCase = TestClass+".Skip",
+            DurationInMilliseconds = 0,
+            Output = "",
+            Reason = "⚠ Skipped with attribute."
+        }));
+        
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
+        {
+            Test = GenericTestClass + ".ShouldBeString"
+        }));
+        
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestPassed
+        {
+            Test = GenericTestClass+".ShouldBeString",
+            TestCase = GenericTestClass+".ShouldBeString<System.String>(\"A\")",
+            DurationInMilliseconds = 105,
+            Output = ""
+        }));
+        
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
+        {
+            Test = GenericTestClass + ".ShouldBeString"
+        }));
+        
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestPassed
+        {
+            Test = GenericTestClass+".ShouldBeString",
+            TestCase = GenericTestClass+".ShouldBeString<System.String>(\"B\")",
+            DurationInMilliseconds = 106,
+            Output = ""
+        }));
+        
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
+        {
+            Test = GenericTestClass + ".ShouldBeString"
+        }));
+        
+        vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestFailed
+        {
+            Test = GenericTestClass+".ShouldBeString",
+            TestCase = GenericTestClass+".ShouldBeString<System.Int32>(123)",
+            DurationInMilliseconds = 107,
+            Output = "",
+            Reason = new PipeMessage.Exception
             {
-                Test =TestClass+".Skip",
-                TestCase = TestClass+".Skip",
-                DurationInMilliseconds = 0,
-                Output = "",
-                Reason = "⚠ Skipped with attribute."
-            }));
-            
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
-            {
-                Test = GenericTestClass + ".ShouldBeString"
-            }));
-            
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestPassed
-            {
-                Test = GenericTestClass+".ShouldBeString",
-                TestCase = GenericTestClass+".ShouldBeString<System.String>(\"A\")",
-                DurationInMilliseconds = 105,
-                Output = ""
-            }));
-            
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
-            {
-                Test = GenericTestClass + ".ShouldBeString"
-            }));
-            
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestPassed
-            {
-                Test = GenericTestClass+".ShouldBeString",
-                TestCase = GenericTestClass+".ShouldBeString<System.String>(\"B\")",
-                DurationInMilliseconds = 106,
-                Output = ""
-            }));
-            
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
-            {
-                Test = GenericTestClass + ".ShouldBeString"
-            }));
-            
-            vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestFailed
-            {
-                Test = GenericTestClass+".ShouldBeString",
-                TestCase = GenericTestClass+".ShouldBeString<System.Int32>(123)",
-                DurationInMilliseconds = 107,
-                Output = "",
-                Reason = new PipeMessage.Exception
-                {
-                    Type = "Fixie.Tests.Assertions.AssertException",
-                    Message = "Expected: System.String" + NewLine + "Actual:   System.Int32",
-                    StackTrace = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
-                }
-            }));
-        }
+                Type = "Fixie.Tests.Assertions.AssertException",
+                Message = "Expected: System.String" + NewLine + "Actual:   System.Int32",
+                StackTrace = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
+            }
+        }));
+    }
 
     static T Deserialized<T>(T original)
     {
-            // Because the inter-process communication between the VsTest process
-            // and the test assembly process is not exercised in these single-process
-            // tests, put a given sample message through the same serialization round
-            // trip that would be applied at runtime, in order to detect data loss.
+        // Because the inter-process communication between the VsTest process
+        // and the test assembly process is not exercised in these single-process
+        // tests, put a given sample message through the same serialization round
+        // trip that would be applied at runtime, in order to detect data loss.
 
-            return Deserialize<T>(Serialize(original))!;
-        }
+        return Deserialize<T>(Serialize(original))!;
+    }
 
     class StubExecutionRecorder : ITestExecutionRecorder
     {

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -1,21 +1,21 @@
-﻿namespace Fixie.Tests.TestAdapter
-{
-    using System;
-    using System.Collections.Generic;
-    using Fixie.TestAdapter;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-    using Assertions;
-    using Fixie.Internal;
-    using Reports;
-    using static System.Environment;
-    using static System.Text.Json.JsonSerializer;
+﻿namespace Fixie.Tests.TestAdapter;
 
-    public class VsExecutionRecorderTests : MessagingTests
+using System;
+using System.Collections.Generic;
+using Fixie.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Assertions;
+using Fixie.Internal;
+using Reports;
+using static System.Environment;
+using static System.Text.Json.JsonSerializer;
+
+public class VsExecutionRecorderTests : MessagingTests
+{
+    public void ShouldMapMessagesToVsTestExecutionRecorder()
     {
-        public void ShouldMapMessagesToVsTestExecutionRecorder()
-        {
             const string assemblyPath = "assembly.path.dll";
             var recorder = new StubExecutionRecorder();
 
@@ -155,8 +155,8 @@
             shouldBeStringFail.Duration.ShouldBe(TimeSpan.FromMilliseconds(107));
         }
 
-        void RecordAnticipatedPipeMessages(VsExecutionRecorder vsExecutionRecorder)
-        {
+    void RecordAnticipatedPipeMessages(VsExecutionRecorder vsExecutionRecorder)
+    {
             vsExecutionRecorder.Record(Deserialized(new PipeMessage.TestStarted
             {
                 Test = TestClass + ".Fail"
@@ -263,8 +263,8 @@
             }));
         }
 
-        static T Deserialized<T>(T original)
-        {
+    static T Deserialized<T>(T original)
+    {
             // Because the inter-process communication between the VsTest process
             // and the test assembly process is not exercised in these single-process
             // tests, put a given sample message through the same serialization round
@@ -273,24 +273,23 @@
             return Deserialize<T>(Serialize(original))!;
         }
 
-        class StubExecutionRecorder : ITestExecutionRecorder
-        {
-            public List<object> Messages { get; } = new List<object>();
+    class StubExecutionRecorder : ITestExecutionRecorder
+    {
+        public List<object> Messages { get; } = new List<object>();
 
-            public void RecordStart(TestCase testCase)
-                => Messages.Add(testCase);
+        public void RecordStart(TestCase testCase)
+            => Messages.Add(testCase);
 
-            public void RecordResult(TestResult testResult)
-                => Messages.Add(testResult);
+        public void RecordResult(TestResult testResult)
+            => Messages.Add(testResult);
 
-            public void SendMessage(TestMessageLevel testMessageLevel, string message)
-                => throw new NotImplementedException();
+        public void SendMessage(TestMessageLevel testMessageLevel, string message)
+            => throw new NotImplementedException();
 
-            public void RecordEnd(TestCase testCase, TestOutcome outcome)
-                => throw new NotImplementedException();
+        public void RecordEnd(TestCase testCase, TestOutcome outcome)
+            => throw new NotImplementedException();
 
-            public void RecordAttachments(IList<AttachmentSet> attachmentSets)
-                => throw new NotImplementedException();
-        }
+        public void RecordAttachments(IList<AttachmentSet> attachmentSets)
+            => throw new NotImplementedException();
     }
 }

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -9,73 +9,73 @@ public class TestClassConstructionTests : InstrumentedExecutionTests
     {
         public SampleTestClass()
         {
-                WhereAmI();
-            }
+            WhereAmI();
+        }
 
         public void Fail()
         {
-                WhereAmI();
-                throw new FailureException();
-            }
+            WhereAmI();
+            throw new FailureException();
+        }
 
         [Input(1)]
         [Input(2)]
         public void Pass(int i)
         {
-                WhereAmI(i);
-            }
+            WhereAmI(i);
+        }
 
         public void Skip()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
     }
 
     class AllSkippedTestClass
     {
         public AllSkippedTestClass()
         {
-                WhereAmI();
-            }
+            WhereAmI();
+        }
 
         public void SkipA()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
 
         public void SkipB()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
 
         public void SkipC()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
     }
 
     static class StaticTestClass
     {
         public static void Fail()
         {
-                WhereAmI();
-                throw new FailureException();
-            }
+            WhereAmI();
+            throw new FailureException();
+        }
 
         public static void Pass()
         {
-                WhereAmI();
-            }
+            WhereAmI();
+        }
 
         public static void Skip()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
     }
 
     class CannotInvokeConstructorTestClass
@@ -84,9 +84,9 @@ public class TestClassConstructionTests : InstrumentedExecutionTests
 
         public void UnreachableCase()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
     }
 
     static bool ShouldSkip(Test test)
@@ -96,270 +96,270 @@ public class TestClassConstructionTests : InstrumentedExecutionTests
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var test in testSuite.Tests)
-                    if (!ShouldSkip(test))
-                        foreach (var parameters in FromInputAttributes(test))
-                            await test.Run(parameters);
-            }
+            foreach (var test in testSuite.Tests)
+                if (!ShouldSkip(test))
+                    foreach (var parameters in FromInputAttributes(test))
+                        await test.Run(parameters);
+        }
     }
 
     class CreateInstancePerCaseExplicitly : IExecution
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var testClass in testSuite.TestClasses)
-                {
-                    var type = testClass.Type;
+            foreach (var testClass in testSuite.TestClasses)
+            {
+                var type = testClass.Type;
 
-                    foreach (var test in testClass.Tests)
-                        if (!ShouldSkip(test))
-                            foreach (var parameters in FromInputAttributes(test))
-                            {
-                                if (test.Method.IsStatic)
-                                    await test.Run(parameters);
-                                else
-                                    await test.Run(testClass.Construct(), parameters);
-                            }
-                }
+                foreach (var test in testClass.Tests)
+                    if (!ShouldSkip(test))
+                        foreach (var parameters in FromInputAttributes(test))
+                        {
+                            if (test.Method.IsStatic)
+                                await test.Run(parameters);
+                            else
+                                await test.Run(testClass.Construct(), parameters);
+                        }
             }
+        }
     }
 
     class CreateInstancePerClassExplicitly : IExecution
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var testClass in testSuite.TestClasses)
-                {
-                    var type = testClass.Type;
-                    var instance = type.IsStatic() ? null : testClass.Construct();
+            foreach (var testClass in testSuite.TestClasses)
+            {
+                var type = testClass.Type;
+                var instance = type.IsStatic() ? null : testClass.Construct();
 
-                    foreach (var test in testClass.Tests)
-                        if (!ShouldSkip(test))
-                            foreach (var parameters in FromInputAttributes(test))
-                            {
-                                if (test.Method.IsStatic)
-                                    await test.Run(parameters);
-                                else
-                                    await test.Run(instance!, parameters);
-                            }
-                }
+                foreach (var test in testClass.Tests)
+                    if (!ShouldSkip(test))
+                        foreach (var parameters in FromInputAttributes(test))
+                        {
+                            if (test.Method.IsStatic)
+                                await test.Run(parameters);
+                            else
+                                await test.Run(instance!, parameters);
+                        }
             }
+        }
     }
 
     public async Task ShouldConstructPerCaseByDefault()
     {
-            //NOTE: With no input parameter or skip behaviors,
-            //      all test methods are attempted once and with zero
-            //      parameters, so Skip() is reached and Pass(int)
-            //      is attempted once but never reached.
+        //NOTE: With no input parameter or skip behaviors,
+        //      all test methods are attempted once and with zero
+        //      parameters, so Skip() is reached and Pass(int)
+        //      is attempted once but never reached.
 
-            var output = await Run<SampleTestClass, DefaultExecution>();
+        var output = await Run<SampleTestClass, DefaultExecution>();
 
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail failed: 'Fail' failed!",
-                "SampleTestClass.Pass failed: Parameter count mismatch.",
-                "SampleTestClass.Skip failed: 'Skip' reached a line of code thought to be unreachable.");
+        output.ShouldHaveResults(
+            "SampleTestClass.Fail failed: 'Fail' failed!",
+            "SampleTestClass.Pass failed: Parameter count mismatch.",
+            "SampleTestClass.Skip failed: 'Skip' reached a line of code thought to be unreachable.");
 
-            output.ShouldHaveLifecycle(
-                ".ctor", "Fail",
-                ".ctor",
-                ".ctor", "Skip");
-        }
+        output.ShouldHaveLifecycle(
+            ".ctor", "Fail",
+            ".ctor",
+            ".ctor", "Skip");
+    }
 
     public async Task ShouldAllowConstructingPerCaseImplicitly()
     {
-            var output = await Run<SampleTestClass, CreateInstancePerCaseImplicitly>();
+        var output = await Run<SampleTestClass, CreateInstancePerCaseImplicitly>();
 
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail failed: 'Fail' failed!",
-                "SampleTestClass.Pass(1) passed",
-                "SampleTestClass.Pass(2) passed",
-                "SampleTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "SampleTestClass.Fail failed: 'Fail' failed!",
+            "SampleTestClass.Pass(1) passed",
+            "SampleTestClass.Pass(2) passed",
+            "SampleTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                ".ctor", "Fail",
-                ".ctor", "Pass(1)",
-                ".ctor", "Pass(2)");
-        }
+        output.ShouldHaveLifecycle(
+            ".ctor", "Fail",
+            ".ctor", "Pass(1)",
+            ".ctor", "Pass(2)");
+    }
 
     public async Task ShouldAllowConstructingPerCaseExplicitly()
     {
-            var output = await Run<SampleTestClass, CreateInstancePerCaseExplicitly>();
+        var output = await Run<SampleTestClass, CreateInstancePerCaseExplicitly>();
 
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail failed: 'Fail' failed!",
-                "SampleTestClass.Pass(1) passed",
-                "SampleTestClass.Pass(2) passed",
-                "SampleTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "SampleTestClass.Fail failed: 'Fail' failed!",
+            "SampleTestClass.Pass(1) passed",
+            "SampleTestClass.Pass(2) passed",
+            "SampleTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                ".ctor", "Fail",
-                ".ctor", "Pass(1)",
-                ".ctor", "Pass(2)");
-        }
+        output.ShouldHaveLifecycle(
+            ".ctor", "Fail",
+            ".ctor", "Pass(1)",
+            ".ctor", "Pass(2)");
+    }
 
     public async Task ShouldAllowConstructingPerClassExplicitly()
     {
-            var output = await Run<SampleTestClass, CreateInstancePerClassExplicitly>();
+        var output = await Run<SampleTestClass, CreateInstancePerClassExplicitly>();
 
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail failed: 'Fail' failed!",
-                "SampleTestClass.Pass(1) passed",
-                "SampleTestClass.Pass(2) passed",
-                "SampleTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "SampleTestClass.Fail failed: 'Fail' failed!",
+            "SampleTestClass.Pass(1) passed",
+            "SampleTestClass.Pass(2) passed",
+            "SampleTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                ".ctor",
-                "Fail",
-                "Pass(1)",
-                "Pass(2)");
-        }
+        output.ShouldHaveLifecycle(
+            ".ctor",
+            "Fail",
+            "Pass(1)",
+            "Pass(2)");
+    }
 
     public async Task ShouldFailCaseInAbsenseOfPrimaryCaseResultWhenConstructingPerCaseImplicitlyAndConstructorThrows()
     {
-            FailDuring(".ctor");
-            
-            var output = await Run<SampleTestClass, CreateInstancePerCaseImplicitly>();
+        FailDuring(".ctor");
+        
+        var output = await Run<SampleTestClass, CreateInstancePerCaseImplicitly>();
 
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail failed: '.ctor' failed!",
-                "SampleTestClass.Pass(1) failed: '.ctor' failed!",
-                "SampleTestClass.Pass(2) failed: '.ctor' failed!",
-                "SampleTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "SampleTestClass.Fail failed: '.ctor' failed!",
+            "SampleTestClass.Pass(1) failed: '.ctor' failed!",
+            "SampleTestClass.Pass(2) failed: '.ctor' failed!",
+            "SampleTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                ".ctor",
-                ".ctor",
-                ".ctor");
-        }
+        output.ShouldHaveLifecycle(
+            ".ctor",
+            ".ctor",
+            ".ctor");
+    }
 
     public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenConstructingPerCaseExplicitlyAndConstructorThrows()
     {
-            FailDuring(".ctor");
-            
-            var output = await Run<SampleTestClass, CreateInstancePerCaseExplicitly>();
+        FailDuring(".ctor");
+        
+        var output = await Run<SampleTestClass, CreateInstancePerCaseExplicitly>();
 
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail failed: '.ctor' failed!",
-                "SampleTestClass.Fail skipped: This test did not run.",
-                "SampleTestClass.Pass failed: '.ctor' failed!",
-                "SampleTestClass.Pass skipped: This test did not run.",
-                "SampleTestClass.Skip failed: '.ctor' failed!",
-                "SampleTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "SampleTestClass.Fail failed: '.ctor' failed!",
+            "SampleTestClass.Fail skipped: This test did not run.",
+            "SampleTestClass.Pass failed: '.ctor' failed!",
+            "SampleTestClass.Pass skipped: This test did not run.",
+            "SampleTestClass.Skip failed: '.ctor' failed!",
+            "SampleTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(".ctor");
-        }
+        output.ShouldHaveLifecycle(".ctor");
+    }
 
     public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenConstructingPerClassExplicitlyAndConstructorThrows()
     {
-            FailDuring(".ctor");
+        FailDuring(".ctor");
 
-            var output = await Run<SampleTestClass, CreateInstancePerClassExplicitly>();
+        var output = await Run<SampleTestClass, CreateInstancePerClassExplicitly>();
 
-            output.ShouldHaveResults(
-                "SampleTestClass.Fail failed: '.ctor' failed!",
-                "SampleTestClass.Fail skipped: This test did not run.",
-                "SampleTestClass.Pass failed: '.ctor' failed!",
-                "SampleTestClass.Pass skipped: This test did not run.",
-                "SampleTestClass.Skip failed: '.ctor' failed!",
-                "SampleTestClass.Skip skipped: This test did not run."
-            );
+        output.ShouldHaveResults(
+            "SampleTestClass.Fail failed: '.ctor' failed!",
+            "SampleTestClass.Fail skipped: This test did not run.",
+            "SampleTestClass.Pass failed: '.ctor' failed!",
+            "SampleTestClass.Pass skipped: This test did not run.",
+            "SampleTestClass.Skip failed: '.ctor' failed!",
+            "SampleTestClass.Skip skipped: This test did not run."
+        );
 
-            output.ShouldHaveLifecycle(".ctor");
-        }
+        output.ShouldHaveLifecycle(".ctor");
+    }
 
     public async Task ShouldBypassConstructionWhenConstructingPerCaseImplicitlyAndAllCasesAreSkipped()
     {
-            var output = await Run<AllSkippedTestClass, CreateInstancePerCaseImplicitly>();
+        var output = await Run<AllSkippedTestClass, CreateInstancePerCaseImplicitly>();
 
-            output.ShouldHaveResults(
-                "AllSkippedTestClass.SkipA skipped: This test did not run.",
-                "AllSkippedTestClass.SkipB skipped: This test did not run.",
-                "AllSkippedTestClass.SkipC skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "AllSkippedTestClass.SkipA skipped: This test did not run.",
+            "AllSkippedTestClass.SkipB skipped: This test did not run.",
+            "AllSkippedTestClass.SkipC skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle();
-        }
+        output.ShouldHaveLifecycle();
+    }
 
     public async Task ShouldBypassConstructionWhenConstructingPerCaseExplicitlyAndAllCasesAreSkipped()
     {
-            var output = await Run<AllSkippedTestClass, CreateInstancePerCaseExplicitly>();
+        var output = await Run<AllSkippedTestClass, CreateInstancePerCaseExplicitly>();
 
-            output.ShouldHaveResults(
-                "AllSkippedTestClass.SkipA skipped: This test did not run.",
-                "AllSkippedTestClass.SkipB skipped: This test did not run.",
-                "AllSkippedTestClass.SkipC skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "AllSkippedTestClass.SkipA skipped: This test did not run.",
+            "AllSkippedTestClass.SkipB skipped: This test did not run.",
+            "AllSkippedTestClass.SkipC skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle();
-        }
+        output.ShouldHaveLifecycle();
+    }
 
     public async Task ShouldNotBypassConstructionWhenConstructingPerClassExplicitlyAndAllCasesAreSkipped()
     {
-            var output = await Run<AllSkippedTestClass, CreateInstancePerClassExplicitly>();
+        var output = await Run<AllSkippedTestClass, CreateInstancePerClassExplicitly>();
 
-            output.ShouldHaveResults(
-                "AllSkippedTestClass.SkipA skipped: This test did not run.",
-                "AllSkippedTestClass.SkipB skipped: This test did not run.",
-                "AllSkippedTestClass.SkipC skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "AllSkippedTestClass.SkipA skipped: This test did not run.",
+            "AllSkippedTestClass.SkipB skipped: This test did not run.",
+            "AllSkippedTestClass.SkipC skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(".ctor");
-        }
+        output.ShouldHaveLifecycle(".ctor");
+    }
 
     public async Task ShouldBypassConstructionAttemptsWhenTestMethodsAreStatic()
     {
-            var output = await Run<DefaultExecution>(typeof(StaticTestClass));
+        var output = await Run<DefaultExecution>(typeof(StaticTestClass));
 
-            output.ShouldHaveResults(
-                "StaticTestClass.Fail failed: 'Fail' failed!",
-                "StaticTestClass.Pass passed",
-                "StaticTestClass.Skip failed: 'Skip' reached a line of code thought to be unreachable."
-            );
+        output.ShouldHaveResults(
+            "StaticTestClass.Fail failed: 'Fail' failed!",
+            "StaticTestClass.Pass passed",
+            "StaticTestClass.Skip failed: 'Skip' reached a line of code thought to be unreachable."
+        );
 
-            output.ShouldHaveLifecycle("Fail", "Pass", "Skip");
-
-
-            output = await Run<CreateInstancePerCaseImplicitly>(typeof(StaticTestClass));
-
-            output.ShouldHaveResults(
-                "StaticTestClass.Fail failed: 'Fail' failed!",
-                "StaticTestClass.Pass passed",
-                "StaticTestClass.Skip skipped: This test did not run."
-            );
-
-            output.ShouldHaveLifecycle("Fail", "Pass");
+        output.ShouldHaveLifecycle("Fail", "Pass", "Skip");
 
 
-            output = await Run<CreateInstancePerCaseExplicitly>(typeof(StaticTestClass));
+        output = await Run<CreateInstancePerCaseImplicitly>(typeof(StaticTestClass));
 
-            output.ShouldHaveResults(
-                "StaticTestClass.Fail failed: 'Fail' failed!",
-                "StaticTestClass.Pass passed",
-                "StaticTestClass.Skip skipped: This test did not run."
-            );
+        output.ShouldHaveResults(
+            "StaticTestClass.Fail failed: 'Fail' failed!",
+            "StaticTestClass.Pass passed",
+            "StaticTestClass.Skip skipped: This test did not run."
+        );
 
-            output.ShouldHaveLifecycle("Fail", "Pass");
+        output.ShouldHaveLifecycle("Fail", "Pass");
 
 
-            output = await Run<CreateInstancePerClassExplicitly>(typeof(StaticTestClass));
+        output = await Run<CreateInstancePerCaseExplicitly>(typeof(StaticTestClass));
 
-            output.ShouldHaveResults(
-                "StaticTestClass.Fail failed: 'Fail' failed!",
-                "StaticTestClass.Pass passed",
-                "StaticTestClass.Skip skipped: This test did not run."
-            );
+        output.ShouldHaveResults(
+            "StaticTestClass.Fail failed: 'Fail' failed!",
+            "StaticTestClass.Pass passed",
+            "StaticTestClass.Skip skipped: This test did not run."
+        );
 
-            output.ShouldHaveLifecycle("Fail", "Pass");
-        }
+        output.ShouldHaveLifecycle("Fail", "Pass");
+
+
+        output = await Run<CreateInstancePerClassExplicitly>(typeof(StaticTestClass));
+
+        output.ShouldHaveResults(
+            "StaticTestClass.Fail failed: 'Fail' failed!",
+            "StaticTestClass.Pass passed",
+            "StaticTestClass.Skip skipped: This test did not run."
+        );
+
+        output.ShouldHaveLifecycle("Fail", "Pass");
+    }
 
     public async Task ShouldFailWhenTestClassConstructorCannotBeInvoked()
     {
-            var output = await Run<CannotInvokeConstructorTestClass, DefaultExecution>();
+        var output = await Run<CannotInvokeConstructorTestClass, DefaultExecution>();
 
-            output.ShouldHaveResults(
-                "CannotInvokeConstructorTestClass.UnreachableCase failed: " +
-                "Cannot dynamically create an instance " +
-                $"of type '{FullName<CannotInvokeConstructorTestClass>()}'. " +
-                "Reason: No parameterless constructor defined.");
+        output.ShouldHaveResults(
+            "CannotInvokeConstructorTestClass.UnreachableCase failed: " +
+            "Cannot dynamically create an instance " +
+            $"of type '{FullName<CannotInvokeConstructorTestClass>()}'. " +
+            "Reason: No parameterless constructor defined.");
 
-            output.ShouldHaveLifecycle();
-        }
+        output.ShouldHaveLifecycle();
+    }
 }

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -1,112 +1,112 @@
-namespace Fixie.Tests
-{
-    using System.Threading.Tasks;
-    using static Utility;
+namespace Fixie.Tests;
+
+using System.Threading.Tasks;
+using static Utility;
     
-    public class TestClassConstructionTests : InstrumentedExecutionTests
+public class TestClassConstructionTests : InstrumentedExecutionTests
+{
+    class SampleTestClass
     {
-        class SampleTestClass
+        public SampleTestClass()
         {
-            public SampleTestClass()
-            {
                 WhereAmI();
             }
 
-            public void Fail()
-            {
+        public void Fail()
+        {
                 WhereAmI();
                 throw new FailureException();
             }
 
-            [Input(1)]
-            [Input(2)]
-            public void Pass(int i)
-            {
+        [Input(1)]
+        [Input(2)]
+        public void Pass(int i)
+        {
                 WhereAmI(i);
             }
 
-            public void Skip()
-            {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
-        }
-
-        class AllSkippedTestClass
+        public void Skip()
         {
-            public AllSkippedTestClass()
-            {
-                WhereAmI();
-            }
-
-            public void SkipA()
-            {
                 WhereAmI();
                 throw new ShouldBeUnreachableException();
             }
+    }
 
-            public void SkipB()
-            {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
-
-            public void SkipC()
-            {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
-        }
-
-        static class StaticTestClass
+    class AllSkippedTestClass
+    {
+        public AllSkippedTestClass()
         {
-            public static void Fail()
-            {
+                WhereAmI();
+            }
+
+        public void SkipA()
+        {
+                WhereAmI();
+                throw new ShouldBeUnreachableException();
+            }
+
+        public void SkipB()
+        {
+                WhereAmI();
+                throw new ShouldBeUnreachableException();
+            }
+
+        public void SkipC()
+        {
+                WhereAmI();
+                throw new ShouldBeUnreachableException();
+            }
+    }
+
+    static class StaticTestClass
+    {
+        public static void Fail()
+        {
                 WhereAmI();
                 throw new FailureException();
             }
 
-            public static void Pass()
-            {
+        public static void Pass()
+        {
                 WhereAmI();
             }
 
-            public static void Skip()
-            {
+        public static void Skip()
+        {
                 WhereAmI();
                 throw new ShouldBeUnreachableException();
             }
-        }
+    }
 
-        class CannotInvokeConstructorTestClass
+    class CannotInvokeConstructorTestClass
+    {
+        public CannotInvokeConstructorTestClass(int argument) { }
+
+        public void UnreachableCase()
         {
-            public CannotInvokeConstructorTestClass(int argument) { }
-
-            public void UnreachableCase()
-            {
                 WhereAmI();
                 throw new ShouldBeUnreachableException();
             }
-        }
+    }
 
-        static bool ShouldSkip(Test test)
-            => test.Name.Contains("Skip");
+    static bool ShouldSkip(Test test)
+        => test.Name.Contains("Skip");
 
-        class CreateInstancePerCaseImplicitly : IExecution
+    class CreateInstancePerCaseImplicitly : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var test in testSuite.Tests)
                     if (!ShouldSkip(test))
                         foreach (var parameters in FromInputAttributes(test))
                             await test.Run(parameters);
             }
-        }
+    }
 
-        class CreateInstancePerCaseExplicitly : IExecution
+    class CreateInstancePerCaseExplicitly : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var testClass in testSuite.TestClasses)
                 {
                     var type = testClass.Type;
@@ -122,12 +122,12 @@ namespace Fixie.Tests
                             }
                 }
             }
-        }
+    }
 
-        class CreateInstancePerClassExplicitly : IExecution
+    class CreateInstancePerClassExplicitly : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var testClass in testSuite.TestClasses)
                 {
                     var type = testClass.Type;
@@ -144,10 +144,10 @@ namespace Fixie.Tests
                             }
                 }
             }
-        }
+    }
 
-        public async Task ShouldConstructPerCaseByDefault()
-        {
+    public async Task ShouldConstructPerCaseByDefault()
+    {
             //NOTE: With no input parameter or skip behaviors,
             //      all test methods are attempted once and with zero
             //      parameters, so Skip() is reached and Pass(int)
@@ -166,8 +166,8 @@ namespace Fixie.Tests
                 ".ctor", "Skip");
         }
 
-        public async Task ShouldAllowConstructingPerCaseImplicitly()
-        {
+    public async Task ShouldAllowConstructingPerCaseImplicitly()
+    {
             var output = await Run<SampleTestClass, CreateInstancePerCaseImplicitly>();
 
             output.ShouldHaveResults(
@@ -182,8 +182,8 @@ namespace Fixie.Tests
                 ".ctor", "Pass(2)");
         }
 
-        public async Task ShouldAllowConstructingPerCaseExplicitly()
-        {
+    public async Task ShouldAllowConstructingPerCaseExplicitly()
+    {
             var output = await Run<SampleTestClass, CreateInstancePerCaseExplicitly>();
 
             output.ShouldHaveResults(
@@ -198,8 +198,8 @@ namespace Fixie.Tests
                 ".ctor", "Pass(2)");
         }
 
-        public async Task ShouldAllowConstructingPerClassExplicitly()
-        {
+    public async Task ShouldAllowConstructingPerClassExplicitly()
+    {
             var output = await Run<SampleTestClass, CreateInstancePerClassExplicitly>();
 
             output.ShouldHaveResults(
@@ -215,8 +215,8 @@ namespace Fixie.Tests
                 "Pass(2)");
         }
 
-        public async Task ShouldFailCaseInAbsenseOfPrimaryCaseResultWhenConstructingPerCaseImplicitlyAndConstructorThrows()
-        {
+    public async Task ShouldFailCaseInAbsenseOfPrimaryCaseResultWhenConstructingPerCaseImplicitlyAndConstructorThrows()
+    {
             FailDuring(".ctor");
             
             var output = await Run<SampleTestClass, CreateInstancePerCaseImplicitly>();
@@ -233,8 +233,8 @@ namespace Fixie.Tests
                 ".ctor");
         }
 
-        public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenConstructingPerCaseExplicitlyAndConstructorThrows()
-        {
+    public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenConstructingPerCaseExplicitlyAndConstructorThrows()
+    {
             FailDuring(".ctor");
             
             var output = await Run<SampleTestClass, CreateInstancePerCaseExplicitly>();
@@ -250,8 +250,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(".ctor");
         }
 
-        public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenConstructingPerClassExplicitlyAndConstructorThrows()
-        {
+    public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenConstructingPerClassExplicitlyAndConstructorThrows()
+    {
             FailDuring(".ctor");
 
             var output = await Run<SampleTestClass, CreateInstancePerClassExplicitly>();
@@ -268,8 +268,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(".ctor");
         }
 
-        public async Task ShouldBypassConstructionWhenConstructingPerCaseImplicitlyAndAllCasesAreSkipped()
-        {
+    public async Task ShouldBypassConstructionWhenConstructingPerCaseImplicitlyAndAllCasesAreSkipped()
+    {
             var output = await Run<AllSkippedTestClass, CreateInstancePerCaseImplicitly>();
 
             output.ShouldHaveResults(
@@ -280,8 +280,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle();
         }
 
-        public async Task ShouldBypassConstructionWhenConstructingPerCaseExplicitlyAndAllCasesAreSkipped()
-        {
+    public async Task ShouldBypassConstructionWhenConstructingPerCaseExplicitlyAndAllCasesAreSkipped()
+    {
             var output = await Run<AllSkippedTestClass, CreateInstancePerCaseExplicitly>();
 
             output.ShouldHaveResults(
@@ -292,8 +292,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle();
         }
 
-        public async Task ShouldNotBypassConstructionWhenConstructingPerClassExplicitlyAndAllCasesAreSkipped()
-        {
+    public async Task ShouldNotBypassConstructionWhenConstructingPerClassExplicitlyAndAllCasesAreSkipped()
+    {
             var output = await Run<AllSkippedTestClass, CreateInstancePerClassExplicitly>();
 
             output.ShouldHaveResults(
@@ -304,8 +304,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle(".ctor");
         }
 
-        public async Task ShouldBypassConstructionAttemptsWhenTestMethodsAreStatic()
-        {
+    public async Task ShouldBypassConstructionAttemptsWhenTestMethodsAreStatic()
+    {
             var output = await Run<DefaultExecution>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
@@ -350,8 +350,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("Fail", "Pass");
         }
 
-        public async Task ShouldFailWhenTestClassConstructorCannotBeInvoked()
-        {
+    public async Task ShouldFailWhenTestClassConstructorCannotBeInvoked()
+    {
             var output = await Run<CannotInvokeConstructorTestClass, DefaultExecution>();
 
             output.ShouldHaveResults(
@@ -362,5 +362,4 @@ namespace Fixie.Tests
 
             output.ShouldHaveLifecycle();
         }
-    }
 }

--- a/src/Fixie.Tests/TestClassLifecycleTests.cs
+++ b/src/Fixie.Tests/TestClassLifecycleTests.cs
@@ -11,140 +11,140 @@ public class TestClassLifecycleTests : InstrumentedExecutionTests
     {
         public void Fail()
         {
-                WhereAmI();
-                throw new FailureException();
-            }
+            WhereAmI();
+            throw new FailureException();
+        }
 
         [Input(1)]
         [Input(2)]
         public void Pass(int i)
         {
-                WhereAmI(i);
-            }
+            WhereAmI(i);
+        }
 
         public void Skip()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
     }
 
     class SecondTestClass
     {
         public void SecondPass()
         {
-                WhereAmI();
-            }
+            WhereAmI();
+        }
     }
 
     class AllSkippedTestClass
     {
         public void SkipA()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
 
         public void SkipB()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
 
         public void SkipC()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
     }
 
     static class StaticTestClass
     {
         public static void Fail()
         {
-                WhereAmI();
-                throw new FailureException();
-            }
+            WhereAmI();
+            throw new FailureException();
+        }
 
         public static void Pass()
         {
-                WhereAmI();
-            }
+            WhereAmI();
+        }
 
         public static void Skip()
         {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
+            WhereAmI();
+            throw new ShouldBeUnreachableException();
+        }
     }
 
     class InstrumentedExecution : IExecution
     {
         public async Task Run(TestSuite testSuite)
         {
-                AssemblySetUp();
+            AssemblySetUp();
 
-                foreach (var testClass in testSuite.TestClasses)
-                    await TestClassLifecycle(testClass);
+            foreach (var testClass in testSuite.TestClasses)
+                await TestClassLifecycle(testClass);
 
-                AssemblyTearDown();
-            }
+            AssemblyTearDown();
+        }
 
         async Task TestClassLifecycle(TestClass testClass)
         {
-                try
-                {
-                    ClassSetUp();
+            try
+            {
+                ClassSetUp();
 
-                    foreach (var test in testClass.Tests)
-                        if (!test.Name.Contains("Skip"))
-                            await TestLifecycle(test);
+                foreach (var test in testClass.Tests)
+                    if (!test.Name.Contains("Skip"))
+                        await TestLifecycle(test);
 
-                    ClassTearDown();
-                }
-                catch (Exception exception)
-                {
-                    await testClass.Fail(exception);
-                }
+                ClassTearDown();
             }
+            catch (Exception exception)
+            {
+                await testClass.Fail(exception);
+            }
+        }
 
         async Task TestLifecycle(Test test)
         {
-                try
-                {
-                    TestSetUp();
+            try
+            {
+                TestSetUp();
 
-                    foreach (var parameters in YieldParameters(test))
-                        await CaseLifecycle(test, parameters);
+                foreach (var parameters in YieldParameters(test))
+                    await CaseLifecycle(test, parameters);
 
-                    TestTearDown();
-                }
-                catch (Exception exception)
-                {
-                    await test.Fail(exception);
-                }
+                TestTearDown();
             }
+            catch (Exception exception)
+            {
+                await test.Fail(exception);
+            }
+        }
 
         static IEnumerable<object?[]> YieldParameters(Test test)
         {
-                ProcessScriptedFailure();
+            ProcessScriptedFailure();
 
-                return FromInputAttributes(test);
-            }
+            return FromInputAttributes(test);
+        }
 
         static async Task CaseLifecycle(Test test, object?[] parameters)
         {
-                try
-                {
-                    CaseSetUp();
-                    await test.Run(parameters);
-                    CaseTearDown();
-                }
-                catch (Exception exception)
-                {
-                    await test.Fail(parameters, exception);
-                }
+            try
+            {
+                CaseSetUp();
+                await test.Run(parameters);
+                CaseTearDown();
             }
+            catch (Exception exception)
+            {
+                await test.Fail(parameters, exception);
+            }
+        }
     }
 
     static void AssemblySetUp() => WhereAmI();
@@ -160,26 +160,26 @@ public class TestClassLifecycleTests : InstrumentedExecutionTests
     {
         public Task Run(TestSuite testSuite)
         {
-                //Lifecycle chooses not to invoke any tests.
-                //Since the tests never run, they are all
-                //considered 'skipped'.
-                return Task.CompletedTask;
-            }
+            //Lifecycle chooses not to invoke any tests.
+            //Since the tests never run, they are all
+            //considered 'skipped'.
+            return Task.CompletedTask;
+        }
     }
 
     class RepeatedExecution : IExecution
     {
         public async Task Run(TestSuite testSuite)
         {
-                foreach (var test in testSuite.Tests)
-                {
-                    if (test.Name.Contains("Skip")) continue;
+            foreach (var test in testSuite.Tests)
+            {
+                if (test.Name.Contains("Skip")) continue;
 
-                    for (int i = 1; i <= 3; i++)
-                        foreach (var parameters in FromInputAttributes(test))
-                            await test.Run(parameters);
-                }
+                for (int i = 1; i <= 3; i++)
+                    foreach (var parameters in FromInputAttributes(test))
+                        await test.Run(parameters);
             }
+        }
     }
 
     class CircuitBreakingExecution : IExecution
@@ -191,484 +191,484 @@ public class TestClassLifecycleTests : InstrumentedExecutionTests
 
         public async Task Run(TestSuite testSuite)
         {
-                int failures = 0;
+            int failures = 0;
 
-                foreach (var test in testSuite.Tests)
+            foreach (var test in testSuite.Tests)
+            {
+                if (test.Name.Contains("Skip")) continue;
+
+                for (int i = 1; i <= 3; i++)
                 {
-                    if (test.Name.Contains("Skip")) continue;
-
-                    for (int i = 1; i <= 3; i++)
+                    foreach (var parameters in FromInputAttributes(test))
                     {
-                        foreach (var parameters in FromInputAttributes(test))
+                        var result = await test.Run(parameters);
+
+                        if (result is Failed)
                         {
-                            var result = await test.Run(parameters);
+                            failures++;
 
-                            if (result is Failed)
-                            {
-                                failures++;
-
-                                if (failures > maxFailures)
-                                    return;
-                            }
+                            if (failures > maxFailures)
+                                return;
                         }
                     }
                 }
             }
+        }
     }
 
     public async Task ShouldRunAllTestsByDefault()
     {
-            var output = await Run<FirstTestClass, SecondTestClass, DefaultExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, DefaultExecution>();
 
-            //NOTE: With no input parameter or skip behaviors,
-            //      all test methods are attempted and with zero
-            //      parameters, so Skip() is reached and Pass(int)
-            //      is attempted but never reached.
+        //NOTE: With no input parameter or skip behaviors,
+        //      all test methods are attempted and with zero
+        //      parameters, so Skip() is reached and Pass(int)
+        //      is attempted but never reached.
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Pass failed: Parameter count mismatch.",
-                "FirstTestClass.Skip failed: 'Skip' reached a line of code thought to be unreachable.",
-                "SecondTestClass.SecondPass passed");
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Pass failed: Parameter count mismatch.",
+            "FirstTestClass.Skip failed: 'Skip' reached a line of code thought to be unreachable.",
+            "SecondTestClass.SecondPass passed");
 
-            output.ShouldHaveLifecycle("Fail", "Skip", "SecondPass");
-        }
+        output.ShouldHaveLifecycle("Fail", "Skip", "SecondPass");
+    }
 
     public async Task ShouldSupportExecutionLifecycleHooks()
     {
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Pass(1) passed",
-                "FirstTestClass.Pass(2) passed",
-                "SecondTestClass.SecondPass passed",
-                "FirstTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Pass(1) passed",
+            "FirstTestClass.Pass(2) passed",
+            "SecondTestClass.SecondPass passed",
+            "FirstTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp", "Fail", "CaseTearDown",
-                "TestTearDown",
-                "TestSetUp",
-                "CaseSetUp", "Pass(1)", "CaseTearDown",
-                "CaseSetUp", "Pass(2)", "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp", "Fail", "CaseTearDown",
+            "TestTearDown",
+            "TestSetUp",
+            "CaseSetUp", "Pass(1)", "CaseTearDown",
+            "CaseSetUp", "Pass(2)", "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp",
-                "SecondPass",
-                "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp",
+            "SecondPass",
+            "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "AssemblyTearDown");
-        }
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldSupportStaticTestClassesAndMethods()
     {
-            var output = await Run<InstrumentedExecution>(typeof(StaticTestClass));
+        var output = await Run<InstrumentedExecution>(typeof(StaticTestClass));
 
-            output.ShouldHaveResults(
-                "StaticTestClass.Fail failed: 'Fail' failed!",
-                "StaticTestClass.Pass passed",
-                "StaticTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "StaticTestClass.Fail failed: 'Fail' failed!",
+            "StaticTestClass.Pass passed",
+            "StaticTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
-                "ClassSetUp",
-                "TestSetUp", "CaseSetUp", "Fail", "CaseTearDown", "TestTearDown",
-                "TestSetUp", "CaseSetUp", "Pass", "CaseTearDown", "TestTearDown",
-                "ClassTearDown",
-                "AssemblyTearDown");
-        }
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
+            "ClassSetUp",
+            "TestSetUp", "CaseSetUp", "Fail", "CaseTearDown", "TestTearDown",
+            "TestSetUp", "CaseSetUp", "Pass", "CaseTearDown", "TestTearDown",
+            "ClassTearDown",
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenAssemblySetUpThrows()
     {
-            FailDuring("AssemblySetUp");
+        FailDuring("AssemblySetUp");
 
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'AssemblySetUp' failed!",
-                "FirstTestClass.Fail skipped: This test did not run.",
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'AssemblySetUp' failed!",
+            "FirstTestClass.Fail skipped: This test did not run.",
 
-                "FirstTestClass.Pass failed: 'AssemblySetUp' failed!",
-                "FirstTestClass.Pass skipped: This test did not run.",
+            "FirstTestClass.Pass failed: 'AssemblySetUp' failed!",
+            "FirstTestClass.Pass skipped: This test did not run.",
 
-                "FirstTestClass.Skip failed: 'AssemblySetUp' failed!",
-                "FirstTestClass.Skip skipped: This test did not run.",
-                
-                "SecondTestClass.SecondPass failed: 'AssemblySetUp' failed!",
-                "SecondTestClass.SecondPass skipped: This test did not run.");
+            "FirstTestClass.Skip failed: 'AssemblySetUp' failed!",
+            "FirstTestClass.Skip skipped: This test did not run.",
+            
+            "SecondTestClass.SecondPass failed: 'AssemblySetUp' failed!",
+            "SecondTestClass.SecondPass skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle("AssemblySetUp");
-        }
+        output.ShouldHaveLifecycle("AssemblySetUp");
+    }
 
     public async Task ShouldFailAllTestsInClassWithoutHidingPrimarySkipResultsWhenClassSetUpThrows()
     {
-            FailDuring("ClassSetUp", occurrence: 1);
-        
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
-        
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'ClassSetUp' failed!",
-                "FirstTestClass.Pass failed: 'ClassSetUp' failed!",
-                "FirstTestClass.Skip failed: 'ClassSetUp' failed!",
-                "SecondTestClass.SecondPass passed");
-        
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
-                "ClassSetUp",
-                "ClassSetUp", "TestSetUp", "CaseSetUp", "SecondPass", "CaseTearDown", "TestTearDown", "ClassTearDown",
-                "AssemblyTearDown");
-        }
+        FailDuring("ClassSetUp", occurrence: 1);
+    
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+    
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'ClassSetUp' failed!",
+            "FirstTestClass.Pass failed: 'ClassSetUp' failed!",
+            "FirstTestClass.Skip failed: 'ClassSetUp' failed!",
+            "SecondTestClass.SecondPass passed");
+    
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
+            "ClassSetUp",
+            "ClassSetUp", "TestSetUp", "CaseSetUp", "SecondPass", "CaseTearDown", "TestTearDown", "ClassTearDown",
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldFailTestWhenTestSetUpThrows()
     {
-            FailDuring("TestSetUp", occurrence: 2);
+        FailDuring("TestSetUp", occurrence: 2);
 
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Pass failed: 'TestSetUp' failed!",
-                "SecondTestClass.SecondPass passed",
-                "FirstTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Pass failed: 'TestSetUp' failed!",
+            "SecondTestClass.SecondPass passed",
+            "FirstTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
-                
-                "ClassSetUp",
-                "TestSetUp", "CaseSetUp", "Fail", "CaseTearDown", "TestTearDown",
-                "TestSetUp",
-                "ClassTearDown",
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
+            
+            "ClassSetUp",
+            "TestSetUp", "CaseSetUp", "Fail", "CaseTearDown", "TestTearDown",
+            "TestSetUp",
+            "ClassTearDown",
 
-                "ClassSetUp",
-                "TestSetUp", "CaseSetUp", "SecondPass", "CaseTearDown", "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp", "CaseSetUp", "SecondPass", "CaseTearDown", "TestTearDown",
+            "ClassTearDown",
 
-                "AssemblyTearDown");
-        }
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldFailTestWhenCustomParameterGenerationThrows()
     {
-            FailDuring("YieldParameters", 2);
+        FailDuring("YieldParameters", 2);
 
-            var execution = new InstrumentedExecution();
-            var output = await Run<FirstTestClass>(execution);
+        var execution = new InstrumentedExecution();
+        var output = await Run<FirstTestClass>(execution);
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Pass failed: 'YieldParameters' failed!",
-                "FirstTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Pass failed: 'YieldParameters' failed!",
+            "FirstTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp", "Fail", "CaseTearDown",
-                "TestTearDown",
-                "TestSetUp",
-                "ClassTearDown",
-                "AssemblyTearDown");
-        }
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp", "Fail", "CaseTearDown",
+            "TestTearDown",
+            "TestSetUp",
+            "ClassTearDown",
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldFailCaseWhenCaseSetUpThrows()
     {
-            FailDuring("CaseSetUp", occurrence: 2);
+        FailDuring("CaseSetUp", occurrence: 2);
 
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Pass(1) failed: 'CaseSetUp' failed!",
-                "FirstTestClass.Pass(2) passed",
-                "SecondTestClass.SecondPass passed",
-                "FirstTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Pass(1) failed: 'CaseSetUp' failed!",
+            "FirstTestClass.Pass(2) passed",
+            "SecondTestClass.SecondPass passed",
+            "FirstTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp", "Fail", "CaseTearDown",
-                "TestTearDown",
-                "TestSetUp",
-                "CaseSetUp",
-                "CaseSetUp", "Pass(2)", "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp", "Fail", "CaseTearDown",
+            "TestTearDown",
+            "TestSetUp",
+            "CaseSetUp",
+            "CaseSetUp", "Pass(2)", "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp",
-                "SecondPass",
-                "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp",
+            "SecondPass",
+            "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "AssemblyTearDown");
-        }
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldFailCaseWithoutHidingPrimaryCaseResultsWhenCaseTearDownThrows()
     {
-            FailDuring("CaseTearDown");
+        FailDuring("CaseTearDown");
 
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Fail failed: 'CaseTearDown' failed!",
-                "FirstTestClass.Pass(1) passed",
-                "FirstTestClass.Pass(1) failed: 'CaseTearDown' failed!",
-                "FirstTestClass.Pass(2) passed",
-                "FirstTestClass.Pass(2) failed: 'CaseTearDown' failed!",
-                "SecondTestClass.SecondPass passed",
-                "SecondTestClass.SecondPass failed: 'CaseTearDown' failed!",
-                "FirstTestClass.Skip skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Fail failed: 'CaseTearDown' failed!",
+            "FirstTestClass.Pass(1) passed",
+            "FirstTestClass.Pass(1) failed: 'CaseTearDown' failed!",
+            "FirstTestClass.Pass(2) passed",
+            "FirstTestClass.Pass(2) failed: 'CaseTearDown' failed!",
+            "SecondTestClass.SecondPass passed",
+            "SecondTestClass.SecondPass failed: 'CaseTearDown' failed!",
+            "FirstTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp", "Fail", "CaseTearDown",
-                "TestTearDown",
-                "TestSetUp",
-                "CaseSetUp", "Pass(1)", "CaseTearDown",
-                "CaseSetUp", "Pass(2)", "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp", "Fail", "CaseTearDown",
+            "TestTearDown",
+            "TestSetUp",
+            "CaseSetUp", "Pass(1)", "CaseTearDown",
+            "CaseSetUp", "Pass(2)", "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp",
-                "SecondPass",
-                "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp",
+            "SecondPass",
+            "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "AssemblyTearDown");
-        }
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldFailTestWithoutHidingPrimaryCaseResultsWhenTestTearDownThrows()
     {
-            FailDuring("TestTearDown");
+        FailDuring("TestTearDown");
 
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Fail failed: 'TestTearDown' failed!",
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Fail failed: 'TestTearDown' failed!",
 
-                "FirstTestClass.Pass(1) passed",
-                "FirstTestClass.Pass(2) passed",
-                "FirstTestClass.Pass failed: 'TestTearDown' failed!",
+            "FirstTestClass.Pass(1) passed",
+            "FirstTestClass.Pass(2) passed",
+            "FirstTestClass.Pass failed: 'TestTearDown' failed!",
 
-                "SecondTestClass.SecondPass passed",
-                "SecondTestClass.SecondPass failed: 'TestTearDown' failed!",
-                
-                "FirstTestClass.Skip skipped: This test did not run.");
+            "SecondTestClass.SecondPass passed",
+            "SecondTestClass.SecondPass failed: 'TestTearDown' failed!",
+            
+            "FirstTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp", "Fail", "CaseTearDown",
-                "TestTearDown",
-                "TestSetUp",
-                "CaseSetUp", "Pass(1)", "CaseTearDown",
-                "CaseSetUp", "Pass(2)", "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp", "Fail", "CaseTearDown",
+            "TestTearDown",
+            "TestSetUp",
+            "CaseSetUp", "Pass(1)", "CaseTearDown",
+            "CaseSetUp", "Pass(2)", "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp",
-                "SecondPass",
-                "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp",
+            "SecondPass",
+            "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "AssemblyTearDown");
-        }
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldFailAllTestsInClassWithoutHidingPrimaryCaseResultsWhenClassTearDownThrows()
     {
-            FailDuring("ClassTearDown", occurrence: 1);
+        FailDuring("ClassTearDown", occurrence: 1);
 
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Pass(1) passed",
-                "FirstTestClass.Pass(2) passed",
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Pass(1) passed",
+            "FirstTestClass.Pass(2) passed",
 
-                "FirstTestClass.Fail failed: 'ClassTearDown' failed!",
-                "FirstTestClass.Pass failed: 'ClassTearDown' failed!",
-                "FirstTestClass.Skip failed: 'ClassTearDown' failed!",
+            "FirstTestClass.Fail failed: 'ClassTearDown' failed!",
+            "FirstTestClass.Pass failed: 'ClassTearDown' failed!",
+            "FirstTestClass.Skip failed: 'ClassTearDown' failed!",
 
-                "SecondTestClass.SecondPass passed");
+            "SecondTestClass.SecondPass passed");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp", "Fail", "CaseTearDown",
-                "TestTearDown",
-                "TestSetUp",
-                "CaseSetUp", "Pass(1)", "CaseTearDown",
-                "CaseSetUp", "Pass(2)", "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp", "Fail", "CaseTearDown",
+            "TestTearDown",
+            "TestSetUp",
+            "CaseSetUp", "Pass(1)", "CaseTearDown",
+            "CaseSetUp", "Pass(2)", "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp",
-                "SecondPass",
-                "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp",
+            "SecondPass",
+            "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "AssemblyTearDown");
-        }
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldFailAllTestsWithoutHidingPrimaryCaseResultsWhenAssemblyTearDownThrows()
     {
-            FailDuring("AssemblyTearDown");
+        FailDuring("AssemblyTearDown");
 
-            var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Pass(1) passed",
-                "FirstTestClass.Pass(2) passed",
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Pass(1) passed",
+            "FirstTestClass.Pass(2) passed",
 
-                "SecondTestClass.SecondPass passed",
+            "SecondTestClass.SecondPass passed",
 
-                "FirstTestClass.Fail failed: 'AssemblyTearDown' failed!",
-                "FirstTestClass.Pass failed: 'AssemblyTearDown' failed!",
-                "FirstTestClass.Skip failed: 'AssemblyTearDown' failed!",
-                "FirstTestClass.Skip skipped: This test did not run.",
-                
-                "SecondTestClass.SecondPass failed: 'AssemblyTearDown' failed!");
+            "FirstTestClass.Fail failed: 'AssemblyTearDown' failed!",
+            "FirstTestClass.Pass failed: 'AssemblyTearDown' failed!",
+            "FirstTestClass.Skip failed: 'AssemblyTearDown' failed!",
+            "FirstTestClass.Skip skipped: This test did not run.",
+            
+            "SecondTestClass.SecondPass failed: 'AssemblyTearDown' failed!");
 
-            output.ShouldHaveLifecycle(
-                "AssemblySetUp",
+        output.ShouldHaveLifecycle(
+            "AssemblySetUp",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp", "Fail", "CaseTearDown",
-                "TestTearDown",
-                "TestSetUp",
-                "CaseSetUp", "Pass(1)", "CaseTearDown",
-                "CaseSetUp", "Pass(2)", "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp", "Fail", "CaseTearDown",
+            "TestTearDown",
+            "TestSetUp",
+            "CaseSetUp", "Pass(1)", "CaseTearDown",
+            "CaseSetUp", "Pass(2)", "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "ClassSetUp",
-                "TestSetUp",
-                "CaseSetUp",
-                "SecondPass",
-                "CaseTearDown",
-                "TestTearDown",
-                "ClassTearDown",
+            "ClassSetUp",
+            "TestSetUp",
+            "CaseSetUp",
+            "SecondPass",
+            "CaseTearDown",
+            "TestTearDown",
+            "ClassTearDown",
 
-                "AssemblyTearDown");
-        }
+            "AssemblyTearDown");
+    }
 
     public async Task ShouldSkipTestLifecyclesWhenTestsAreSkipped()
     {
-            var output = await Run<AllSkippedTestClass, InstrumentedExecution>();
+        var output = await Run<AllSkippedTestClass, InstrumentedExecution>();
 
-            output.ShouldHaveResults(
-                "AllSkippedTestClass.SkipA skipped: This test did not run.",
-                "AllSkippedTestClass.SkipB skipped: This test did not run.",
-                "AllSkippedTestClass.SkipC skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "AllSkippedTestClass.SkipA skipped: This test did not run.",
+            "AllSkippedTestClass.SkipB skipped: This test did not run.",
+            "AllSkippedTestClass.SkipC skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle("AssemblySetUp", "ClassSetUp", "ClassTearDown", "AssemblyTearDown");
-        }
+        output.ShouldHaveLifecycle("AssemblySetUp", "ClassSetUp", "ClassTearDown", "AssemblyTearDown");
+    }
 
     public async Task ShouldAllowRunningTestsMultipleTimesWithDistinctResultPerInvocation()
     {
-            FailDuring("Pass", occurrence: 3);
+        FailDuring("Pass", occurrence: 3);
 
-            var output = await Run<FirstTestClass, SecondTestClass, RepeatedExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, RepeatedExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                
-                "FirstTestClass.Pass(1) passed",
-                "FirstTestClass.Pass(2) passed",
-                "FirstTestClass.Pass(1) failed: 'Pass' failed!",
-                "FirstTestClass.Pass(2) passed",
-                "FirstTestClass.Pass(1) passed",
-                "FirstTestClass.Pass(2) passed",
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            
+            "FirstTestClass.Pass(1) passed",
+            "FirstTestClass.Pass(2) passed",
+            "FirstTestClass.Pass(1) failed: 'Pass' failed!",
+            "FirstTestClass.Pass(2) passed",
+            "FirstTestClass.Pass(1) passed",
+            "FirstTestClass.Pass(2) passed",
 
-                "SecondTestClass.SecondPass passed",
-                "SecondTestClass.SecondPass passed",
-                "SecondTestClass.SecondPass passed",
+            "SecondTestClass.SecondPass passed",
+            "SecondTestClass.SecondPass passed",
+            "SecondTestClass.SecondPass passed",
 
-                "FirstTestClass.Skip skipped: This test did not run.");
+            "FirstTestClass.Skip skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "Fail",
-                "Fail",
-                "Fail",
-                "Pass(1)", "Pass(2)",
-                "Pass(1)", "Pass(2)",
-                "Pass(1)", "Pass(2)",
-                "SecondPass",
-                "SecondPass",
-                "SecondPass");
-        }
+        output.ShouldHaveLifecycle(
+            "Fail",
+            "Fail",
+            "Fail",
+            "Pass(1)", "Pass(2)",
+            "Pass(1)", "Pass(2)",
+            "Pass(1)", "Pass(2)",
+            "SecondPass",
+            "SecondPass",
+            "SecondPass");
+    }
 
     public async Task ShouldAllowInspectionOfIndividualTestInvocationResultsToDriveExecutionDecisions()
     {
-            FailDuring("Pass", occurrence: 3);
+        FailDuring("Pass", occurrence: 3);
 
-            var output = await Run<FirstTestClass, SecondTestClass>(new CircuitBreakingExecution(maxFailures: 3));
+        var output = await Run<FirstTestClass, SecondTestClass>(new CircuitBreakingExecution(maxFailures: 3));
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                "FirstTestClass.Fail failed: 'Fail' failed!",
-                
-                "FirstTestClass.Pass(1) passed",
-                "FirstTestClass.Pass(2) passed",
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            "FirstTestClass.Fail failed: 'Fail' failed!",
+            
+            "FirstTestClass.Pass(1) passed",
+            "FirstTestClass.Pass(2) passed",
 
-                "FirstTestClass.Pass(1) failed: 'Pass' failed!", //The fourth failure stops the entire run early.
+            "FirstTestClass.Pass(1) failed: 'Pass' failed!", //The fourth failure stops the entire run early.
 
-                "FirstTestClass.Skip skipped: This test did not run.",
-                "SecondTestClass.SecondPass skipped: This test did not run.");
+            "FirstTestClass.Skip skipped: This test did not run.",
+            "SecondTestClass.SecondPass skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle(
-                "Fail",
-                "Fail",
-                "Fail",
-                "Pass(1)", "Pass(2)",
-                "Pass(1)");
-        }
+        output.ShouldHaveLifecycle(
+            "Fail",
+            "Fail",
+            "Fail",
+            "Pass(1)", "Pass(2)",
+            "Pass(1)");
+    }
 
     public async Task ShouldSkipAllTestsWhenShortCircuitingTestExecution()
     {
-            var output = await Run<FirstTestClass, SecondTestClass, ShortCircuitTestExecution>();
+        var output = await Run<FirstTestClass, SecondTestClass, ShortCircuitTestExecution>();
 
-            output.ShouldHaveResults(
-                "FirstTestClass.Fail skipped: This test did not run.",
-                "FirstTestClass.Pass skipped: This test did not run.",
-                "FirstTestClass.Skip skipped: This test did not run.",
-                "SecondTestClass.SecondPass skipped: This test did not run.");
+        output.ShouldHaveResults(
+            "FirstTestClass.Fail skipped: This test did not run.",
+            "FirstTestClass.Pass skipped: This test did not run.",
+            "FirstTestClass.Skip skipped: This test did not run.",
+            "SecondTestClass.SecondPass skipped: This test did not run.");
 
-            output.ShouldHaveLifecycle();
-        }
+        output.ShouldHaveLifecycle();
+    }
 }

--- a/src/Fixie.Tests/TestClassLifecycleTests.cs
+++ b/src/Fixie.Tests/TestClassLifecycleTests.cs
@@ -1,87 +1,87 @@
-namespace Fixie.Tests
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using static Utility;
+namespace Fixie.Tests;
 
-    public class TestClassLifecycleTests : InstrumentedExecutionTests
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using static Utility;
+
+public class TestClassLifecycleTests : InstrumentedExecutionTests
+{
+    class FirstTestClass
     {
-        class FirstTestClass
+        public void Fail()
         {
-            public void Fail()
-            {
                 WhereAmI();
                 throw new FailureException();
             }
 
-            [Input(1)]
-            [Input(2)]
-            public void Pass(int i)
-            {
+        [Input(1)]
+        [Input(2)]
+        public void Pass(int i)
+        {
                 WhereAmI(i);
             }
 
-            public void Skip()
-            {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
-        }
-
-        class SecondTestClass
+        public void Skip()
         {
-            public void SecondPass()
-            {
                 WhereAmI();
+                throw new ShouldBeUnreachableException();
             }
-        }
+    }
 
-        class AllSkippedTestClass
+    class SecondTestClass
+    {
+        public void SecondPass()
         {
-            public void SkipA()
-            {
                 WhereAmI();
-                throw new ShouldBeUnreachableException();
             }
+    }
 
-            public void SkipB()
-            {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
-
-            public void SkipC()
-            {
-                WhereAmI();
-                throw new ShouldBeUnreachableException();
-            }
-        }
-
-        static class StaticTestClass
+    class AllSkippedTestClass
+    {
+        public void SkipA()
         {
-            public static void Fail()
-            {
+                WhereAmI();
+                throw new ShouldBeUnreachableException();
+            }
+
+        public void SkipB()
+        {
+                WhereAmI();
+                throw new ShouldBeUnreachableException();
+            }
+
+        public void SkipC()
+        {
+                WhereAmI();
+                throw new ShouldBeUnreachableException();
+            }
+    }
+
+    static class StaticTestClass
+    {
+        public static void Fail()
+        {
                 WhereAmI();
                 throw new FailureException();
             }
 
-            public static void Pass()
-            {
+        public static void Pass()
+        {
                 WhereAmI();
             }
 
-            public static void Skip()
-            {
+        public static void Skip()
+        {
                 WhereAmI();
                 throw new ShouldBeUnreachableException();
             }
-        }
+    }
 
-        class InstrumentedExecution : IExecution
+    class InstrumentedExecution : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 AssemblySetUp();
 
                 foreach (var testClass in testSuite.TestClasses)
@@ -90,8 +90,8 @@ namespace Fixie.Tests
                 AssemblyTearDown();
             }
 
-            async Task TestClassLifecycle(TestClass testClass)
-            {
+        async Task TestClassLifecycle(TestClass testClass)
+        {
                 try
                 {
                     ClassSetUp();
@@ -108,8 +108,8 @@ namespace Fixie.Tests
                 }
             }
 
-            async Task TestLifecycle(Test test)
-            {
+        async Task TestLifecycle(Test test)
+        {
                 try
                 {
                     TestSetUp();
@@ -125,15 +125,15 @@ namespace Fixie.Tests
                 }
             }
 
-            static IEnumerable<object?[]> YieldParameters(Test test)
-            {
+        static IEnumerable<object?[]> YieldParameters(Test test)
+        {
                 ProcessScriptedFailure();
 
                 return FromInputAttributes(test);
             }
 
-            static async Task CaseLifecycle(Test test, object?[] parameters)
-            {
+        static async Task CaseLifecycle(Test test, object?[] parameters)
+        {
                 try
                 {
                     CaseSetUp();
@@ -145,32 +145,32 @@ namespace Fixie.Tests
                     await test.Fail(parameters, exception);
                 }
             }
-        }
+    }
 
-        static void AssemblySetUp() => WhereAmI();
-        static void ClassSetUp() => WhereAmI();
-        static void TestSetUp() => WhereAmI();
-        static void CaseSetUp() => WhereAmI();
-        static void CaseTearDown() => WhereAmI();
-        static void TestTearDown() => WhereAmI();
-        static void ClassTearDown() => WhereAmI();
-        static void AssemblyTearDown() => WhereAmI();
+    static void AssemblySetUp() => WhereAmI();
+    static void ClassSetUp() => WhereAmI();
+    static void TestSetUp() => WhereAmI();
+    static void CaseSetUp() => WhereAmI();
+    static void CaseTearDown() => WhereAmI();
+    static void TestTearDown() => WhereAmI();
+    static void ClassTearDown() => WhereAmI();
+    static void AssemblyTearDown() => WhereAmI();
 
-        class ShortCircuitTestExecution : IExecution
+    class ShortCircuitTestExecution : IExecution
+    {
+        public Task Run(TestSuite testSuite)
         {
-            public Task Run(TestSuite testSuite)
-            {
                 //Lifecycle chooses not to invoke any tests.
                 //Since the tests never run, they are all
                 //considered 'skipped'.
                 return Task.CompletedTask;
             }
-        }
+    }
 
-        class RepeatedExecution : IExecution
+    class RepeatedExecution : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
         {
-            public async Task Run(TestSuite testSuite)
-            {
                 foreach (var test in testSuite.Tests)
                 {
                     if (test.Name.Contains("Skip")) continue;
@@ -180,17 +180,17 @@ namespace Fixie.Tests
                             await test.Run(parameters);
                 }
             }
-        }
+    }
 
-        class CircuitBreakingExecution : IExecution
+    class CircuitBreakingExecution : IExecution
+    {
+        readonly int maxFailures;
+
+        public CircuitBreakingExecution(int maxFailures)
+            => this.maxFailures = maxFailures;
+
+        public async Task Run(TestSuite testSuite)
         {
-            readonly int maxFailures;
-
-            public CircuitBreakingExecution(int maxFailures)
-                => this.maxFailures = maxFailures;
-
-            public async Task Run(TestSuite testSuite)
-            {
                 int failures = 0;
 
                 foreach (var test in testSuite.Tests)
@@ -214,10 +214,10 @@ namespace Fixie.Tests
                     }
                 }
             }
-        }
+    }
 
-        public async Task ShouldRunAllTestsByDefault()
-        {
+    public async Task ShouldRunAllTestsByDefault()
+    {
             var output = await Run<FirstTestClass, SecondTestClass, DefaultExecution>();
 
             //NOTE: With no input parameter or skip behaviors,
@@ -234,8 +234,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("Fail", "Skip", "SecondPass");
         }
 
-        public async Task ShouldSupportExecutionLifecycleHooks()
-        {
+    public async Task ShouldSupportExecutionLifecycleHooks()
+    {
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
@@ -269,8 +269,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldSupportStaticTestClassesAndMethods()
-        {
+    public async Task ShouldSupportStaticTestClassesAndMethods()
+    {
             var output = await Run<InstrumentedExecution>(typeof(StaticTestClass));
 
             output.ShouldHaveResults(
@@ -287,8 +287,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenAssemblySetUpThrows()
-        {
+    public async Task ShouldFailAllTestsWithoutHidingPrimarySkipResultsWhenAssemblySetUpThrows()
+    {
             FailDuring("AssemblySetUp");
 
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
@@ -309,8 +309,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("AssemblySetUp");
         }
 
-        public async Task ShouldFailAllTestsInClassWithoutHidingPrimarySkipResultsWhenClassSetUpThrows()
-        {
+    public async Task ShouldFailAllTestsInClassWithoutHidingPrimarySkipResultsWhenClassSetUpThrows()
+    {
             FailDuring("ClassSetUp", occurrence: 1);
         
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
@@ -328,8 +328,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldFailTestWhenTestSetUpThrows()
-        {
+    public async Task ShouldFailTestWhenTestSetUpThrows()
+    {
             FailDuring("TestSetUp", occurrence: 2);
 
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
@@ -355,8 +355,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldFailTestWhenCustomParameterGenerationThrows()
-        {
+    public async Task ShouldFailTestWhenCustomParameterGenerationThrows()
+    {
             FailDuring("YieldParameters", 2);
 
             var execution = new InstrumentedExecution();
@@ -378,8 +378,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldFailCaseWhenCaseSetUpThrows()
-        {
+    public async Task ShouldFailCaseWhenCaseSetUpThrows()
+    {
             FailDuring("CaseSetUp", occurrence: 2);
 
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
@@ -415,8 +415,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldFailCaseWithoutHidingPrimaryCaseResultsWhenCaseTearDownThrows()
-        {
+    public async Task ShouldFailCaseWithoutHidingPrimaryCaseResultsWhenCaseTearDownThrows()
+    {
             FailDuring("CaseTearDown");
 
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
@@ -456,8 +456,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldFailTestWithoutHidingPrimaryCaseResultsWhenTestTearDownThrows()
-        {
+    public async Task ShouldFailTestWithoutHidingPrimaryCaseResultsWhenTestTearDownThrows()
+    {
             FailDuring("TestTearDown");
 
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
@@ -499,8 +499,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldFailAllTestsInClassWithoutHidingPrimaryCaseResultsWhenClassTearDownThrows()
-        {
+    public async Task ShouldFailAllTestsInClassWithoutHidingPrimaryCaseResultsWhenClassTearDownThrows()
+    {
             FailDuring("ClassTearDown", occurrence: 1);
 
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
@@ -540,8 +540,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldFailAllTestsWithoutHidingPrimaryCaseResultsWhenAssemblyTearDownThrows()
-        {
+    public async Task ShouldFailAllTestsWithoutHidingPrimaryCaseResultsWhenAssemblyTearDownThrows()
+    {
             FailDuring("AssemblyTearDown");
 
             var output = await Run<FirstTestClass, SecondTestClass, InstrumentedExecution>();
@@ -584,8 +584,8 @@ namespace Fixie.Tests
                 "AssemblyTearDown");
         }
 
-        public async Task ShouldSkipTestLifecyclesWhenTestsAreSkipped()
-        {
+    public async Task ShouldSkipTestLifecyclesWhenTestsAreSkipped()
+    {
             var output = await Run<AllSkippedTestClass, InstrumentedExecution>();
 
             output.ShouldHaveResults(
@@ -596,8 +596,8 @@ namespace Fixie.Tests
             output.ShouldHaveLifecycle("AssemblySetUp", "ClassSetUp", "ClassTearDown", "AssemblyTearDown");
         }
 
-        public async Task ShouldAllowRunningTestsMultipleTimesWithDistinctResultPerInvocation()
-        {
+    public async Task ShouldAllowRunningTestsMultipleTimesWithDistinctResultPerInvocation()
+    {
             FailDuring("Pass", occurrence: 3);
 
             var output = await Run<FirstTestClass, SecondTestClass, RepeatedExecution>();
@@ -632,8 +632,8 @@ namespace Fixie.Tests
                 "SecondPass");
         }
 
-        public async Task ShouldAllowInspectionOfIndividualTestInvocationResultsToDriveExecutionDecisions()
-        {
+    public async Task ShouldAllowInspectionOfIndividualTestInvocationResultsToDriveExecutionDecisions()
+    {
             FailDuring("Pass", occurrence: 3);
 
             var output = await Run<FirstTestClass, SecondTestClass>(new CircuitBreakingExecution(maxFailures: 3));
@@ -659,8 +659,8 @@ namespace Fixie.Tests
                 "Pass(1)");
         }
 
-        public async Task ShouldSkipAllTestsWhenShortCircuitingTestExecution()
-        {
+    public async Task ShouldSkipAllTestsWhenShortCircuitingTestExecution()
+    {
             var output = await Run<FirstTestClass, SecondTestClass, ShortCircuitTestExecution>();
 
             output.ShouldHaveResults(
@@ -671,5 +671,4 @@ namespace Fixie.Tests
 
             output.ShouldHaveLifecycle();
         }
-    }
 }

--- a/src/Fixie.Tests/TestNameTests.cs
+++ b/src/Fixie.Tests/TestNameTests.cs
@@ -6,21 +6,21 @@ public class TestNameTests
 {
     public void CanRepresentMethodsDeclaredInChildClasses()
     {
-            Test<ChildClass>("MethodDefinedWithinChildClass")
-                .ShouldBe("Fixie.Tests.TestNameTests+ChildClass.MethodDefinedWithinChildClass");
-        }
+        Test<ChildClass>("MethodDefinedWithinChildClass")
+            .ShouldBe("Fixie.Tests.TestNameTests+ChildClass.MethodDefinedWithinChildClass");
+    }
 
     public void CanRepresentMethodsDeclaredInParentClasses()
     {
-            Test<ParentClass>("MethodDefinedWithinParentClass")
-                .ShouldBe("Fixie.Tests.TestNameTests+ParentClass.MethodDefinedWithinParentClass");
-        }
+        Test<ParentClass>("MethodDefinedWithinParentClass")
+            .ShouldBe("Fixie.Tests.TestNameTests+ParentClass.MethodDefinedWithinParentClass");
+    }
 
     public void CanRepresentParentMethodsInheritedByChildClasses()
     {
-            Test<ChildClass>("MethodDefinedWithinParentClass")
-                .ShouldBe("Fixie.Tests.TestNameTests+ChildClass.MethodDefinedWithinParentClass");
-        }
+        Test<ChildClass>("MethodDefinedWithinParentClass")
+            .ShouldBe("Fixie.Tests.TestNameTests+ChildClass.MethodDefinedWithinParentClass");
+    }
 
     static string Test<TTestClass>(string method)
         => typeof(TTestClass).GetInstanceMethod(method).TestName();
@@ -29,13 +29,13 @@ public class TestNameTests
     {
         public void MethodDefinedWithinParentClass()
         {
-            }
+        }
     }
 
     class ChildClass : ParentClass
     {
         public void MethodDefinedWithinChildClass()
         {
-            }
+        }
     }
 }

--- a/src/Fixie.Tests/TestNameTests.cs
+++ b/src/Fixie.Tests/TestNameTests.cs
@@ -1,42 +1,41 @@
-﻿namespace Fixie.Tests
-{
-    using Assertions;
+﻿namespace Fixie.Tests;
 
-    public class TestNameTests
+using Assertions;
+
+public class TestNameTests
+{
+    public void CanRepresentMethodsDeclaredInChildClasses()
     {
-        public void CanRepresentMethodsDeclaredInChildClasses()
-        {
             Test<ChildClass>("MethodDefinedWithinChildClass")
                 .ShouldBe("Fixie.Tests.TestNameTests+ChildClass.MethodDefinedWithinChildClass");
         }
 
-        public void CanRepresentMethodsDeclaredInParentClasses()
-        {
+    public void CanRepresentMethodsDeclaredInParentClasses()
+    {
             Test<ParentClass>("MethodDefinedWithinParentClass")
                 .ShouldBe("Fixie.Tests.TestNameTests+ParentClass.MethodDefinedWithinParentClass");
         }
 
-        public void CanRepresentParentMethodsInheritedByChildClasses()
-        {
+    public void CanRepresentParentMethodsInheritedByChildClasses()
+    {
             Test<ChildClass>("MethodDefinedWithinParentClass")
                 .ShouldBe("Fixie.Tests.TestNameTests+ChildClass.MethodDefinedWithinParentClass");
         }
 
-        static string Test<TTestClass>(string method)
-            => typeof(TTestClass).GetInstanceMethod(method).TestName();
+    static string Test<TTestClass>(string method)
+        => typeof(TTestClass).GetInstanceMethod(method).TestName();
 
-        class ParentClass
+    class ParentClass
+    {
+        public void MethodDefinedWithinParentClass()
         {
-            public void MethodDefinedWithinParentClass()
-            {
             }
-        }
+    }
 
-        class ChildClass : ParentClass
+    class ChildClass : ParentClass
+    {
+        public void MethodDefinedWithinChildClass()
         {
-            public void MethodDefinedWithinChildClass()
-            {
             }
-        }
     }
 }

--- a/src/Fixie.Tests/TestProject.cs
+++ b/src/Fixie.Tests/TestProject.cs
@@ -1,13 +1,12 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+class TestProject : ITestProject
 {
-    class TestProject : ITestProject
+    public void Configure(TestConfiguration configuration, TestEnvironment environment)
     {
-        public void Configure(TestConfiguration configuration, TestEnvironment environment)
-        {
-            if (environment.IsDevelopment())
-                configuration.Reports.Add<DiffToolReport>();
-            else
-                configuration.Reports.Add(new GitHubReport(environment));
-        }
+        if (environment.IsDevelopment())
+            configuration.Reports.Add<DiffToolReport>();
+        else
+            configuration.Reports.Add(new GitHubReport(environment));
     }
 }

--- a/src/Fixie.Tests/UntrustworthyAwaitable.cs
+++ b/src/Fixie.Tests/UntrustworthyAwaitable.cs
@@ -1,49 +1,48 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+using System;
+using System.Runtime.CompilerServices;
+
+// This provides enough structural support for the async/await keywords
+// to be satisfied at compile time, but is not expected to behave well.
+
+[AsyncMethodBuilder(typeof(UntrustworthyMethodBuilder))]
+class UntrustworthyAwaitable
 {
-    using System;
-    using System.Runtime.CompilerServices;
+    public UntrustworthyAwaiter GetAwaiter()
+        => new UntrustworthyAwaiter();
+}
 
-    // This provides enough structural support for the async/await keywords
-    // to be satisfied at compile time, but is not expected to behave well.
+class UntrustworthyAwaiter : INotifyCompletion
+{
+    public void OnCompleted(Action completion)
+        => throw new ShouldBeUnreachableException();
+}
 
-    [AsyncMethodBuilder(typeof(UntrustworthyMethodBuilder))]
-    class UntrustworthyAwaitable
-    {
-        public UntrustworthyAwaiter GetAwaiter()
-            => new UntrustworthyAwaiter();
-    }
+class UntrustworthyMethodBuilder
+{
+    public static UntrustworthyMethodBuilder Create()
+        => new UntrustworthyMethodBuilder();
 
-    class UntrustworthyAwaiter : INotifyCompletion
-    {
-        public void OnCompleted(Action completion)
-            => throw new ShouldBeUnreachableException();
-    }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine)
+        where TStateMachine : IAsyncStateMachine { }
 
-    class UntrustworthyMethodBuilder
-    {
-        public static UntrustworthyMethodBuilder Create()
-            => new UntrustworthyMethodBuilder();
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
 
-        public void Start<TStateMachine>(ref TStateMachine stateMachine)
-            where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception exception) { }
 
-        public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult() { }
 
-        public void SetException(Exception exception) { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(
+        ref TAwaiter awaiter, ref TStateMachine stateMachine)
+        where TAwaiter : INotifyCompletion
+        where TStateMachine : IAsyncStateMachine { }
 
-        public void SetResult() { }
-
-        public void AwaitOnCompleted<TAwaiter, TStateMachine>(
-            ref TAwaiter awaiter, ref TStateMachine stateMachine)
-            where TAwaiter : INotifyCompletion
-            where TStateMachine : IAsyncStateMachine { }
-
-        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(
-            ref TAwaiter awaiter, ref TStateMachine stateMachine)
-            where TAwaiter : ICriticalNotifyCompletion
-            where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(
+        ref TAwaiter awaiter, ref TStateMachine stateMachine)
+        where TAwaiter : ICriticalNotifyCompletion
+        where TStateMachine : IAsyncStateMachine { }
         
-        public UntrustworthyAwaitable Task
-            => new UntrustworthyAwaitable();
-    }
+    public UntrustworthyAwaitable Task
+        => new UntrustworthyAwaitable();
 }

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -1,99 +1,98 @@
-﻿namespace Fixie.Tests
+﻿namespace Fixie.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Fixie.Internal;
+using Fixie.Reports;
+
+public static class Utility
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Runtime.CompilerServices;
-    using System.Text.RegularExpressions;
-    using System.Threading.Tasks;
-    using Fixie.Internal;
-    using Fixie.Reports;
-
-    public static class Utility
+    public static TestEnvironment GetTestEnvironment()
     {
-        public static TestEnvironment GetTestEnvironment()
-        {
-            return new TestEnvironment(
-                typeof(TestProject).Assembly,
-                System.Console.Out,
-                Directory.GetCurrentDirectory());
-        }
-
-        public static string TargetFrameworkVersion => "8.0";
-
-        public static string FullName<T>()
-        {
-            return typeof(T).FullName ??
-                   throw new Exception($"Expected type {typeof(T).Name} to have a non-null FullName.");
-        }
-
-        public static string At<T>(string method, [CallerFilePath] string path = default!)
-            => At(typeof(T), method, NormalizedPath(path));
-
-        public static string At(Type type, string method, string normalizedPath)
-        {
-            var typeFullName = type.FullName ??
-                   throw new Exception($"Expected type {type.Name} to have a non-null FullName.");
-
-            return $"   at {typeFullName.Replace("+", ".")}.{method} in {normalizedPath}:line #";
-        }
-
-        static string NormalizedPath(string path)
-            => Regex.Replace(path,
-                @".+([\\/])src([\\/])Fixie(.+)\.cs",
-                "...$1src$2Fixie$3.cs");
-
-        public static async Task<IEnumerable<string>> Run(Type testClass, IExecution execution)
-        {
-            var report = new StubReport();
-            var discovery = new SelfTestDiscovery();
-
-            await Run(report, discovery, execution, testClass);
-            return report.Entries;
-        }
-
-        public static async Task<IEnumerable<string>> Run(Type[] testClasses, IExecution execution)
-        {
-            var report = new StubReport();
-            var discovery = new SelfTestDiscovery();
-
-            await Run(report, discovery, execution, testClasses);
-            return report.Entries;
-        }
-
-        public static async Task Discover(IReport report, IDiscovery discovery, params Type[] candidateTypes)
-        {
-            if (candidateTypes.Length == 0)
-                throw new InvalidOperationException("At least one type must be specified.");
-
-            var environment = new TestEnvironment(candidateTypes[0].Assembly, System.Console.Out, Directory.GetCurrentDirectory());
-            var runner = new Runner(environment, report);
-
-            await runner.Discover(candidateTypes, discovery);
-        }
-
-        internal static async Task Run(IReport report, IDiscovery discovery, IExecution execution, params Type[] candidateTypes)
-        {
-            if (candidateTypes.Length == 0)
-                throw new InvalidOperationException("At least one type must be specified.");
-
-            var environment = new TestEnvironment(candidateTypes[0].Assembly, System.Console.Out, Directory.GetCurrentDirectory());
-            var runner = new Runner(environment, report);
-            var configuration = new TestConfiguration();
-            configuration.Conventions.Add(discovery, execution);
-
-            await runner.Run(candidateTypes, configuration, new HashSet<string>());
-        }
-
-        public static IEnumerable<object?[]> FromInputAttributes(Test test)
-        {
-            return test.HasParameters
-                ? test.GetAll<InputAttribute>().Select(x => x.Parameters)
-                : InvokeOnceWithZeroParameters;
-        }
-
-        static readonly object[] EmptyParameters = {};
-        static readonly object[][] InvokeOnceWithZeroParameters = { EmptyParameters };
+        return new TestEnvironment(
+            typeof(TestProject).Assembly,
+            System.Console.Out,
+            Directory.GetCurrentDirectory());
     }
+
+    public static string TargetFrameworkVersion => "8.0";
+
+    public static string FullName<T>()
+    {
+        return typeof(T).FullName ??
+               throw new Exception($"Expected type {typeof(T).Name} to have a non-null FullName.");
+    }
+
+    public static string At<T>(string method, [CallerFilePath] string path = default!)
+        => At(typeof(T), method, NormalizedPath(path));
+
+    public static string At(Type type, string method, string normalizedPath)
+    {
+        var typeFullName = type.FullName ??
+                           throw new Exception($"Expected type {type.Name} to have a non-null FullName.");
+
+        return $"   at {typeFullName.Replace("+", ".")}.{method} in {normalizedPath}:line #";
+    }
+
+    static string NormalizedPath(string path)
+        => Regex.Replace(path,
+            @".+([\\/])src([\\/])Fixie(.+)\.cs",
+            "...$1src$2Fixie$3.cs");
+
+    public static async Task<IEnumerable<string>> Run(Type testClass, IExecution execution)
+    {
+        var report = new StubReport();
+        var discovery = new SelfTestDiscovery();
+
+        await Run(report, discovery, execution, testClass);
+        return report.Entries;
+    }
+
+    public static async Task<IEnumerable<string>> Run(Type[] testClasses, IExecution execution)
+    {
+        var report = new StubReport();
+        var discovery = new SelfTestDiscovery();
+
+        await Run(report, discovery, execution, testClasses);
+        return report.Entries;
+    }
+
+    public static async Task Discover(IReport report, IDiscovery discovery, params Type[] candidateTypes)
+    {
+        if (candidateTypes.Length == 0)
+            throw new InvalidOperationException("At least one type must be specified.");
+
+        var environment = new TestEnvironment(candidateTypes[0].Assembly, System.Console.Out, Directory.GetCurrentDirectory());
+        var runner = new Runner(environment, report);
+
+        await runner.Discover(candidateTypes, discovery);
+    }
+
+    internal static async Task Run(IReport report, IDiscovery discovery, IExecution execution, params Type[] candidateTypes)
+    {
+        if (candidateTypes.Length == 0)
+            throw new InvalidOperationException("At least one type must be specified.");
+
+        var environment = new TestEnvironment(candidateTypes[0].Assembly, System.Console.Out, Directory.GetCurrentDirectory());
+        var runner = new Runner(environment, report);
+        var configuration = new TestConfiguration();
+        configuration.Conventions.Add(discovery, execution);
+
+        await runner.Run(candidateTypes, configuration, new HashSet<string>());
+    }
+
+    public static IEnumerable<object?[]> FromInputAttributes(Test test)
+    {
+        return test.HasParameters
+            ? test.GetAll<InputAttribute>().Select(x => x.Parameters)
+            : InvokeOnceWithZeroParameters;
+    }
+
+    static readonly object[] EmptyParameters = {};
+    static readonly object[][] InvokeOnceWithZeroParameters = { EmptyParameters };
 }

--- a/src/Fixie.sln.DotSettings
+++ b/src/Fixie.sln.DotSettings
@@ -3,7 +3,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_FOREACH_STMT/@EntryValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/Fixie/ConventionCollection.cs
+++ b/src/Fixie/ConventionCollection.cs
@@ -1,20 +1,19 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+using System.Collections.Generic;
+using Internal;
+
+public class ConventionCollection
 {
-    using System.Collections.Generic;
-    using Internal;
+    internal List<Convention> Items { get; }
 
-    public class ConventionCollection
-    {
-        internal List<Convention> Items { get; }
+    internal ConventionCollection() => Items = new List<Convention>();
 
-        internal ConventionCollection() => Items = new List<Convention>();
+    public void Add(IDiscovery discovery, IExecution execution)
+        => Items.Add(new Convention(discovery, execution));
 
-        public void Add(IDiscovery discovery, IExecution execution)
-            => Items.Add(new Convention(discovery, execution));
-
-        public void Add<TDiscovery, TExecution>()
-            where TDiscovery : IDiscovery, new()
-            where TExecution : IExecution, new()
-            => Add(new TDiscovery(), new TExecution());
-    }
+    public void Add<TDiscovery, TExecution>()
+        where TDiscovery : IDiscovery, new()
+        where TExecution : IExecution, new()
+        => Add(new TDiscovery(), new TExecution());
 }

--- a/src/Fixie/DefaultDiscovery.cs
+++ b/src/Fixie/DefaultDiscovery.cs
@@ -1,16 +1,15 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+public sealed class DefaultDiscovery : IDiscovery
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
+    public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
+        => concreteClasses.Where(x => x.Name.EndsWith("Tests"));
 
-    public sealed class DefaultDiscovery : IDiscovery
-    {
-        public IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses)
-            => concreteClasses.Where(x => x.Name.EndsWith("Tests"));
-
-        public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
-            => publicMethods.Where(x => !x.IsStatic);
-    }
+    public IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods)
+        => publicMethods.Where(x => !x.IsStatic);
 }

--- a/src/Fixie/DefaultExecution.cs
+++ b/src/Fixie/DefaultExecution.cs
@@ -1,13 +1,12 @@
-﻿namespace Fixie
-{
-    using System.Threading.Tasks;
+﻿namespace Fixie;
 
-    public sealed class DefaultExecution : IExecution
+using System.Threading.Tasks;
+
+public sealed class DefaultExecution : IExecution
+{
+    public async Task Run(TestSuite testSuite)
     {
-        public async Task Run(TestSuite testSuite)
-        {
-            foreach (var test in testSuite.Tests)
-                await test.Run();
-        }
+        foreach (var test in testSuite.Tests)
+            await test.Run();
     }
 }

--- a/src/Fixie/IDiscovery.cs
+++ b/src/Fixie/IDiscovery.cs
@@ -1,19 +1,18 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+public interface IDiscovery
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Reflection;
+    /// <summary>
+    /// Filters a set of candidate classes to those which are to be treated as test classes.
+    /// </summary>
+    IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses);
 
-    public interface IDiscovery
-    {
-        /// <summary>
-        /// Filters a set of candidate classes to those which are to be treated as test classes.
-        /// </summary>
-        IEnumerable<Type> TestClasses(IEnumerable<Type> concreteClasses);
-
-        /// <summary>
-        /// Filters a set of candidate methods to those which are to be treated as test methods.
-        /// </summary>
-        IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods);
-    }
+    /// <summary>
+    /// Filters a set of candidate methods to those which are to be treated as test methods.
+    /// </summary>
+    IEnumerable<MethodInfo> TestMethods(IEnumerable<MethodInfo> publicMethods);
 }

--- a/src/Fixie/IExecution.cs
+++ b/src/Fixie/IExecution.cs
@@ -1,12 +1,11 @@
-﻿namespace Fixie
-{
-    using System.Threading.Tasks;
+﻿namespace Fixie;
 
-    public interface IExecution
-    {
-        /// <summary>
-        /// Runs the given set of discovered tests.
-        /// </summary>
-        Task Run(TestSuite testSuite);
-    }
+using System.Threading.Tasks;
+
+public interface IExecution
+{
+    /// <summary>
+    /// Runs the given set of discovered tests.
+    /// </summary>
+    Task Run(TestSuite testSuite);
 }

--- a/src/Fixie/ITestProject.cs
+++ b/src/Fixie/ITestProject.cs
@@ -1,7 +1,6 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+public interface ITestProject
 {
-    public interface ITestProject
-    {
-        void Configure(TestConfiguration configuration, TestEnvironment environment);
-    }
+    void Configure(TestConfiguration configuration, TestEnvironment environment);
 }

--- a/src/Fixie/Internal/Bus.cs
+++ b/src/Fixie/Internal/Bus.cs
@@ -1,24 +1,24 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Reports;
+
+class Bus
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Threading.Tasks;
-    using Reports;
+    readonly TextWriter console;
+    readonly List<IReport> reports;
 
-    class Bus
+    public Bus(TextWriter console, IReadOnlyList<IReport> reports)
     {
-        readonly TextWriter console;
-        readonly List<IReport> reports;
-
-        public Bus(TextWriter console, IReadOnlyList<IReport> reports)
-        {
             this.console = console;
             this.reports = new List<IReport>(reports);
         }
 
-        public async Task Publish<TMessage>(TMessage message) where TMessage : IMessage
-        {
+    public async Task Publish<TMessage>(TMessage message) where TMessage : IMessage
+    {
             foreach (var report in reports)
             {
                 try
@@ -38,5 +38,4 @@
                 }
             }
         }
-    }
 }

--- a/src/Fixie/Internal/Bus.cs
+++ b/src/Fixie/Internal/Bus.cs
@@ -13,29 +13,29 @@ class Bus
 
     public Bus(TextWriter console, IReadOnlyList<IReport> reports)
     {
-            this.console = console;
-            this.reports = new List<IReport>(reports);
-        }
+        this.console = console;
+        this.reports = new List<IReport>(reports);
+    }
 
     public async Task Publish<TMessage>(TMessage message) where TMessage : IMessage
     {
-            foreach (var report in reports)
+        foreach (var report in reports)
+        {
+            try
             {
-                try
-                {
-                    if (report is IHandler<TMessage> handler)
-                        await handler.Handle(message);
-                }
-                catch (Exception exception)
-                {
-                    using (Foreground.Yellow)
-                        console.WriteLine(
-                            $"{report.GetType().FullName} threw an exception while " +
-                            $"attempting to handle a message of type {typeof(TMessage).FullName}:");
-                    console.WriteLine();
-                    console.WriteLine(exception.ToString());
-                    console.WriteLine();
-                }
+                if (report is IHandler<TMessage> handler)
+                    await handler.Handle(message);
+            }
+            catch (Exception exception)
+            {
+                using (Foreground.Yellow)
+                    console.WriteLine(
+                        $"{report.GetType().FullName} threw an exception while " +
+                        $"attempting to handle a message of type {typeof(TMessage).FullName}:");
+                console.WriteLine();
+                console.WriteLine(exception.ToString());
+                console.WriteLine();
             }
         }
+    }
 }

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -1,93 +1,92 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+static class CaseNameBuilder
 {
-    using System;
-    using System.Globalization;
-    using System.Linq;
-    using System.Reflection;
-    using System.Text;
-
-    static class CaseNameBuilder
+    public static string GetName(MethodInfo method, object?[] parameters)
     {
-        public static string GetName(MethodInfo method, object?[] parameters)
-        {
-            var name = method.ReflectedType!.FullName + "." + method.Name;
+        var name = method.ReflectedType!.FullName + "." + method.Name;
 
-            if (method.IsGenericMethod)
-                name += $"<{string.Join(", ", method.GetGenericArguments().Select(x => x.IsGenericParameter ? x.Name : x.FullName))}>";
+        if (method.IsGenericMethod)
+            name += $"<{string.Join(", ", method.GetGenericArguments().Select(x => x.IsGenericParameter ? x.Name : x.FullName))}>";
 
-            if (parameters.Length > 0)
-                name += $"({string.Join(", ", parameters.Select(x => x.ToDisplayString()))})";
+        if (parameters.Length > 0)
+            name += $"({string.Join(", ", parameters.Select(x => x.ToDisplayString()))})";
 
-            return name;
-        }
-
-        static string ToDisplayString(this object? parameter)
-        {
-            if (parameter == null)
-                return "null";
-
-            if (parameter is char ch)
-                return CharacterLiteral(ch);
-
-            if (parameter is string s)
-                return ShortStringLiteral(s);
-
-            var displayString = Convert.ToString(parameter, CultureInfo.InvariantCulture);
-
-            if (displayString == null)
-                return parameter.GetType().ToString();
-
-            return displayString;
-        }
-
-        static string CharacterLiteral(char ch)
-        {
-            return "'" + ch.Escape(Literal.Character) + "'";
-        }
-
-        static string ShortStringLiteral(string s)
-        {
-            const int trimLength = 15;
-
-            if (s.Length > trimLength)
-                s = s.Substring(0, trimLength) + "...";
-
-            var sb = new StringBuilder();
-
-            foreach (var ch in s)
-                sb.Append(ch.Escape(Literal.String));
-
-            return "\"" + sb + "\"";
-        }
-
-        static string Escape(this char ch, Literal literal)
-        {
-            switch (ch)
-            {
-                case '\"': return literal == Literal.String ? "\\\"" : Char.ToString(ch);
-                case '\'': return literal == Literal.Character ? "\\\'" : Char.ToString(ch);
-
-                case '\\': return "\\\\";
-                case '\0': return "\\0";
-                case '\a': return "\\a";
-                case '\b': return "\\b";
-                case '\f': return "\\f";
-                case '\n': return "\\n";
-                case '\r': return "\\r";
-                case '\t': return "\\t";
-                case '\v': return "\\v";
-
-                case '\u0085': //Next Line
-                case '\u2028': //Line Separator
-                case '\u2029': //Paragraph Separator
-                    var digits = (int)ch;
-                    return $"\\u{digits:X4}";
-
-                default:
-                    return char.ToString(ch);
-            }
-        }
-
-        enum Literal { Character, String }
+        return name;
     }
+
+    static string ToDisplayString(this object? parameter)
+    {
+        if (parameter == null)
+            return "null";
+
+        if (parameter is char ch)
+            return CharacterLiteral(ch);
+
+        if (parameter is string s)
+            return ShortStringLiteral(s);
+
+        var displayString = Convert.ToString(parameter, CultureInfo.InvariantCulture);
+
+        if (displayString == null)
+            return parameter.GetType().ToString();
+
+        return displayString;
+    }
+
+    static string CharacterLiteral(char ch)
+    {
+        return "'" + ch.Escape(Literal.Character) + "'";
+    }
+
+    static string ShortStringLiteral(string s)
+    {
+        const int trimLength = 15;
+
+        if (s.Length > trimLength)
+            s = s.Substring(0, trimLength) + "...";
+
+        var sb = new StringBuilder();
+
+        foreach (var ch in s)
+            sb.Append(ch.Escape(Literal.String));
+
+        return "\"" + sb + "\"";
+    }
+
+    static string Escape(this char ch, Literal literal)
+    {
+        switch (ch)
+        {
+            case '\"': return literal == Literal.String ? "\\\"" : Char.ToString(ch);
+            case '\'': return literal == Literal.Character ? "\\\'" : Char.ToString(ch);
+
+            case '\\': return "\\\\";
+            case '\0': return "\\0";
+            case '\a': return "\\a";
+            case '\b': return "\\b";
+            case '\f': return "\\f";
+            case '\n': return "\\n";
+            case '\r': return "\\r";
+            case '\t': return "\\t";
+            case '\v': return "\\v";
+
+            case '\u0085': //Next Line
+            case '\u2028': //Line Separator
+            case '\u2029': //Paragraph Separator
+                var digits = (int)ch;
+                return $"\\u{digits:X4}";
+
+            default:
+                return char.ToString(ch);
+        }
+    }
+
+    enum Literal { Character, String }
 }

--- a/src/Fixie/Internal/ClassDiscoverer.cs
+++ b/src/Fixie/Internal/ClassDiscoverer.cs
@@ -1,19 +1,19 @@
-namespace Fixie.Internal
+namespace Fixie.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+class ClassDiscoverer
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Runtime.CompilerServices;
+    readonly IDiscovery discovery;
 
-    class ClassDiscoverer
+    public ClassDiscoverer(IDiscovery discovery)
+        => this.discovery = discovery;
+
+    public IReadOnlyList<Type> TestClasses(IEnumerable<Type> candidates)
     {
-        readonly IDiscovery discovery;
-
-        public ClassDiscoverer(IDiscovery discovery)
-            => this.discovery = discovery;
-
-        public IReadOnlyList<Type> TestClasses(IEnumerable<Type> candidates)
-        {
             try
             {
                 return discovery.TestClasses(candidates.Where(IsApplicable)).ToList();
@@ -26,16 +26,15 @@ namespace Fixie.Internal
             }
         }
 
-        static bool IsApplicable(Type candidate)
-        {
+    static bool IsApplicable(Type candidate)
+    {
             return ConcreteClasses(candidate) &&
                    NonCompilerGeneratedClasses(candidate);
         }
 
-        static bool ConcreteClasses(Type type)
-            => type.IsClass && (!type.IsAbstract || type.IsStatic());
+    static bool ConcreteClasses(Type type)
+        => type.IsClass && (!type.IsAbstract || type.IsStatic());
 
-        static bool NonCompilerGeneratedClasses(Type type)
-            => !type.Has<CompilerGeneratedAttribute>();
-    }
+    static bool NonCompilerGeneratedClasses(Type type)
+        => !type.Has<CompilerGeneratedAttribute>();
 }

--- a/src/Fixie/Internal/ClassDiscoverer.cs
+++ b/src/Fixie/Internal/ClassDiscoverer.cs
@@ -14,23 +14,23 @@ class ClassDiscoverer
 
     public IReadOnlyList<Type> TestClasses(IEnumerable<Type> candidates)
     {
-            try
-            {
-                return discovery.TestClasses(candidates.Where(IsApplicable)).ToList();
-            }
-            catch (Exception exception)
-            {
-                throw new Exception(
-                    "Exception thrown during test class discovery. " +
-                    "Check the inner exception for more details.", exception);
-            }
+        try
+        {
+            return discovery.TestClasses(candidates.Where(IsApplicable)).ToList();
         }
+        catch (Exception exception)
+        {
+            throw new Exception(
+                "Exception thrown during test class discovery. " +
+                "Check the inner exception for more details.", exception);
+        }
+    }
 
     static bool IsApplicable(Type candidate)
     {
-            return ConcreteClasses(candidate) &&
-                   NonCompilerGeneratedClasses(candidate);
-        }
+        return ConcreteClasses(candidate) &&
+               NonCompilerGeneratedClasses(candidate);
+    }
 
     static bool ConcreteClasses(Type type)
         => type.IsClass && (!type.IsAbstract || type.IsStatic());

--- a/src/Fixie/Internal/ConsoleRedirectionBoundary.cs
+++ b/src/Fixie/Internal/ConsoleRedirectionBoundary.cs
@@ -1,16 +1,15 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.IO;
+
+class ConsoleRedirectionBoundary : IDisposable
 {
-    using System;
-    using System.IO;
+    readonly TextWriter original;
 
-    class ConsoleRedirectionBoundary : IDisposable
-    {
-        readonly TextWriter original;
+    public ConsoleRedirectionBoundary() => original = Console.Out;
 
-        public ConsoleRedirectionBoundary() => original = Console.Out;
+    void Revert() => Console.SetOut(original);
 
-        void Revert() => Console.SetOut(original);
-
-        public void Dispose() => Revert();
-    }
+    public void Dispose() => Revert();
 }

--- a/src/Fixie/Internal/Convention.cs
+++ b/src/Fixie/Internal/Convention.cs
@@ -1,14 +1,13 @@
-﻿namespace Fixie.Internal
-{
-    class Convention
-    {
-        public Convention(IDiscovery discovery, IExecution execution)
-        {
-            Discovery = discovery;
-            Execution = execution;
-        }
+﻿namespace Fixie.Internal;
 
-        public IDiscovery Discovery { get; }
-        public IExecution Execution { get; }
+class Convention
+{
+    public Convention(IDiscovery discovery, IExecution execution)
+    {
+        Discovery = discovery;
+        Execution = execution;
     }
+
+    public IDiscovery Discovery { get; }
+    public IExecution Execution { get; }
 }

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -1,136 +1,135 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Reports;
+using static System.Environment;
+using static Maybe;
+
+public class EntryPoint
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.IO.Pipes;
-    using System.Linq;
-    using System.Reflection;
-    using System.Threading.Tasks;
-    using Reports;
-    using static System.Environment;
-    using static Maybe;
-
-    public class EntryPoint
+    enum ExitCode
     {
-        enum ExitCode
-        {
-            Success = 0,
-            Failure = 1,
-            FatalError = 2
-        }
+        Success = 0,
+        Failure = 1,
+        FatalError = 2
+    }
 
-        public static async Task<int> Main(Assembly assembly, string[] customArguments)
-        {
-            var console = Console.Out;
-            var rootPath = Directory.GetCurrentDirectory();
-            var environment = new TestEnvironment(assembly, console, rootPath, customArguments);
+    public static async Task<int> Main(Assembly assembly, string[] customArguments)
+    {
+        var console = Console.Out;
+        var rootPath = Directory.GetCurrentDirectory();
+        var environment = new TestEnvironment(assembly, console, rootPath, customArguments);
 
-            using var boundary = new ConsoleRedirectionBoundary();
+        using var boundary = new ConsoleRedirectionBoundary();
+
+        try
+        {
+            var pipeName = GetEnvironmentVariable("FIXIE_NAMED_PIPE");
+
+            if (pipeName == null)
+            {
+                var reports = DefaultReports(environment).ToArray();
+
+                var pattern = GetEnvironmentVariable("FIXIE_TESTS_PATTERN");
+
+                return pattern == null
+                    ? (int) await Run(environment, reports, async runner => await runner.Run())
+                    : (int) await Run(environment, reports, async runner => await runner.Run(new TestPattern(pattern)));
+            }
+
+            using var pipeStream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut);
+            using var pipe = new TestAdapterPipe(pipeStream);
+
+            pipeStream.Connect();
+            pipeStream.ReadMode = PipeTransmissionMode.Byte;
+                
+            var testAdapterReport = new TestAdapterReport(pipe);
+
+            var exitCode = ExitCode.Success;
 
             try
             {
-                var pipeName = GetEnvironmentVariable("FIXIE_NAMED_PIPE");
+                var messageType = pipe.ReceiveMessageType();
 
-                if (pipeName == null)
+                if (messageType == typeof(PipeMessage.DiscoverTests).FullName)
                 {
-                    var reports = DefaultReports(environment).ToArray();
-
-                    var pattern = GetEnvironmentVariable("FIXIE_TESTS_PATTERN");
-
-                    return pattern == null
-                        ? (int) await Run(environment, reports, async runner => await runner.Run())
-                        : (int) await Run(environment, reports, async runner => await runner.Run(new TestPattern(pattern)));
+                    var discoverTests = pipe.Receive<PipeMessage.DiscoverTests>();
+                    await DiscoverMethods(environment, testAdapterReport);
                 }
-
-                using var pipeStream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut);
-                using var pipe = new TestAdapterPipe(pipeStream);
-
-                pipeStream.Connect();
-                pipeStream.ReadMode = PipeTransmissionMode.Byte;
-                
-                var testAdapterReport = new TestAdapterReport(pipe);
-
-                var exitCode = ExitCode.Success;
-
-                try
+                else if (messageType == typeof(PipeMessage.ExecuteTests).FullName)
                 {
-                    var messageType = pipe.ReceiveMessageType();
+                    var executeTests = pipe.Receive<PipeMessage.ExecuteTests>();
 
-                    if (messageType == typeof(PipeMessage.DiscoverTests).FullName)
-                    {
-                        var discoverTests = pipe.Receive<PipeMessage.DiscoverTests>();
-                        await DiscoverMethods(environment, testAdapterReport);
-                    }
-                    else if (messageType == typeof(PipeMessage.ExecuteTests).FullName)
-                    {
-                        var executeTests = pipe.Receive<PipeMessage.ExecuteTests>();
+                    var reports = new IReport[] { testAdapterReport };
 
-                        var reports = new IReport[] { testAdapterReport };
-
-                        exitCode = executeTests.Filter.Length == 0
-                            ? await Run(environment, reports, async runner => await runner.Run())
-                            : await Run(environment, reports, async runner => await runner.Run(new HashSet<string>(executeTests.Filter)));
-                    }
-                    else
-                    {
-                        var body = pipe.ReceiveMessageBody();
-                        throw new Exception($"Test assembly received unexpected message of type {messageType}: {body}");
-                    }
+                    exitCode = executeTests.Filter.Length == 0
+                        ? await Run(environment, reports, async runner => await runner.Run())
+                        : await Run(environment, reports, async runner => await runner.Run(new HashSet<string>(executeTests.Filter)));
                 }
-                catch (Exception exception)
+                else
                 {
-                    pipe.Send(exception);
+                    var body = pipe.ReceiveMessageBody();
+                    throw new Exception($"Test assembly received unexpected message of type {messageType}: {body}");
                 }
-                finally
-                {
-                    pipe.Send<PipeMessage.EndOfPipe>();
-                }
-
-                return (int)exitCode;
             }
             catch (Exception exception)
             {
-                using (Foreground.Red)
-                    console.WriteLine($"Fatal Error: {exception}");
-
-                return (int)ExitCode.FatalError;
+                pipe.Send(exception);
             }
-        }
+            finally
+            {
+                pipe.Send<PipeMessage.EndOfPipe>();
+            }
 
-        static async Task DiscoverMethods(TestEnvironment environment, TestAdapterReport testAdapterReport)
-        {
-            var runner = new Runner(environment, testAdapterReport);
-            await runner.Discover();
+            return (int)exitCode;
         }
-
-        static async Task<ExitCode> Run(TestEnvironment environment, IReport[] reports, Func<Runner, Task<ExecutionSummary>> run)
+        catch (Exception exception)
         {
-            var runner = new Runner(environment, reports);
+            using (Foreground.Red)
+                console.WriteLine($"Fatal Error: {exception}");
+
+            return (int)ExitCode.FatalError;
+        }
+    }
+
+    static async Task DiscoverMethods(TestEnvironment environment, TestAdapterReport testAdapterReport)
+    {
+        var runner = new Runner(environment, testAdapterReport);
+        await runner.Discover();
+    }
+
+    static async Task<ExitCode> Run(TestEnvironment environment, IReport[] reports, Func<Runner, Task<ExecutionSummary>> run)
+    {
+        var runner = new Runner(environment, reports);
             
-            var summary = await run(runner);
+        var summary = await run(runner);
 
-            if (summary.Total == 0)
-                return ExitCode.Failure;
+        if (summary.Total == 0)
+            return ExitCode.Failure;
 
-            if (summary.Failed > 0)
-                return ExitCode.Failure;
+        if (summary.Failed > 0)
+            return ExitCode.Failure;
 
-            return ExitCode.Success;
-        }
+        return ExitCode.Success;
+    }
 
-        static IEnumerable<IReport> DefaultReports(TestEnvironment environment)
-        {
-            if (Try(AzureReport.Create, environment, out var azure))
-                yield return azure;
+    static IEnumerable<IReport> DefaultReports(TestEnvironment environment)
+    {
+        if (Try(AzureReport.Create, environment, out var azure))
+            yield return azure;
 
-            if (Try(AppVeyorReport.Create, environment, out var appVeyor))
-                yield return appVeyor;
+        if (Try(AppVeyorReport.Create, environment, out var appVeyor))
+            yield return appVeyor;
 
-            if (Try(TeamCityReport.Create, environment, out var teamCity))
-                yield return teamCity;
+        if (Try(TeamCityReport.Create, environment, out var teamCity))
+            yield return teamCity;
 
-            yield return ConsoleReport.Create(environment);
-        }
+        yield return ConsoleReport.Create(environment);
     }
 }

--- a/src/Fixie/Internal/ExecutionRecorder.cs
+++ b/src/Fixie/Internal/ExecutionRecorder.cs
@@ -1,92 +1,91 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Reports;
+
+class ExecutionRecorder
 {
-    using System;
-    using System.Diagnostics;
-    using System.Threading.Tasks;
-    using Reports;
+    readonly RecordingWriter recordingConsole;
+    readonly Bus bus;
 
-    class ExecutionRecorder
+    readonly ExecutionSummary assemblySummary;
+    readonly Stopwatch assemblyStopwatch;
+    readonly Stopwatch caseStopwatch;
+
+    public ExecutionRecorder(RecordingWriter recordingConsole, Bus bus)
     {
-        readonly RecordingWriter recordingConsole;
-        readonly Bus bus;
+        this.recordingConsole = recordingConsole;
+        this.bus = bus;
 
-        readonly ExecutionSummary assemblySummary;
-        readonly Stopwatch assemblyStopwatch;
-        readonly Stopwatch caseStopwatch;
+        assemblySummary = new ExecutionSummary();
 
-        public ExecutionRecorder(RecordingWriter recordingConsole, Bus bus)
-        {
-            this.recordingConsole = recordingConsole;
-            this.bus = bus;
+        assemblyStopwatch = new Stopwatch();
+        caseStopwatch = new Stopwatch();
+    }
 
-            assemblySummary = new ExecutionSummary();
+    public async Task StartExecution()
+    {
+        await bus.Publish(new ExecutionStarted());
+        assemblyStopwatch.Restart();
+        caseStopwatch.Restart();
+        recordingConsole.StartRecording();
+    }
 
-            assemblyStopwatch = new Stopwatch();
-            caseStopwatch = new Stopwatch();
-        }
+    public async Task Start(Test test)
+    {
+        await bus.Publish(new TestStarted(test));
+    }
 
-        public async Task StartExecution()
-        {
-            await bus.Publish(new ExecutionStarted());
-            assemblyStopwatch.Restart();
-            caseStopwatch.Restart();
-            recordingConsole.StartRecording();
-        }
+    public async Task Skip(Test test, string name, string reason)
+    {
+        var duration = caseStopwatch.Elapsed;
+        recordingConsole.StopRecording(out var output);
 
-        public async Task Start(Test test)
-        {
-            await bus.Publish(new TestStarted(test));
-        }
+        var message = new TestSkipped(test.Name, name, duration, output, reason);
+        assemblySummary.Add(message);
+        await bus.Publish(message);
 
-        public async Task Skip(Test test, string name, string reason)
-        {
-            var duration = caseStopwatch.Elapsed;
-            recordingConsole.StopRecording(out var output);
+        caseStopwatch.Restart();
+        recordingConsole.StartRecording();
+    }
 
-            var message = new TestSkipped(test.Name, name, duration, output, reason);
-            assemblySummary.Add(message);
-            await bus.Publish(message);
+    public async Task Pass(Test test, string name)
+    {
+        var duration = caseStopwatch.Elapsed;
+        recordingConsole.StopRecording(out var output);
 
-            caseStopwatch.Restart();
-            recordingConsole.StartRecording();
-        }
+        var message = new TestPassed(test.Name, name, duration, output);
+        assemblySummary.Add(message);
+        await bus.Publish(message);
 
-        public async Task Pass(Test test, string name)
-        {
-            var duration = caseStopwatch.Elapsed;
-            recordingConsole.StopRecording(out var output);
+        caseStopwatch.Restart();
+        recordingConsole.StartRecording();
+    }
 
-            var message = new TestPassed(test.Name, name, duration, output);
-            assemblySummary.Add(message);
-            await bus.Publish(message);
+    public async Task Fail(Test test, string name, Exception reason)
+    {
+        var duration = caseStopwatch.Elapsed;
+        recordingConsole.StopRecording(out var output);
 
-            caseStopwatch.Restart();
-            recordingConsole.StartRecording();
-        }
+        var message = new TestFailed(test.Name, name, duration, output, reason);
+        assemblySummary.Add(message);
+        await bus.Publish(message);
 
-        public async Task Fail(Test test, string name, Exception reason)
-        {
-            var duration = caseStopwatch.Elapsed;
-            recordingConsole.StopRecording(out var output);
+        caseStopwatch.Restart();
+        recordingConsole.StartRecording();
+    }
 
-            var message = new TestFailed(test.Name, name, duration, output, reason);
-            assemblySummary.Add(message);
-            await bus.Publish(message);
+    public async Task<ExecutionSummary> CompleteExecution()
+    {
+        var duration = assemblyStopwatch.Elapsed;
+        recordingConsole.StopRecording();
+        caseStopwatch.Stop();
+        assemblyStopwatch.Stop();
 
-            caseStopwatch.Restart();
-            recordingConsole.StartRecording();
-        }
+        await bus.Publish(new ExecutionCompleted(assemblySummary, duration));
 
-        public async Task<ExecutionSummary> CompleteExecution()
-        {
-            var duration = assemblyStopwatch.Elapsed;
-            recordingConsole.StopRecording();
-            caseStopwatch.Stop();
-            assemblyStopwatch.Stop();
-
-            await bus.Publish(new ExecutionCompleted(assemblySummary, duration));
-
-            return assemblySummary;
-        }
+        return assemblySummary;
     }
 }

--- a/src/Fixie/Internal/ExecutionSummary.cs
+++ b/src/Fixie/Internal/ExecutionSummary.cs
@@ -1,23 +1,22 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using Reports;
+
+class ExecutionSummary
 {
-    using Reports;
-
-    class ExecutionSummary
+    public ExecutionSummary()
     {
-        public ExecutionSummary()
-        {
-            Passed = 0;
-            Failed = 0;
-            Skipped = 0;
-        }
-
-        public int Passed { get; private set; }
-        public int Failed { get; private set; }
-        public int Skipped { get; private set; }
-        public int Total => Passed + Failed + Skipped;
-
-        public void Add(TestSkipped message) => Skipped += 1;
-        public void Add(TestPassed message) => Passed += 1;
-        public void Add(TestFailed message) => Failed += 1;
+        Passed = 0;
+        Failed = 0;
+        Skipped = 0;
     }
+
+    public int Passed { get; private set; }
+    public int Failed { get; private set; }
+    public int Skipped { get; private set; }
+    public int Total => Passed + Failed + Skipped;
+
+    public void Add(TestSkipped message) => Skipped += 1;
+    public void Add(TestPassed message) => Passed += 1;
+    public void Add(TestFailed message) => Failed += 1;
 }

--- a/src/Fixie/Internal/Foreground.cs
+++ b/src/Fixie/Internal/Foreground.cs
@@ -1,23 +1,22 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+
+class Foreground : IDisposable
 {
-    using System;
+    readonly ConsoleColor before;
 
-    class Foreground : IDisposable
+    public Foreground(ConsoleColor color)
     {
-        readonly ConsoleColor before;
-
-        public Foreground(ConsoleColor color)
-        {
-            before = Console.ForegroundColor;
-            Console.ForegroundColor = color;
-        }
-
-        public void Dispose() => Console.ForegroundColor = before;
-
-        public static Foreground Red => new Foreground(ConsoleColor.Red);
-
-        public static Foreground Yellow => new Foreground(ConsoleColor.Yellow);
-
-        public static Foreground Green => new Foreground(ConsoleColor.Green);
+        before = Console.ForegroundColor;
+        Console.ForegroundColor = color;
     }
+
+    public void Dispose() => Console.ForegroundColor = before;
+
+    public static Foreground Red => new Foreground(ConsoleColor.Red);
+
+    public static Foreground Yellow => new Foreground(ConsoleColor.Yellow);
+
+    public static Foreground Green => new Foreground(ConsoleColor.Green);
 }

--- a/src/Fixie/Internal/Framework.cs
+++ b/src/Fixie/Internal/Framework.cs
@@ -1,16 +1,15 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System.Reflection;
+
+static class Framework
 {
-    using System.Reflection;
+    public static string Version
+        => "Fixie " + ProductVersion();
 
-    static class Framework
-    {
-        public static string Version
-            => "Fixie " + ProductVersion();
-
-        static string ProductVersion()
-            => typeof(Framework)
-                .Assembly
-                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
-                .InformationalVersion;
-    }
+    static string ProductVersion()
+        => typeof(Framework)
+            .Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+            .InformationalVersion;
 }

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -1,176 +1,175 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+
+static class GenericArgumentResolver
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
-    using System.Reflection;
-
-    static class GenericArgumentResolver
+    public static MethodInfo TryResolveTypeArguments(this MethodInfo caseMethod, object?[] arguments)
     {
-        public static MethodInfo TryResolveTypeArguments(this MethodInfo caseMethod, object?[] arguments)
+        if (!caseMethod.IsGenericMethodDefinition)
+            return caseMethod;
+
+        if (!TryResolveTypeArguments(caseMethod, arguments, out var resolvedTypeParameters))
+            return caseMethod;
+
+        try
         {
-            if (!caseMethod.IsGenericMethodDefinition)
-                return caseMethod;
+            return caseMethod.MakeGenericMethod(resolvedTypeParameters);
+        }
+        catch (Exception)
+        {
+            // Allow MethodInfo.Invoke(...) to provide a more useful error message.
+            return caseMethod;
+        }
+    }
 
-            if (!TryResolveTypeArguments(caseMethod, arguments, out var resolvedTypeParameters))
-                return caseMethod;
+    static bool TryResolveTypeArguments(MethodInfo method, object?[] arguments, [NotNullWhen(true)] out Type[]? resolvedTypeParameters)
+    {
+        var genericArguments = method.GetGenericArguments();
+        var parameterTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
 
-            try
-            {
-                return caseMethod.MakeGenericMethod(resolvedTypeParameters);
-            }
-            catch (Exception)
-            {
-                // Allow MethodInfo.Invoke(...) to provide a more useful error message.
-                return caseMethod;
-            }
+        if (parameterTypes.Length > arguments.Length)
+        {
+            resolvedTypeParameters = null;
+            return false;
         }
 
-        static bool TryResolveTypeArguments(MethodInfo method, object?[] arguments, [NotNullWhen(true)] out Type[]? resolvedTypeParameters)
+        if (parameterTypes.Length < arguments.Length)
         {
-            var genericArguments = method.GetGenericArguments();
-            var parameterTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
+            // Proceed with type argument resolution as if the excess arguments were not provided,
+            // allowing as much resolution as possible while still allowing the "Parameter count mismatch"
+            // failure to arise at invocation time.
 
-            if (parameterTypes.Length > arguments.Length)
+            arguments = arguments.Take(parameterTypes.Length).ToArray();
+        }
+
+        var genericToSpecific = new Dictionary<Type, Type>();
+
+        for (int i = 0; i < parameterTypes.Length; i++)
+        {
+            var argument = arguments[i];
+            var parameterType = parameterTypes[i];
+
+            // The null value has no type, so it
+            // provides no new type mappings.
+            if (argument == null)
+                continue;
+
+            TraverseTypes(genericToSpecific, parameterType, argument.GetType());
+        }
+
+        var results = new List<Type>();
+        foreach (var genericArgument in genericArguments)
+        {
+            if (genericToSpecific.TryGetValue(genericArgument, out var specificType))
+            {
+                results.Add(specificType);
+            }
+            else
             {
                 resolvedTypeParameters = null;
                 return false;
             }
-
-            if (parameterTypes.Length < arguments.Length)
-            {
-                // Proceed with type argument resolution as if the excess arguments were not provided,
-                // allowing as much resolution as possible while still allowing the "Parameter count mismatch"
-                // failure to arise at invocation time.
-
-                arguments = arguments.Take(parameterTypes.Length).ToArray();
-            }
-
-            var genericToSpecific = new Dictionary<Type, Type>();
-
-            for (int i = 0; i < parameterTypes.Length; i++)
-            {
-                var argument = arguments[i];
-                var parameterType = parameterTypes[i];
-
-                // The null value has no type, so it
-                // provides no new type mappings.
-                if (argument == null)
-                    continue;
-
-                TraverseTypes(genericToSpecific, parameterType, argument.GetType());
-            }
-
-            var results = new List<Type>();
-            foreach (var genericArgument in genericArguments)
-            {
-                if (genericToSpecific.TryGetValue(genericArgument, out var specificType))
-                {
-                    results.Add(specificType);
-                }
-                else
-                {
-                    resolvedTypeParameters = null;
-                    return false;
-                }
-            }
-
-            resolvedTypeParameters = results.ToArray();
-            return true;
         }
 
-        static void TraverseTypes(Dictionary<Type, Type> genericToSpecific, Type parameterType, Type argumentType)
+        resolvedTypeParameters = results.ToArray();
+        return true;
+    }
+
+    static void TraverseTypes(Dictionary<Type, Type> genericToSpecific, Type parameterType, Type argumentType)
+    {
+        if (parameterType.IsGenericParameter)
         {
-            if (parameterType.IsGenericParameter)
+            // A type mapping has been detected:
+            //   Parameter: T, Argument: Dictionary<int, string>
+
+            var genericTypeParameterHasAlreadyBeenFixed = genericToSpecific.ContainsKey(parameterType);
+
+            // The first mapping wins. Subsequent ambiguity will be detected by MethodInfo.Invoke(...).
+            if (genericTypeParameterHasAlreadyBeenFixed)
+                return;
+
+            genericToSpecific[parameterType] = argumentType;
+            return;
+        }
+
+        // Array item types may provide new type mappings:
+        //   Parameter: T[], Argument: int[]
+        if (parameterType.IsArray && argumentType.IsArray)
+        {
+            var parameterElementType = parameterType.GetElementType();
+            var argumentElementType = argumentType.GetElementType();
+
+            if (parameterElementType != null && argumentElementType != null)
             {
-                // A type mapping has been detected:
-                //   Parameter: T, Argument: Dictionary<int, string>
-
-                var genericTypeParameterHasAlreadyBeenFixed = genericToSpecific.ContainsKey(parameterType);
-
-                // The first mapping wins. Subsequent ambiguity will be detected by MethodInfo.Invoke(...).
-                if (genericTypeParameterHasAlreadyBeenFixed)
-                    return;
-
-                genericToSpecific[parameterType] = argumentType;
+                TraverseTypes(genericToSpecific, parameterElementType, argumentElementType);
                 return;
             }
+        }
 
-            // Array item types may provide new type mappings:
-            //   Parameter: T[], Argument: int[]
-            if (parameterType.IsArray && argumentType.IsArray)
+        // Nullable<T> is a generic type with the unusual property that it can provide a type mapping
+        // when the argument is a non-generic value type. For example, Nullable<T> can receive an int,
+        // giving us a mapping from T to int.
+        //
+        // We cannot simply check for `parameterType == typeof(Nullable<>)`, though, because an unresolved
+        // nullable parameter type would be some generic Nullable<T1> or Nullable<T2> or... Though not yet
+        // resolved, that IS NOT equal to the more general Nullable<> generic type definition.
+        //
+        // The reflection API makes this distinction because the compiler must as well. Consider a generic
+        // method that accepts 2 arguments, `Nullable<T>` and `Nullable<U>`: these must be assumed to be
+        // different types even though they have not been fully resolved yet. The compiler must distinguish
+        // them, and we must likewise avoid conflating them in the genericToSpecific type mapping.
+        //
+        // Instead, we check whether we are dealing with *any* unresolved generic whose generic type
+        // definition is typeof(Nullable<>).
+        if (parameterType.IsGenericType &&
+            parameterType.GetGenericTypeDefinition() == typeof(Nullable<>) &&
+            parameterType.ContainsGenericParameters)
+        {
+            if (!argumentType.IsGenericType && argumentType.IsValueType)
             {
-                var parameterElementType = parameterType.GetElementType();
-                var argumentElementType = argumentType.GetElementType();
-
-                if (parameterElementType != null && argumentElementType != null)
-                {
-                    TraverseTypes(genericToSpecific, parameterElementType, argumentElementType);
-                    return;
-                }
-            }
-
-            // Nullable<T> is a generic type with the unusual property that it can provide a type mapping
-            // when the argument is a non-generic value type. For example, Nullable<T> can receive an int,
-            // giving us a mapping from T to int.
-            //
-            // We cannot simply check for `parameterType == typeof(Nullable<>)`, though, because an unresolved
-            // nullable parameter type would be some generic Nullable<T1> or Nullable<T2> or... Though not yet
-            // resolved, that IS NOT equal to the more general Nullable<> generic type definition.
-            //
-            // The reflection API makes this distinction because the compiler must as well. Consider a generic
-            // method that accepts 2 arguments, `Nullable<T>` and `Nullable<U>`: these must be assumed to be
-            // different types even though they have not been fully resolved yet. The compiler must distinguish
-            // them, and we must likewise avoid conflating them in the genericToSpecific type mapping.
-            //
-            // Instead, we check whether we are dealing with *any* unresolved generic whose generic type
-            // definition is typeof(Nullable<>).
-            if (parameterType.IsGenericType &&
-                parameterType.GetGenericTypeDefinition() == typeof(Nullable<>) &&
-                parameterType.ContainsGenericParameters)
-            {
-                if (!argumentType.IsGenericType && argumentType.IsValueType)
-                {
-                    var genericTypeParameter = parameterType.GetGenericArguments().Single();
+                var genericTypeParameter = parameterType.GetGenericArguments().Single();
                     
-                    TraverseTypes(genericToSpecific, genericTypeParameter, argumentType);
-                    return;
-                }
+                TraverseTypes(genericToSpecific, genericTypeParameter, argumentType);
+                return;
             }
+        }
 
-            // With Nullable<T> handled, any remaining non-generics provide no new type mappings:
-            //   Parameter: int, Argument: bool
-            //   Parameter: List<int>, Argument: bool
-            //   Parameter: int, Argument: List<bool>
-            if (!parameterType.IsGenericType || !argumentType.IsGenericType)
-                return;
+        // With Nullable<T> handled, any remaining non-generics provide no new type mappings:
+        //   Parameter: int, Argument: bool
+        //   Parameter: List<int>, Argument: bool
+        //   Parameter: int, Argument: List<bool>
+        if (!parameterType.IsGenericType || !argumentType.IsGenericType)
+            return;
 
-            // A perfect match provides no new type mappings:
-            //   Parameter: Dictionary<int, bool>, Argument: Dictionary<int, bool>
-            //   Parameter: Dictionary<T, bool>, Argument: Dictionary<T, bool>
-            if (parameterType == argumentType)
-                return;
+        // A perfect match provides no new type mappings:
+        //   Parameter: Dictionary<int, bool>, Argument: Dictionary<int, bool>
+        //   Parameter: Dictionary<T, bool>, Argument: Dictionary<T, bool>
+        if (parameterType == argumentType)
+            return;
 
-            var parameterGenericTypeDefinition = parameterType.GetGenericTypeDefinition();
-            var argumentGenericTypeDefinition = argumentType.GetGenericTypeDefinition();
+        var parameterGenericTypeDefinition = parameterType.GetGenericTypeDefinition();
+        var argumentGenericTypeDefinition = argumentType.GetGenericTypeDefinition();
 
-            // A complete mismatch provides no new type mappings:
-            //   Parameter: Nullable<T>, Argument: Dictionary<int, bool>
-            if (parameterGenericTypeDefinition != argumentGenericTypeDefinition)
-                return;
+        // A complete mismatch provides no new type mappings:
+        //   Parameter: Nullable<T>, Argument: Dictionary<int, bool>
+        if (parameterGenericTypeDefinition != argumentGenericTypeDefinition)
+            return;
 
-            // The generic types are compatible and may provide more type mappings:
-            //   Parameter: Dictionary<T1, List<T2>>, Argument: Dictionary<int, List<bool>>
-            var parameterTypeGenericArguments = parameterType.GetGenericArguments(); // [T1, List<T2>]
-            var argumentTypeGenericArguments = argumentType.GetGenericArguments(); // [int, List<bool>]
+        // The generic types are compatible and may provide more type mappings:
+        //   Parameter: Dictionary<T1, List<T2>>, Argument: Dictionary<int, List<bool>>
+        var parameterTypeGenericArguments = parameterType.GetGenericArguments(); // [T1, List<T2>]
+        var argumentTypeGenericArguments = argumentType.GetGenericArguments(); // [int, List<bool>]
 
-            for (int i = 0; i < parameterTypeGenericArguments.Length; i++)
-            {
-                TraverseTypes(genericToSpecific,
-                    parameterTypeGenericArguments[i],
-                    argumentTypeGenericArguments[i]);
-            }
+        for (int i = 0; i < parameterTypeGenericArguments.Length; i++)
+        {
+            TraverseTypes(genericToSpecific,
+                parameterTypeGenericArguments[i],
+                argumentTypeGenericArguments[i]);
         }
     }
 }

--- a/src/Fixie/Internal/Maybe.cs
+++ b/src/Fixie/Internal/Maybe.cs
@@ -1,29 +1,28 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+static class Maybe
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-
-    static class Maybe
+    public static bool Try<T>(Func<T> create, [NotNullWhen(true)] out T output)
     {
-        public static bool Try<T>(Func<T> create, [NotNullWhen(true)] out T output)
-        {
-            output = create();
+        output = create();
 
-            return output != null;
-        }
+        return output != null;
+    }
 
-        public static bool Try<TInput, TOutput>(Func<TInput, TOutput> create, TInput input, [NotNullWhen(true)] out TOutput output)
-        {
-            output = create(input);
+    public static bool Try<TInput, TOutput>(Func<TInput, TOutput> create, TInput input, [NotNullWhen(true)] out TOutput output)
+    {
+        output = create(input);
 
-            return output != null;
-        }
+        return output != null;
+    }
         
-        public static bool Try<TInput1, TInput2, TOutput>(Func<TInput1, TInput2, TOutput> create, TInput1 input1, TInput2 input2, [NotNullWhen(true)] out TOutput output)
-        {
-            output = create(input1, input2);
+    public static bool Try<TInput1, TInput2, TOutput>(Func<TInput1, TInput2, TOutput> create, TInput1 input1, TInput2 input2, [NotNullWhen(true)] out TOutput output)
+    {
+        output = create(input1, input2);
 
-            return output != null;
-        }
+        return output != null;
     }
 }

--- a/src/Fixie/Internal/MethodDiscoverer.cs
+++ b/src/Fixie/Internal/MethodDiscoverer.cs
@@ -1,33 +1,32 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+class MethodDiscoverer
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
+    readonly IDiscovery discovery;
 
-    class MethodDiscoverer
+    public MethodDiscoverer(IDiscovery discovery)
+        => this.discovery = discovery;
+
+    public IReadOnlyList<MethodInfo> TestMethods(Type testClass)
     {
-        readonly IDiscovery discovery;
-
-        public MethodDiscoverer(IDiscovery discovery)
-            => this.discovery = discovery;
-
-        public IReadOnlyList<MethodInfo> TestMethods(Type testClass)
+        try
         {
-            try
-            {
-                return discovery.TestMethods(
-                        testClass
-                            .GetMethods()
-                            .Where(method => method.DeclaringType != typeof(object)))
-                    .ToList();
-            }
-            catch (Exception exception)
-            {
-                throw new Exception(
-                    "Exception thrown during test method discovery. " +
-                    "Check the inner exception for more details.", exception);
-            }
+            return discovery.TestMethods(
+                    testClass
+                        .GetMethods()
+                        .Where(method => method.DeclaringType != typeof(object)))
+                .ToList();
+        }
+        catch (Exception exception)
+        {
+            throw new Exception(
+                "Exception thrown during test method discovery. " +
+                "Check the inner exception for more details.", exception);
         }
     }
 }

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -1,72 +1,71 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using Reports;
+
+/*
+ * Nullability hints here are informed by usages. Although these types are serialized and deserialized
+ * to and from JSON, and in theory could be null upon deserialization, we can trace all real
+ * deserialization from corresponding serialization where no nulls are in play.
+ */
+
+static class PipeMessage
 {
-    using Reports;
+    public class DiscoverTests { }
 
-    /*
-     * Nullability hints here are informed by usages. Although these types are serialized and deserialized
-     * to and from JSON, and in theory could be null upon deserialization, we can trace all real
-     * deserialization from corresponding serialization where no nulls are in play.
-     */
-
-    static class PipeMessage
+    public class ExecuteTests
     {
-        public class DiscoverTests { }
-
-        public class ExecuteTests
-        {
-            public string[] Filter { get; set; } = default!;
-        }
-
-        public class TestDiscovered
-        {
-            public string Test { get; set; } = default!;
-        }
-
-        public class TestStarted
-        {
-            public string Test { get; set; } = default!;
-        }
-
-        public abstract class TestCompleted
-        {
-            public string Test { get; set; } = default!;
-            public string TestCase { get; set; } = default!;
-            public double DurationInMilliseconds { get; set; }
-            public string Output { get; set; } = default!;
-        }
-
-        public class TestSkipped : TestCompleted
-        {
-            public string Reason { get; set; } = default!;
-        }
-
-        public class TestPassed : TestCompleted
-        {
-        }
-
-        public class TestFailed : TestCompleted
-        {
-            public Exception Reason { get; set; } = default!;
-        }
-
-        public class Exception
-        {
-            public Exception()
-            {
-            }
-
-            public Exception(System.Exception exception)
-            {
-                Type = exception.GetType().FullName!;
-                Message = exception.Message;
-                StackTrace = exception.StackTraceSummary();
-            }
-
-            public string Type { get; set; } = default!;
-            public string Message { get; set; } = default!;
-            public string StackTrace { get; set; } = default!;
-        }
-
-        public class EndOfPipe { }
+        public string[] Filter { get; set; } = default!;
     }
+
+    public class TestDiscovered
+    {
+        public string Test { get; set; } = default!;
+    }
+
+    public class TestStarted
+    {
+        public string Test { get; set; } = default!;
+    }
+
+    public abstract class TestCompleted
+    {
+        public string Test { get; set; } = default!;
+        public string TestCase { get; set; } = default!;
+        public double DurationInMilliseconds { get; set; }
+        public string Output { get; set; } = default!;
+    }
+
+    public class TestSkipped : TestCompleted
+    {
+        public string Reason { get; set; } = default!;
+    }
+
+    public class TestPassed : TestCompleted
+    {
+    }
+
+    public class TestFailed : TestCompleted
+    {
+        public Exception Reason { get; set; } = default!;
+    }
+
+    public class Exception
+    {
+        public Exception()
+        {
+        }
+
+        public Exception(System.Exception exception)
+        {
+            Type = exception.GetType().FullName!;
+            Message = exception.Message;
+            StackTrace = exception.StackTraceSummary();
+        }
+
+        public string Type { get; set; } = default!;
+        public string Message { get; set; } = default!;
+        public string StackTrace { get; set; } = default!;
+    }
+
+    public class EndOfPipe { }
 }

--- a/src/Fixie/Internal/RecordingWriter.cs
+++ b/src/Fixie/Internal/RecordingWriter.cs
@@ -1,117 +1,116 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+
+sealed class RecordingWriter : TextWriter
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using System.IO;
-    using System.Text;
+    bool recording;
+    readonly TextWriter original;
+    readonly StringWriter copy;
 
-    sealed class RecordingWriter : TextWriter
+    public RecordingWriter(TextWriter original)
     {
-        bool recording;
-        readonly TextWriter original;
-        readonly StringWriter copy;
+        this.original = original;
 
-        public RecordingWriter(TextWriter original)
+        copy = new StringWriter(original.FormatProvider)
         {
-            this.original = original;
+            NewLine = original.NewLine
+        };
 
-            copy = new StringWriter(original.FormatProvider)
-            {
-                NewLine = original.NewLine
-            };
+        recording = false;
+    }
 
-            recording = false;
+    public void StartRecording()
+    {
+        recording = true;
+    }
+
+    public void StopRecording()
+    {
+        recording = false;
+        copy.GetStringBuilder().Clear();
+    }
+
+    public void StopRecording(out string recordedOutput)
+    {
+        recordedOutput = copy.ToString();
+        StopRecording();
+    }
+
+    public override IFormatProvider FormatProvider => original.FormatProvider;
+
+    public override Encoding Encoding => original.Encoding;
+
+    [AllowNull]
+    public override string NewLine
+    {
+        get => original.NewLine;
+        set
+        {
+            original.NewLine = value;
+            copy.NewLine = value;
+        }
+    }
+
+    public override void Write(char value)
+    {
+        original.Write(value);
+        if (recording) copy.Write(value);
+    }
+
+    public override void Write(char[]? buffer)
+    {
+        original.Write(buffer);
+        if (recording) copy.Write(buffer);
+    }
+
+    public override void Write(char[] buffer, int index, int count)
+    {
+        original.Write(buffer, index, count);
+        if (recording) copy.Write(buffer, index, count);
+    }
+
+    public override void Write(ReadOnlySpan<char> buffer)
+    {
+        original.Write(buffer);
+        if (recording) copy.Write(buffer);
+    }
+
+    public override void Write(string? value)
+    {
+        original.Write(value);
+        if (recording) copy.Write(value);
+    }
+
+    public override void Flush()
+    {
+        original.Flush();
+        copy.Flush();
+    }
+
+    public override void Close()
+    {
+        original.Close();
+        copy.Close();
+    }
+
+    bool disposed;
+    protected override void Dispose(bool disposing)
+    {
+        if (disposed)
+            return;
+
+        if (disposing)
+        {
+            original.Dispose();
+            copy.Dispose();
         }
 
-        public void StartRecording()
-        {
-            recording = true;
-        }
+        disposed = true;
 
-        public void StopRecording()
-        {
-            recording = false;
-            copy.GetStringBuilder().Clear();
-        }
-
-        public void StopRecording(out string recordedOutput)
-        {
-            recordedOutput = copy.ToString();
-            StopRecording();
-        }
-
-        public override IFormatProvider FormatProvider => original.FormatProvider;
-
-        public override Encoding Encoding => original.Encoding;
-
-        [AllowNull]
-        public override string NewLine
-        {
-            get => original.NewLine;
-            set
-            {
-                original.NewLine = value;
-                copy.NewLine = value;
-            }
-        }
-
-        public override void Write(char value)
-        {
-            original.Write(value);
-            if (recording) copy.Write(value);
-        }
-
-        public override void Write(char[]? buffer)
-        {
-            original.Write(buffer);
-            if (recording) copy.Write(buffer);
-        }
-
-        public override void Write(char[] buffer, int index, int count)
-        {
-            original.Write(buffer, index, count);
-            if (recording) copy.Write(buffer, index, count);
-        }
-
-        public override void Write(ReadOnlySpan<char> buffer)
-        {
-            original.Write(buffer);
-            if (recording) copy.Write(buffer);
-        }
-
-        public override void Write(string? value)
-        {
-            original.Write(value);
-            if (recording) copy.Write(value);
-        }
-
-        public override void Flush()
-        {
-            original.Flush();
-            copy.Flush();
-        }
-
-        public override void Close()
-        {
-            original.Close();
-            copy.Close();
-        }
-
-        bool disposed;
-        protected override void Dispose(bool disposing)
-        {
-            if (disposed)
-                return;
-
-            if (disposing)
-            {
-                original.Dispose();
-                copy.Dispose();
-            }
-
-            disposed = true;
-
-            base.Dispose(disposing);
-        }
+        base.Dispose(disposing);
     }
 }

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -1,84 +1,83 @@
-﻿namespace Fixie.Internal
+﻿namespace Fixie.Internal;
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using static System.Text.Json.JsonSerializer;
+
+class TestAdapterPipe : IDisposable
 {
-    using System;
-    using System.IO;
-    using System.IO.Pipes;
-    using System.Text;
-    using static System.Text.Json.JsonSerializer;
+    readonly StreamReader reader;
+    readonly StreamWriter writer;
 
-    class TestAdapterPipe : IDisposable
+    public TestAdapterPipe(PipeStream pipeStream)
     {
-        readonly StreamReader reader;
-        readonly StreamWriter writer;
+        // Normal attempts to call dispose on this reader
+        // and writer cause the underlying PipeStream to
+        // throw ObjectDisposedException when the original
+        // PipeStream's 'using' block ends. Here we allow
+        // the reader and writer to be disposed of, ignoring
+        // the PipeStream itself by leaving that open.
+        // Then, the original using block for the PipeStream
+        // is trusted to own that cleanup.
 
-        public TestAdapterPipe(PipeStream pipeStream)
+        reader = new StreamReader(pipeStream, leaveOpen: true);
+        writer = new StreamWriter(pipeStream, leaveOpen: true);
+    }
+
+    const string EndOfMessage = "--End of Message--";
+
+    public string? ReceiveMessageType()
+    {
+        return reader.ReadLine();
+    }
+
+    public TMessage Receive<TMessage>()
+    {
+        return Deserialize<TMessage>(ReceiveMessageBody())!;
+    }
+
+    public string ReceiveMessageBody()
+    {
+        var lines = new StringBuilder();
+
+        while (true)
         {
-            // Normal attempts to call dispose on this reader
-            // and writer cause the underlying PipeStream to
-            // throw ObjectDisposedException when the original
-            // PipeStream's 'using' block ends. Here we allow
-            // the reader and writer to be disposed of, ignoring
-            // the PipeStream itself by leaving that open.
-            // Then, the original using block for the PipeStream
-            // is trusted to own that cleanup.
+            var line = reader.ReadLine();
 
-            reader = new StreamReader(pipeStream, leaveOpen: true);
-            writer = new StreamWriter(pipeStream, leaveOpen: true);
+            if (line == null || line == EndOfMessage)
+                break;
+
+            lines.AppendLine(line);
         }
 
-        const string EndOfMessage = "--End of Message--";
+        return lines.ToString();
+    }
 
-        public string? ReceiveMessageType()
-        {
-            return reader.ReadLine();
-        }
+    public void Send<TMessage>() where TMessage: new()
+    {
+        Send(new TMessage());
+    }
 
-        public TMessage Receive<TMessage>()
-        {
-            return Deserialize<TMessage>(ReceiveMessageBody())!;
-        }
+    public void Send(Exception exception)
+    {
+        Send(new PipeMessage.Exception(exception));
+    }
 
-        public string ReceiveMessageBody()
-        {
-            var lines = new StringBuilder();
+    public void Send<TMessage>(TMessage message)
+    {
+        var messageType = typeof(TMessage).FullName!;
 
-            while (true)
-            {
-                var line = reader.ReadLine();
+        writer.WriteLine(messageType);
+        writer.WriteLine(Serialize(message));
+        writer.WriteLine(EndOfMessage);
+        writer.Flush();
+    }
 
-                if (line == null || line == EndOfMessage)
-                    break;
-
-                lines.AppendLine(line);
-            }
-
-            return lines.ToString();
-        }
-
-        public void Send<TMessage>() where TMessage: new()
-        {
-            Send(new TMessage());
-        }
-
-        public void Send(Exception exception)
-        {
-            Send(new PipeMessage.Exception(exception));
-        }
-
-        public void Send<TMessage>(TMessage message)
-        {
-            var messageType = typeof(TMessage).FullName!;
-
-            writer.WriteLine(messageType);
-            writer.WriteLine(Serialize(message));
-            writer.WriteLine(EndOfMessage);
-            writer.Flush();
-        }
-
-        public void Dispose()
-        {
-            reader.Dispose();
-            writer.Dispose();
-        }
+    public void Dispose()
+    {
+        reader.Dispose();
+        writer.Dispose();
     }
 }

--- a/src/Fixie/Internal/TestPattern.cs
+++ b/src/Fixie/Internal/TestPattern.cs
@@ -1,43 +1,42 @@
-namespace Fixie.Internal
+namespace Fixie.Internal;
+
+using System.Text.RegularExpressions;
+
+class TestPattern
 {
-    using System.Text.RegularExpressions;
+    readonly Regex regex;
 
-    class TestPattern
+    public TestPattern(string pattern)
     {
-        readonly Regex regex;
-
-        public TestPattern(string pattern)
-        {
-            var patternWithWildcards = "";
+        var patternWithWildcards = "";
             
-            var previousWasUpperCase = false;
+        var previousWasUpperCase = false;
 
-            foreach (var c in pattern)
-            {
-                if (c == '*')
-                {
-                    patternWithWildcards += ".*";
-                    previousWasUpperCase = false;
-                }
-                else
-                {
-                    if (previousWasUpperCase && !char.IsLower(c))
-                        patternWithWildcards += "[a-z]*";
-
-                    patternWithWildcards += Regex.Escape(c.ToString());
-                    previousWasUpperCase = char.IsUpper(c);
-                }
-            }
-
-            if (previousWasUpperCase)
-                patternWithWildcards += "[a-z]*";
-
-            regex = new Regex(patternWithWildcards + "$");
-        }
-
-        public bool Matches(string test)
+        foreach (var c in pattern)
         {
-            return regex.IsMatch(test);
+            if (c == '*')
+            {
+                patternWithWildcards += ".*";
+                previousWasUpperCase = false;
+            }
+            else
+            {
+                if (previousWasUpperCase && !char.IsLower(c))
+                    patternWithWildcards += "[a-z]*";
+
+                patternWithWildcards += Regex.Escape(c.ToString());
+                previousWasUpperCase = char.IsUpper(c);
+            }
         }
+
+        if (previousWasUpperCase)
+            patternWithWildcards += "[a-z]*";
+
+        regex = new Regex(patternWithWildcards + "$");
+    }
+
+    public bool Matches(string test)
+    {
+        return regex.IsMatch(test);
     }
 }

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -1,187 +1,186 @@
-namespace Fixie
+namespace Fixie;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using Internal;
+
+public static class MethodInfoExtensions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
-    using System.Reflection;
-    using System.Runtime.CompilerServices;
-    using System.Runtime.ExceptionServices;
-    using System.Threading.Tasks;
-    using Internal;
+    static MethodInfo? startAsTask;
 
-    public static class MethodInfoExtensions
+    public static async Task<object?> Call(this MethodInfo method, object? instance, params object?[] parameters)
+        => await method.TryResolveTypeArguments(parameters).CallResolvedMethod(instance, parameters);
+
+    internal static async Task<object?> CallResolvedMethod(this MethodInfo resolvedMethod, object? instance, object?[] parameters)
     {
-        static MethodInfo? startAsTask;
+        var isVoid = resolvedMethod.ReturnType == typeof(void);
 
-        public static async Task<object?> Call(this MethodInfo method, object? instance, params object?[] parameters)
-            => await method.TryResolveTypeArguments(parameters).CallResolvedMethod(instance, parameters);
+        if (isVoid && resolvedMethod.HasAsyncKeyword())
+            ThrowForAsyncVoid(resolvedMethod);
 
-        internal static async Task<object?> CallResolvedMethod(this MethodInfo resolvedMethod, object? instance, object?[] parameters)
+        if (resolvedMethod.ContainsGenericParameters)
+            ThrowForUnresolvedTypeParameters(resolvedMethod);
+
+        object? result;
+
+        try
         {
-            var isVoid = resolvedMethod.ReturnType == typeof(void);
-
-            if (isVoid && resolvedMethod.HasAsyncKeyword())
-                ThrowForAsyncVoid(resolvedMethod);
-
-            if (resolvedMethod.ContainsGenericParameters)
-                ThrowForUnresolvedTypeParameters(resolvedMethod);
-
-            object? result;
-
-            try
-            {
-                result = resolvedMethod.Invoke(instance, parameters.Length == 0 ? null : parameters);
-            }
-            catch (TargetInvocationException exception)
-            {
-                ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
-                throw; // Unreachable.
-            }
-
-            if (isVoid)
-                return null;
-
-            if (IsAwaitable(resolvedMethod, result, out var task, out var taskHasResult))
-            {
-                if (task.Status == TaskStatus.Created)
-                    ThrowForNonStartedTask(resolvedMethod);
-
-                await task;
-
-                return taskHasResult
-                    ? task.GetType().GetProperty("Result")!.GetValue(task)
-                    : null;
-            }
-
-            return result;
+            result = resolvedMethod.Invoke(instance, parameters.Length == 0 ? null : parameters);
+        }
+        catch (TargetInvocationException exception)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
+            throw; // Unreachable.
         }
 
-        static bool IsAwaitable(MethodInfo resolvedMethod, object? result, [NotNullWhen(true)] out Task? task, out bool taskHasResult)
+        if (isVoid)
+            return null;
+
+        if (IsAwaitable(resolvedMethod, result, out var task, out var taskHasResult))
         {
-            var returnType = resolvedMethod.ReturnType;
+            if (task.Status == TaskStatus.Created)
+                ThrowForNonStartedTask(resolvedMethod);
 
-            if (returnType.IsGenericType)
+            await task;
+
+            return taskHasResult
+                ? task.GetType().GetProperty("Result")!.GetValue(task)
+                : null;
+        }
+
+        return result;
+    }
+
+    static bool IsAwaitable(MethodInfo resolvedMethod, object? result, [NotNullWhen(true)] out Task? task, out bool taskHasResult)
+    {
+        var returnType = resolvedMethod.ReturnType;
+
+        if (returnType.IsGenericType)
+        {
+            var genericDefinition = returnType.GetGenericTypeDefinition();
+
+            if (genericDefinition == typeof(ValueTask<>))
             {
-                var genericDefinition = returnType.GetGenericTypeDefinition();
-
-                if (genericDefinition == typeof(ValueTask<>))
-                {
-                    task = (Task)returnType.GetMethod("AsTask")!.Invoke(result, null)!;
-                    taskHasResult = true;
-                    return true;
-                }
-
-                if (genericDefinition == typeof(Task<>))
-                {
-                    if (result == null)
-                        ThrowForNullAwaitable(resolvedMethod);
-                    task = (Task)result;
-                    taskHasResult = true;
-                    return true;
-                }
-
-                if (genericDefinition.FullName == "Microsoft.FSharp.Control.FSharpAsync`1")
-                {
-                    if (result == null)
-                        ThrowForNullAwaitable(resolvedMethod);
-                    task = ConvertFSharpAsyncToTask(result, returnType);
-                    taskHasResult = true;
-                    return true;
-                }
-
-                if (genericDefinition == typeof(IAsyncEnumerable<>) ||
-                    genericDefinition == typeof(IAsyncEnumerator<>))
-                    ThrowForUnsupportedAwaitable(resolvedMethod);
+                task = (Task)returnType.GetMethod("AsTask")!.Invoke(result, null)!;
+                taskHasResult = true;
+                return true;
             }
-            else if (returnType == typeof(Task))
+
+            if (genericDefinition == typeof(Task<>))
             {
                 if (result == null)
                     ThrowForNullAwaitable(resolvedMethod);
                 task = (Task)result;
-                taskHasResult = false;
+                taskHasResult = true;
                 return true;
             }
-            else if (returnType == typeof(ValueTask))
+
+            if (genericDefinition.FullName == "Microsoft.FSharp.Control.FSharpAsync`1")
             {
-                task = ((ValueTask)result!).AsTask();
-                taskHasResult = false;
+                if (result == null)
+                    ThrowForNullAwaitable(resolvedMethod);
+                task = ConvertFSharpAsyncToTask(result, returnType);
+                taskHasResult = true;
                 return true;
             }
-            
-            if (returnType.Has<AsyncMethodBuilderAttribute>())
+
+            if (genericDefinition == typeof(IAsyncEnumerable<>) ||
+                genericDefinition == typeof(IAsyncEnumerator<>))
                 ThrowForUnsupportedAwaitable(resolvedMethod);
-
-            task = null;
+        }
+        else if (returnType == typeof(Task))
+        {
+            if (result == null)
+                ThrowForNullAwaitable(resolvedMethod);
+            task = (Task)result;
             taskHasResult = false;
-            return false;
+            return true;
+        }
+        else if (returnType == typeof(ValueTask))
+        {
+            task = ((ValueTask)result!).AsTask();
+            taskHasResult = false;
+            return true;
+        }
+            
+        if (returnType.Has<AsyncMethodBuilderAttribute>())
+            ThrowForUnsupportedAwaitable(resolvedMethod);
+
+        task = null;
+        taskHasResult = false;
+        return false;
+    }
+
+    [DoesNotReturn]
+    static void ThrowForAsyncVoid(MethodInfo resolvedMethod)
+        => throw new NotSupportedException(
+            $"The method {resolvedMethod.Name} is declared as `async void`, " +
+            "which is not supported. To ensure the reliability of the test " +
+            "runner, declare the method as `async Task`.");
+
+    [DoesNotReturn]
+    static void ThrowForUnresolvedTypeParameters(MethodInfo resolvedMethod)
+        => throw new InvalidOperationException(
+            $"The type parameters for generic method {resolvedMethod.Name} " +
+            "could not be resolved.");
+
+    [DoesNotReturn]
+    static void ThrowForNullAwaitable(MethodInfo method)
+        => throw new NullReferenceException(
+            $"The asynchronous method {method.Name} returned null, but " +
+            "a non-null awaitable object was expected.");
+
+    [DoesNotReturn]
+    static void ThrowForNonStartedTask(MethodInfo resolvedMethod)
+        => throw new InvalidOperationException(
+            $"The method {resolvedMethod.Name} returned a non-started task, which " +
+            "cannot be awaited. Consider using Task.Run or Task.Factory.StartNew.");
+
+    [DoesNotReturn]
+    static void ThrowForUnsupportedAwaitable(MethodInfo method)
+        => throw new NotSupportedException(
+            $"The return type of method {method.Name} is an unsupported awaitable type. " +
+            "To ensure the reliability of the test runner, declare " +
+            "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
+            "or `ValueTask<T>`.");
+
+    static bool HasAsyncKeyword(this MethodInfo method)
+    {
+        return method.Has<AsyncStateMachineAttribute>();
+    }
+
+    static Task ConvertFSharpAsyncToTask(object result, Type resultType)
+    {
+        try
+        {
+            if (startAsTask == null)
+                startAsTask = resultType
+                    .Assembly
+                    .GetType("Microsoft.FSharp.Control.FSharpAsync")!
+                    .GetRuntimeMethods()
+                    .Single(x => x.Name == "StartAsTask");
+        }
+        catch (Exception exception)
+        {
+            throw new InvalidOperationException("Unable to locate F# Control.Async.StartAsTask method.", exception);
         }
 
-        [DoesNotReturn]
-        static void ThrowForAsyncVoid(MethodInfo resolvedMethod)
-            => throw new NotSupportedException(
-                $"The method {resolvedMethod.Name} is declared as `async void`, " +
-                "which is not supported. To ensure the reliability of the test " +
-                "runner, declare the method as `async Task`.");
+        var genericStartAsTask = startAsTask.MakeGenericMethod(resultType.GetGenericArguments());
 
-        [DoesNotReturn]
-        static void ThrowForUnresolvedTypeParameters(MethodInfo resolvedMethod)
-            => throw new InvalidOperationException(
-                $"The type parameters for generic method {resolvedMethod.Name} " +
-                "could not be resolved.");
-
-        [DoesNotReturn]
-        static void ThrowForNullAwaitable(MethodInfo method)
-            => throw new NullReferenceException(
-                $"The asynchronous method {method.Name} returned null, but " +
-                "a non-null awaitable object was expected.");
-
-        [DoesNotReturn]
-        static void ThrowForNonStartedTask(MethodInfo resolvedMethod)
-            => throw new InvalidOperationException(
-                $"The method {resolvedMethod.Name} returned a non-started task, which " +
-                "cannot be awaited. Consider using Task.Run or Task.Factory.StartNew.");
-
-        [DoesNotReturn]
-        static void ThrowForUnsupportedAwaitable(MethodInfo method)
-            => throw new NotSupportedException(
-                $"The return type of method {method.Name} is an unsupported awaitable type. " +
-                "To ensure the reliability of the test runner, declare " +
-                "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
-                "or `ValueTask<T>`.");
-
-        static bool HasAsyncKeyword(this MethodInfo method)
+        try
         {
-            return method.Has<AsyncStateMachineAttribute>();
+            return (Task) genericStartAsTask.Invoke(null, new[] { result, null, null })!;
         }
-
-        static Task ConvertFSharpAsyncToTask(object result, Type resultType)
+        catch (TargetInvocationException exception)
         {
-            try
-            {
-                if (startAsTask == null)
-                    startAsTask = resultType
-                        .Assembly
-                        .GetType("Microsoft.FSharp.Control.FSharpAsync")!
-                        .GetRuntimeMethods()
-                        .Single(x => x.Name == "StartAsTask");
-            }
-            catch (Exception exception)
-            {
-                throw new InvalidOperationException("Unable to locate F# Control.Async.StartAsTask method.", exception);
-            }
-
-            var genericStartAsTask = startAsTask.MakeGenericMethod(resultType.GetGenericArguments());
-
-            try
-            {
-                return (Task) genericStartAsTask.Invoke(null, new[] { result, null, null })!;
-            }
-            catch (TargetInvocationException exception)
-            {
-                ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
-                throw; // Unreachable.
-            }
+            ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
+            throw; // Unreachable.
         }
     }
 }

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -1,32 +1,31 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using static Internal.Maybe;
+
+public static class ReflectionExtensions
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
-    using System.Reflection;
-    using static Internal.Maybe;
+    internal static string TestName(this MethodInfo method)
+        => method.ReflectedType!.FullName! + "." + method.Name;
 
-    public static class ReflectionExtensions
-    {
-        internal static string TestName(this MethodInfo method)
-            => method.ReflectedType!.FullName! + "." + method.Name;
+    internal static bool IsStatic(this Type type)
+        => type.IsAbstract && type.IsSealed;
 
-        internal static bool IsStatic(this Type type)
-            => type.IsAbstract && type.IsSealed;
+    /// <summary>
+    /// Determines whether any attributes of the specified type are applied to a
+    /// specified member including the ancestors of that member.
+    /// </summary>
+    public static bool Has<TAttribute>(this MemberInfo member) where TAttribute : Attribute
+        => member.GetCustomAttributes<TAttribute>(true).Any();
 
-        /// <summary>
-        /// Determines whether any attributes of the specified type are applied to a
-        /// specified member including the ancestors of that member.
-        /// </summary>
-        public static bool Has<TAttribute>(this MemberInfo member) where TAttribute : Attribute
-            => member.GetCustomAttributes<TAttribute>(true).Any();
-
-        /// <summary>
-        /// Determines whether an attribute of the specified type is applied to a
-        /// specified member including the ancestors of that member, providing that
-        /// attribute as an `out` parameter when found.
-        /// </summary>
-        public static bool Has<TAttribute>(this MemberInfo member, [NotNullWhen(true)] out TAttribute? matchingAttribute) where TAttribute : Attribute
-            => Try(() => member.GetCustomAttribute<TAttribute>(true), out matchingAttribute);
-    }
+    /// <summary>
+    /// Determines whether an attribute of the specified type is applied to a
+    /// specified member including the ancestors of that member, providing that
+    /// attribute as an `out` parameter when found.
+    /// </summary>
+    public static bool Has<TAttribute>(this MemberInfo member, [NotNullWhen(true)] out TAttribute? matchingAttribute) where TAttribute : Attribute
+        => Try(() => member.GetCustomAttribute<TAttribute>(true), out matchingAttribute);
 }

--- a/src/Fixie/ReportCollection.cs
+++ b/src/Fixie/ReportCollection.cs
@@ -1,18 +1,17 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+using System.Collections.Generic;
+using Reports;
+
+public class ReportCollection
 {
-    using System.Collections.Generic;
-    using Reports;
+    internal List<IReport> Items { get; }
 
-    public class ReportCollection
-    {
-        internal List<IReport> Items { get; }
+    internal ReportCollection() => Items = new List<IReport>();
 
-        internal ReportCollection() => Items = new List<IReport>();
+    public void Add(IReport report)
+        => Items.Add(report);
 
-        public void Add(IReport report)
-            => Items.Add(report);
-
-        public void Add<TReport>() where TReport : IReport, new()
-            => Add(new TReport());
-    }
+    public void Add<TReport>() where TReport : IReport, new()
+        => Add(new TReport());
 }

--- a/src/Fixie/Reports/AppVeyorReport.cs
+++ b/src/Fixie/Reports/AppVeyorReport.cs
@@ -1,124 +1,123 @@
-﻿namespace Fixie.Reports
+﻿namespace Fixie.Reports;
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using static System.Environment;
+using static System.Text.Json.JsonSerializer;
+
+class AppVeyorReport :
+    IHandler<ExecutionStarted>,
+    IHandler<TestSkipped>,
+    IHandler<TestPassed>,
+    IHandler<TestFailed>
 {
-    using System;
-    using System.IO;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Text;
-    using System.Threading.Tasks;
-    using static System.Environment;
-    using static System.Text.Json.JsonSerializer;
+    public delegate Task PostAction(string uri, Result result);
 
-    class AppVeyorReport :
-        IHandler<ExecutionStarted>,
-        IHandler<TestSkipped>,
-        IHandler<TestPassed>,
-        IHandler<TestFailed>
+    readonly TestEnvironment environment;
+    readonly PostAction postAction;
+    readonly string uri;
+    string runName;
+
+    static readonly HttpClient Client;
+
+    internal static AppVeyorReport? Create(TestEnvironment environment)
     {
-        public delegate Task PostAction(string uri, Result result);
-
-        readonly TestEnvironment environment;
-        readonly PostAction postAction;
-        readonly string uri;
-        string runName;
-
-        static readonly HttpClient Client;
-
-        internal static AppVeyorReport? Create(TestEnvironment environment)
+        if (GetEnvironmentVariable("APPVEYOR") == "True")
         {
-            if (GetEnvironmentVariable("APPVEYOR") == "True")
-            {
-                var uri = GetEnvironmentVariable("APPVEYOR_API_URL");
-                if (uri != null)
-                    return new AppVeyorReport(environment, uri, Post);
-            }
-
-            return null;
+            var uri = GetEnvironmentVariable("APPVEYOR_API_URL");
+            if (uri != null)
+                return new AppVeyorReport(environment, uri, Post);
         }
 
-        static AppVeyorReport()
+        return null;
+    }
+
+    static AppVeyorReport()
+    {
+        Client = new HttpClient();
+        Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    }
+
+    public AppVeyorReport(TestEnvironment environment, string uri, PostAction postAction)
+    {
+        this.environment = environment;
+        this.postAction = postAction;
+        this.uri = new Uri(new Uri(uri), "api/tests").ToString();
+        runName = "Unknown";
+    }
+
+    public Task Handle(ExecutionStarted message)
+    {
+        runName = Path.GetFileNameWithoutExtension(environment.Assembly.Location);
+
+        var framework = environment.TargetFramework;
+
+        if (!string.IsNullOrEmpty(framework))
+            runName = $"{runName} ({framework})";
+
+        return Task.CompletedTask;
+    }
+
+    public async Task Handle(TestSkipped message)
+    {
+        await Post(new Result(runName, message, "Skipped")
         {
-            Client = new HttpClient();
-            Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            ErrorMessage = message.Reason
+        });
+    }
+
+    public async Task Handle(TestPassed message)
+    {
+        await Post(new Result(runName, message, "Passed"));
+    }
+
+    public async Task Handle(TestFailed message)
+    {
+        await Post(new Result(runName, message, "Failed")
+        {
+            ErrorMessage = message.Reason.Message,
+            ErrorStackTrace =
+                message.Reason.GetType().FullName +
+                NewLine +
+                message.Reason.StackTraceSummary()
+        });
+    }
+
+    async Task Post(Result result)
+    {
+        await postAction(uri, result);
+    }
+
+    static async Task Post(string uri, Result result)
+    {
+        var content = Serialize(result);
+        var response = await Client.PostAsync(uri, new StringContent(content, Encoding.UTF8, "application/json"));
+        response.EnsureSuccessStatusCode();
+    }
+
+    public class Result
+    {
+        public Result(string runName, TestCompleted message, string outcome)
+        {
+            TestFramework = "Fixie";
+            FileName = runName;
+            TestName = message.TestCase;
+            Outcome = outcome;
+            DurationMilliseconds = $"{message.Duration.TotalMilliseconds:0}";
+            StdOut = message.Output;
         }
 
-        public AppVeyorReport(TestEnvironment environment, string uri, PostAction postAction)
-        {
-            this.environment = environment;
-            this.postAction = postAction;
-            this.uri = new Uri(new Uri(uri), "api/tests").ToString();
-            runName = "Unknown";
-        }
-
-        public Task Handle(ExecutionStarted message)
-        {
-            runName = Path.GetFileNameWithoutExtension(environment.Assembly.Location);
-
-            var framework = environment.TargetFramework;
-
-            if (!string.IsNullOrEmpty(framework))
-                runName = $"{runName} ({framework})";
-
-            return Task.CompletedTask;
-        }
-
-        public async Task Handle(TestSkipped message)
-        {
-            await Post(new Result(runName, message, "Skipped")
-            {
-                ErrorMessage = message.Reason
-            });
-        }
-
-        public async Task Handle(TestPassed message)
-        {
-            await Post(new Result(runName, message, "Passed"));
-        }
-
-        public async Task Handle(TestFailed message)
-        {
-            await Post(new Result(runName, message, "Failed")
-            {
-                ErrorMessage = message.Reason.Message,
-                ErrorStackTrace =
-                    message.Reason.GetType().FullName +
-                    NewLine +
-                    message.Reason.StackTraceSummary()
-            });
-        }
-
-        async Task Post(Result result)
-        {
-            await postAction(uri, result);
-        }
-
-        static async Task Post(string uri, Result result)
-        {
-            var content = Serialize(result);
-            var response = await Client.PostAsync(uri, new StringContent(content, Encoding.UTF8, "application/json"));
-            response.EnsureSuccessStatusCode();
-        }
-
-        public class Result
-        {
-            public Result(string runName, TestCompleted message, string outcome)
-            {
-                TestFramework = "Fixie";
-                FileName = runName;
-                TestName = message.TestCase;
-                Outcome = outcome;
-                DurationMilliseconds = $"{message.Duration.TotalMilliseconds:0}";
-                StdOut = message.Output;
-            }
-
-            public string TestFramework { get; set; }
-            public string FileName { get; set; }
-            public string TestName { get; set; }
-            public string Outcome { get; set; }
-            public string DurationMilliseconds { get; set; }
-            public string StdOut { get; set; }
-            public string? ErrorMessage { get; set; }
-            public string? ErrorStackTrace { get; set; }
-        }
+        public string TestFramework { get; set; }
+        public string FileName { get; set; }
+        public string TestName { get; set; }
+        public string Outcome { get; set; }
+        public string DurationMilliseconds { get; set; }
+        public string StdOut { get; set; }
+        public string? ErrorMessage { get; set; }
+        public string? ErrorStackTrace { get; set; }
     }
 }

--- a/src/Fixie/Reports/AzureReport.cs
+++ b/src/Fixie/Reports/AzureReport.cs
@@ -1,317 +1,316 @@
-﻿namespace Fixie.Reports
+﻿namespace Fixie.Reports;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Internal;
+using static System.Environment;
+using static System.Text.Json.JsonSerializer;
+using static Internal.Maybe;
+
+class AzureReport :
+    IHandler<ExecutionStarted>,
+    IHandler<TestSkipped>,
+    IHandler<TestPassed>,
+    IHandler<TestFailed>,
+    IHandler<ExecutionCompleted>
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
-    using System.IO;
-    using System.Linq;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Internal;
-    using static System.Environment;
-    using static System.Text.Json.JsonSerializer;
-    using static Internal.Maybe;
+    const string AzureDevOpsRestApiVersion = "5.0";
 
-    class AzureReport :
-        IHandler<ExecutionStarted>,
-        IHandler<TestSkipped>,
-        IHandler<TestPassed>,
-        IHandler<TestFailed>,
-        IHandler<ExecutionCompleted>
+    public delegate Task<string> ApiAction<in T>(HttpClient client, HttpMethod method, string uri, T content);
+
+    readonly TextWriter console;
+    readonly TestEnvironment environment;
+    readonly string collectionUri;
+    readonly string project;
+    readonly string buildId;
+    readonly ApiAction<CreateRun> sendCreateRun;
+    readonly ApiAction<IReadOnlyList<Result>> sendResultsBatch;
+    readonly ApiAction<CompleteRun> sendCompleteRun;
+    readonly HttpClient client;
+
+    string? runUrl;
+
+    readonly int batchSize;
+    readonly List<Result> batch;
+    bool apiUnavailable;
+
+    internal static AzureReport? Create(TestEnvironment environment)
     {
-        const string AzureDevOpsRestApiVersion = "5.0";
+        var console = environment.Console;
+        var runningUnderAzure = GetEnvironmentVariable("TF_BUILD") == "True";
 
-        public delegate Task<string> ApiAction<in T>(HttpClient client, HttpMethod method, string uri, T content);
-
-        readonly TextWriter console;
-        readonly TestEnvironment environment;
-        readonly string collectionUri;
-        readonly string project;
-        readonly string buildId;
-        readonly ApiAction<CreateRun> sendCreateRun;
-        readonly ApiAction<IReadOnlyList<Result>> sendResultsBatch;
-        readonly ApiAction<CompleteRun> sendCompleteRun;
-        readonly HttpClient client;
-
-        string? runUrl;
-
-        readonly int batchSize;
-        readonly List<Result> batch;
-        bool apiUnavailable;
-
-        internal static AzureReport? Create(TestEnvironment environment)
+        if (runningUnderAzure)
         {
-            var console = environment.Console;
-            var runningUnderAzure = GetEnvironmentVariable("TF_BUILD") == "True";
+            var accessTokenIsAvailable =
+                !string.IsNullOrEmpty(GetEnvironmentVariable("SYSTEM_ACCESSTOKEN"));
 
-            if (runningUnderAzure)
+            if (accessTokenIsAvailable)
             {
-                var accessTokenIsAvailable =
-                    !string.IsNullOrEmpty(GetEnvironmentVariable("SYSTEM_ACCESSTOKEN"));
-
-                if (accessTokenIsAvailable)
+                if (TryGetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", console, out var collectionUri)
+                    && TryGetEnvironmentVariable("SYSTEM_TEAMPROJECT", console, out var project)
+                    && TryGetEnvironmentVariable("SYSTEM_ACCESSTOKEN", console, out var accessToken)
+                    && TryGetEnvironmentVariable("BUILD_BUILDID", console, out var buildId))
                 {
-                    if (TryGetEnvironmentVariable("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", console, out var collectionUri)
-                        && TryGetEnvironmentVariable("SYSTEM_TEAMPROJECT", console, out var project)
-                        && TryGetEnvironmentVariable("SYSTEM_ACCESSTOKEN", console, out var accessToken)
-                        && TryGetEnvironmentVariable("BUILD_BUILDID", console, out var buildId))
-                    {
-                        return new AzureReport(
-                            environment,
-                            collectionUri,
-                            project,
-                            accessToken,
-                            buildId,
-                            Send,
-                            Send,
-                            Send,
-                            batchSize: 25);
-                    }
-
-                    return null;
+                    return new AzureReport(
+                        environment,
+                        collectionUri,
+                        project,
+                        accessToken,
+                        buildId,
+                        Send,
+                        Send,
+                        Send,
+                        batchSize: 25);
                 }
 
-                using (Foreground.Yellow)
-                {
-                    console.WriteLine("The Azure DevOps access token has not been made available to this process, so");
-                    console.WriteLine("test results will not be collected. To resolve this issue, review your pipeline");
-                    console.WriteLine("definition to ensure that the access token is made available as the environment");
-                    console.WriteLine("variable SYSTEM_ACCESSTOKEN.");
-                    console.WriteLine();
-                    console.WriteLine("From https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#systemaccesstoken");
-                    console.WriteLine();
-                    console.WriteLine("  env:");
-                    console.WriteLine("    SYSTEM_ACCESSTOKEN: $(System.AccessToken)");
-                    console.WriteLine();
-                }
+                return null;
             }
 
-            return null;
-        }
-
-        static bool TryGetEnvironmentVariable(string variable, TextWriter console, [NotNullWhen(true)] out string? value)
-        {
-            if (Try(GetEnvironmentVariable, variable, out value))
-                return true;
-            
             using (Foreground.Yellow)
             {
-                console.WriteLine($"The Azure DevOps environment variable '{variable}' has not been made");
-                console.WriteLine("available to this process, so test results will not be collected.");
+                console.WriteLine("The Azure DevOps access token has not been made available to this process, so");
+                console.WriteLine("test results will not be collected. To resolve this issue, review your pipeline");
+                console.WriteLine("definition to ensure that the access token is made available as the environment");
+                console.WriteLine("variable SYSTEM_ACCESSTOKEN.");
+                console.WriteLine();
+                console.WriteLine("From https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#systemaccesstoken");
+                console.WriteLine();
+                console.WriteLine("  env:");
+                console.WriteLine("    SYSTEM_ACCESSTOKEN: $(System.AccessToken)");
                 console.WriteLine();
             }
-
-            return false;
         }
 
-        public AzureReport(
-            TestEnvironment environment,
-            string collectionUri,
-            string project,
-            string accessToken,
-            string buildId,
-            ApiAction<CreateRun> sendCreateRun,
-            ApiAction<IReadOnlyList<Result>> sendResultsBatch,
-            ApiAction<CompleteRun> sendCompleteRun,
-            int batchSize)
+        return null;
+    }
+
+    static bool TryGetEnvironmentVariable(string variable, TextWriter console, [NotNullWhen(true)] out string? value)
+    {
+        if (Try(GetEnvironmentVariable, variable, out value))
+            return true;
+            
+        using (Foreground.Yellow)
         {
-            this.environment = environment;
-            console = environment.Console;
-            this.collectionUri = collectionUri;
-            this.project = project;
-            this.buildId = buildId;
-            this.sendCreateRun = sendCreateRun;
-            this.sendResultsBatch = sendResultsBatch;
-            this.sendCompleteRun = sendCompleteRun;
-            this.batchSize = batchSize;
-
-            batch = new List<Result>(batchSize);
-
-            client = new HttpClient();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-        }
-
-        public async Task Handle(ExecutionStarted message)
-        {
-            var runName = Path.GetFileNameWithoutExtension(environment.Assembly.Location);
-
-            var framework = environment.TargetFramework;
-
-            if (!string.IsNullOrEmpty(framework))
-                runName = $"{runName} ({framework})";
-
-            var createRun = new CreateRun(runName, buildId);
-
-            var runsUri = new Uri(new Uri(collectionUri), $"{project}/_apis/test/runs").ToString();
-
-            var response = await sendCreateRun(client, HttpMethod.Post, $"{runsUri}?api-version={AzureDevOpsRestApiVersion}", createRun);
-
-            runUrl = Deserialize<TestRun>(response)!.url;
-        }
-
-        public async Task Handle(TestSkipped message)
-        {
-            if (apiUnavailable) return;
-
-            await Include(new Result(message, "Warning")
-            {
-                errorMessage = message.Reason
-            });
-        }
-
-        public async Task Handle(TestPassed message)
-        {
-            if (apiUnavailable) return;
-
-            await Include(new Result(message, "Passed"));
-        }
-
-        public async Task Handle(TestFailed message)
-        {
-            if (apiUnavailable) return;
-
-            await Include(new Result(message, "Failed")
-            {
-                errorMessage = message.Reason.Message,
-                stackTrace =
-                    message.Reason.GetType().FullName +
-                    NewLine +
-                    message.Reason.StackTraceSummary()
-            });
-        }
-
-        public async Task Handle(ExecutionCompleted message)
-        {
-            if (apiUnavailable) return;
-
-            if (batch.Any())
-                await PostBatch();
-
-            var completeRun = new CompleteRun();
-
-            await sendCompleteRun(client, new HttpMethod("PATCH"), $"{runUrl}?api-version={AzureDevOpsRestApiVersion}", completeRun);
-        }
-
-        async Task Include(Result result)
-        {
-            batch.Add(result);
-
-            if (batch.Count >= batchSize)
-                await PostBatch();
-        }
-
-        async Task PostBatch()
-        {
-            var attempt = 1;
-            const int maxAttempts = 5;
-            const int coolDownInSeconds = 5;
-
-            while (attempt <= maxAttempts)
-            {
-                try
-                {
-                    await sendResultsBatch(client, HttpMethod.Post, $"{runUrl}/results?api-version={AzureDevOpsRestApiVersion}", batch.ToList());
-                    batch.Clear();
-
-                    if (attempt > 1)
-                    {
-                        console.WriteLine($"Successfully submitted test result batch to Azure DevOps API on attempt #{attempt}.");
-                        console.WriteLine();
-                    }
-
-                    return;
-                }
-                catch (Exception exception)
-                {
-                    console.WriteLine($"Failed to submit test result batch to Azure DevOps API (attempt #{attempt} of {maxAttempts}): " + exception);
-                    console.WriteLine();
-                    await Task.Delay(TimeSpan.FromSeconds(coolDownInSeconds));
-                    attempt++;
-                }
-            }
-
-            console.WriteLine("Due to repeated failures while submitting test results to the Azure DevOps API,");
-            console.WriteLine("further attempts will be suppressed for the remainder of this test run. Full test");
-            console.WriteLine("results will continue to be reported to this console and to the test process exit");
-            console.WriteLine("code, but the Azure DevOps \"Tests\" summary will be incomplete.");
+            console.WriteLine($"The Azure DevOps environment variable '{variable}' has not been made");
+            console.WriteLine("available to this process, so test results will not be collected.");
             console.WriteLine();
-
-            apiUnavailable = true;
-            batch.Clear();
         }
 
-        static async Task<string> Send<T>(HttpClient client, HttpMethod method, string uri, T content)
-        {
-            var serialized = Serialize(content);
+        return false;
+    }
 
-            using var httpResponse = await client.SendAsync(
-                new HttpRequestMessage(method, new Uri(uri, UriKind.RelativeOrAbsolute))
+    public AzureReport(
+        TestEnvironment environment,
+        string collectionUri,
+        string project,
+        string accessToken,
+        string buildId,
+        ApiAction<CreateRun> sendCreateRun,
+        ApiAction<IReadOnlyList<Result>> sendResultsBatch,
+        ApiAction<CompleteRun> sendCompleteRun,
+        int batchSize)
+    {
+        this.environment = environment;
+        console = environment.Console;
+        this.collectionUri = collectionUri;
+        this.project = project;
+        this.buildId = buildId;
+        this.sendCreateRun = sendCreateRun;
+        this.sendResultsBatch = sendResultsBatch;
+        this.sendCompleteRun = sendCompleteRun;
+        this.batchSize = batchSize;
+
+        batch = new List<Result>(batchSize);
+
+        client = new HttpClient();
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+    }
+
+    public async Task Handle(ExecutionStarted message)
+    {
+        var runName = Path.GetFileNameWithoutExtension(environment.Assembly.Location);
+
+        var framework = environment.TargetFramework;
+
+        if (!string.IsNullOrEmpty(framework))
+            runName = $"{runName} ({framework})";
+
+        var createRun = new CreateRun(runName, buildId);
+
+        var runsUri = new Uri(new Uri(collectionUri), $"{project}/_apis/test/runs").ToString();
+
+        var response = await sendCreateRun(client, HttpMethod.Post, $"{runsUri}?api-version={AzureDevOpsRestApiVersion}", createRun);
+
+        runUrl = Deserialize<TestRun>(response)!.url;
+    }
+
+    public async Task Handle(TestSkipped message)
+    {
+        if (apiUnavailable) return;
+
+        await Include(new Result(message, "Warning")
+        {
+            errorMessage = message.Reason
+        });
+    }
+
+    public async Task Handle(TestPassed message)
+    {
+        if (apiUnavailable) return;
+
+        await Include(new Result(message, "Passed"));
+    }
+
+    public async Task Handle(TestFailed message)
+    {
+        if (apiUnavailable) return;
+
+        await Include(new Result(message, "Failed")
+        {
+            errorMessage = message.Reason.Message,
+            stackTrace =
+                message.Reason.GetType().FullName +
+                NewLine +
+                message.Reason.StackTraceSummary()
+        });
+    }
+
+    public async Task Handle(ExecutionCompleted message)
+    {
+        if (apiUnavailable) return;
+
+        if (batch.Any())
+            await PostBatch();
+
+        var completeRun = new CompleteRun();
+
+        await sendCompleteRun(client, new HttpMethod("PATCH"), $"{runUrl}?api-version={AzureDevOpsRestApiVersion}", completeRun);
+    }
+
+    async Task Include(Result result)
+    {
+        batch.Add(result);
+
+        if (batch.Count >= batchSize)
+            await PostBatch();
+    }
+
+    async Task PostBatch()
+    {
+        var attempt = 1;
+        const int maxAttempts = 5;
+        const int coolDownInSeconds = 5;
+
+        while (attempt <= maxAttempts)
+        {
+            try
+            {
+                await sendResultsBatch(client, HttpMethod.Post, $"{runUrl}/results?api-version={AzureDevOpsRestApiVersion}", batch.ToList());
+                batch.Clear();
+
+                if (attempt > 1)
                 {
-                    Content = new StringContent(serialized, Encoding.UTF8, "application/json")
-                });
+                    console.WriteLine($"Successfully submitted test result batch to Azure DevOps API on attempt #{attempt}.");
+                    console.WriteLine();
+                }
 
-            var body = await httpResponse.Content.ReadAsStringAsync();
-
-            if (!httpResponse.IsSuccessStatusCode)
-                throw new HttpRequestException(new StringBuilder()
-                    .AppendLine($"{typeof(AzureReport).FullName} failed to {method} a message:")
-                    .AppendLine($"{(int) httpResponse.StatusCode} {httpResponse.ReasonPhrase}")
-                    .AppendLine(body)
-                    .ToString());
-
-            return body;
-        }
-
-        public class CreateRun
-        {
-            public CreateRun(string runName, string buildId)
-            {
-                name = runName;
-                build = new BuildDetail(buildId);
+                return;
             }
-
-            public string name { get; }
-            public BuildDetail build { get; }
-            public bool isAutomated => true;
-
-            public class BuildDetail
+            catch (Exception exception)
             {
-                public BuildDetail(string buildId) => id = buildId;
-
-                public string id { get; }
+                console.WriteLine($"Failed to submit test result batch to Azure DevOps API (attempt #{attempt} of {maxAttempts}): " + exception);
+                console.WriteLine();
+                await Task.Delay(TimeSpan.FromSeconds(coolDownInSeconds));
+                attempt++;
             }
         }
 
-        public class CompleteRun
-        {
-            public string state => "Completed";
-        }
+        console.WriteLine("Due to repeated failures while submitting test results to the Azure DevOps API,");
+        console.WriteLine("further attempts will be suppressed for the remainder of this test run. Full test");
+        console.WriteLine("results will continue to be reported to this console and to the test process exit");
+        console.WriteLine("code, but the Azure DevOps \"Tests\" summary will be incomplete.");
+        console.WriteLine();
 
-        public class TestRun
-        {
-            public string? url { get; set; }
-        }
+        apiUnavailable = true;
+        batch.Clear();
+    }
 
-        public class Result
-        {
-            public Result(TestCompleted message, string outcome)
+    static async Task<string> Send<T>(HttpClient client, HttpMethod method, string uri, T content)
+    {
+        var serialized = Serialize(content);
+
+        using var httpResponse = await client.SendAsync(
+            new HttpRequestMessage(method, new Uri(uri, UriKind.RelativeOrAbsolute))
             {
-                automatedTestName = message.TestCase;
-                testCaseTitle = message.TestCase;
-                durationInMs = message.Duration.TotalMilliseconds;
-                this.outcome = outcome;
-            }
+                Content = new StringContent(serialized, Encoding.UTF8, "application/json")
+            });
 
-            public string automatedTestName { get; }
-            public string testCaseTitle { get; }
-            public double durationInMs { get; }
-            public string outcome { get; set; }
-            public string? errorMessage { get; set; }
-            public string? stackTrace { get; set; }
+        var body = await httpResponse.Content.ReadAsStringAsync();
+
+        if (!httpResponse.IsSuccessStatusCode)
+            throw new HttpRequestException(new StringBuilder()
+                .AppendLine($"{typeof(AzureReport).FullName} failed to {method} a message:")
+                .AppendLine($"{(int) httpResponse.StatusCode} {httpResponse.ReasonPhrase}")
+                .AppendLine(body)
+                .ToString());
+
+        return body;
+    }
+
+    public class CreateRun
+    {
+        public CreateRun(string runName, string buildId)
+        {
+            name = runName;
+            build = new BuildDetail(buildId);
         }
+
+        public string name { get; }
+        public BuildDetail build { get; }
+        public bool isAutomated => true;
+
+        public class BuildDetail
+        {
+            public BuildDetail(string buildId) => id = buildId;
+
+            public string id { get; }
+        }
+    }
+
+    public class CompleteRun
+    {
+        public string state => "Completed";
+    }
+
+    public class TestRun
+    {
+        public string? url { get; set; }
+    }
+
+    public class Result
+    {
+        public Result(TestCompleted message, string outcome)
+        {
+            automatedTestName = message.TestCase;
+            testCaseTitle = message.TestCase;
+            durationInMs = message.Duration.TotalMilliseconds;
+            this.outcome = outcome;
+        }
+
+        public string automatedTestName { get; }
+        public string testCaseTitle { get; }
+        public double durationInMs { get; }
+        public string outcome { get; set; }
+        public string? errorMessage { get; set; }
+        public string? stackTrace { get; set; }
     }
 }

--- a/src/Fixie/Reports/ExceptionExtensions.cs
+++ b/src/Fixie/Reports/ExceptionExtensions.cs
@@ -1,95 +1,94 @@
-﻿namespace Fixie.Reports
+﻿namespace Fixie.Reports;
+
+using System;
+using System.Text;
+using static System.Environment;
+
+public static class ExceptionExtensions
 {
-    using System;
-    using System.Text;
-    using static System.Environment;
-
-    public static class ExceptionExtensions
+    public static string StackTraceSummary(this Exception exception)
     {
-        public static string StackTraceSummary(this Exception exception)
+        var console = new StringBuilder();
+
+        console.Append(StackTraceOmittingInternalTestMethodFrames(exception));
+
+        var walk = exception;
+        while (walk.InnerException != null)
         {
-            var console = new StringBuilder();
-
-            console.Append(StackTraceOmittingInternalTestMethodFrames(exception));
-
-            var walk = exception;
-            while (walk.InnerException != null)
-            {
-                walk = walk.InnerException;
-                console.AppendLine();
-                console.AppendLine();
-                console.AppendLine($"------- Inner Exception: {walk.GetType().FullName} -------");
-                console.AppendLine(walk.Message);
-                console.Append(walk.StackTrace);
-            }
-
-            return console.ToString();
+            walk = walk.InnerException;
+            console.AppendLine();
+            console.AppendLine();
+            console.AppendLine($"------- Inner Exception: {walk.GetType().FullName} -------");
+            console.AppendLine(walk.Message);
+            console.Append(walk.StackTrace);
         }
 
-        static string? StackTraceOmittingInternalTestMethodFrames(Exception exception)
+        return console.ToString();
+    }
+
+    static string? StackTraceOmittingInternalTestMethodFrames(Exception exception)
+    {
+        // Test failure stack traces can include test runner implementation
+        // details which distract the user in their diagnosing of a test failure.
+        //
+        // Similar to the way that assertion libraries simplify their assertion
+        // exception stack traces to omit implementation details of the assertion
+        // library, we omit these test runner implementation details as well.
+        //
+        // When in a code path where the test runner catches, reports, and stops
+        // propagation of rethrown reflection exceptions, we have an opportunity
+        // to trim that fully-managed rethrow noise from the end of the stack
+        // trace. In any other scenario, we provide the full stack trace as it
+        // will contain end user code relevant to diagnosing the exception.
+
+        if (exception.StackTrace == null)
+            return null;
+
+        var lines = exception.StackTrace.Split(NewLine);
+
+        var totalLines = lines.Length;
+
+        if (totalLines >= 2)
         {
-            // Test failure stack traces can include test runner implementation
-            // details which distract the user in their diagnosing of a test failure.
-            //
-            // Similar to the way that assertion libraries simplify their assertion
-            // exception stack traces to omit implementation details of the assertion
-            // library, we omit these test runner implementation details as well.
-            //
-            // When in a code path where the test runner catches, reports, and stops
-            // propagation of rethrown reflection exceptions, we have an opportunity
-            // to trim that fully-managed rethrow noise from the end of the stack
-            // trace. In any other scenario, we provide the full stack trace as it
-            // will contain end user code relevant to diagnosing the exception.
+            const string subsequentInvoke = " InvokeStub_";
+            const string firstInvoke = " System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
+            const string methodInvoker = " System.Reflection.MethodBaseInvoker.Invoke";
+            const string synchronousRethrowMarker = "--- End of stack trace from previous location";
+            const string callResolvedMethod = " Fixie.MethodInfoExtensions.CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)";
+            const string constructTestClass = " Fixie.Test.Construct(Type testClass)";
+            const string runCore = " Fixie.Test.RunCore(Object instance, Object[] parameters)";
 
-            if (exception.StackTrace == null)
-                return null;
-
-            var lines = exception.StackTrace.Split(NewLine);
-
-            var totalLines = lines.Length;
-
-            if (totalLines >= 2)
+            if (lines[^1].Contains(runCore))
             {
-                const string subsequentInvoke = " InvokeStub_";
-                const string firstInvoke = " System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
-                const string methodInvoker = " System.Reflection.MethodBaseInvoker.Invoke";
-                const string synchronousRethrowMarker = "--- End of stack trace from previous location";
-                const string callResolvedMethod = " Fixie.MethodInfoExtensions.CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)";
-                const string constructTestClass = " Fixie.Test.Construct(Type testClass)";
-                const string runCore = " Fixie.Test.RunCore(Object instance, Object[] parameters)";
-
-                if (lines[^1].Contains(runCore))
+                if (lines[^2].Contains(callResolvedMethod) ||
+                    lines[^2].Contains(constructTestClass))
                 {
-                    if (lines[^2].Contains(callResolvedMethod) ||
-                        lines[^2].Contains(constructTestClass))
-                    {
-                        int linesToRemove = 2;
+                    int linesToRemove = 2;
 
-                        if (totalLines >= 3 && lines[^3].Contains(synchronousRethrowMarker))
+                    if (totalLines >= 3 && lines[^3].Contains(synchronousRethrowMarker))
+                    {
+                        linesToRemove++;
+
+                        if (totalLines >= 4 && lines[^4].Contains(methodInvoker))
                         {
                             linesToRemove++;
 
-                            if (totalLines >= 4 && lines[^4].Contains(methodInvoker))
+                            if (totalLines >= 5)
                             {
-                                linesToRemove++;
-
-                                if (totalLines >= 5)
+                                if (lines[^5].Contains(firstInvoke) ||
+                                    lines[^5].Contains(subsequentInvoke))
                                 {
-                                    if (lines[^5].Contains(firstInvoke) ||
-                                        lines[^5].Contains(subsequentInvoke))
-                                    {
-                                        linesToRemove++;
-                                    }
+                                    linesToRemove++;
                                 }
                             }
                         }
-
-                        return string.Join(NewLine, lines[..^linesToRemove]);
                     }
+
+                    return string.Join(NewLine, lines[..^linesToRemove]);
                 }
             }
-
-            return exception.StackTrace;
         }
+
+        return exception.StackTrace;
     }
 }

--- a/src/Fixie/Reports/ExecutionCompleted.cs
+++ b/src/Fixie/Reports/ExecutionCompleted.cs
@@ -1,44 +1,43 @@
-﻿namespace Fixie.Reports
+﻿namespace Fixie.Reports;
+
+using System;
+using Internal;
+
+/// <summary>
+/// Fired once at the end of the execution phase for the test assembly.
+/// </summary>
+public class ExecutionCompleted : IMessage
 {
-    using System;
-    using Internal;
+    readonly ExecutionSummary summary;
 
-    /// <summary>
-    /// Fired once at the end of the execution phase for the test assembly.
-    /// </summary>
-    public class ExecutionCompleted : IMessage
+    internal ExecutionCompleted(ExecutionSummary summary, TimeSpan duration)
     {
-        readonly ExecutionSummary summary;
-
-        internal ExecutionCompleted(ExecutionSummary summary, TimeSpan duration)
-        {
             Duration = duration;
             this.summary = summary;
         }
 
-        /// <summary>
-        /// The count of passing test results for the test assembly.
-        /// </summary>
-        public int Passed => summary.Passed;
+    /// <summary>
+    /// The count of passing test results for the test assembly.
+    /// </summary>
+    public int Passed => summary.Passed;
         
-        /// <summary>
-        /// The count of failing test results for the test assembly.
-        /// </summary>
-        public int Failed => summary.Failed;
+    /// <summary>
+    /// The count of failing test results for the test assembly.
+    /// </summary>
+    public int Failed => summary.Failed;
         
-        /// <summary>
-        /// The count of skipped test results for the test assembly.
-        /// </summary>
-        public int Skipped => summary.Skipped;
+    /// <summary>
+    /// The count of skipped test results for the test assembly.
+    /// </summary>
+    public int Skipped => summary.Skipped;
         
-        /// <summary>
-        /// The total count of all test results for the test assembly.
-        /// </summary>
-        public int Total => summary.Total;
+    /// <summary>
+    /// The total count of all test results for the test assembly.
+    /// </summary>
+    public int Total => summary.Total;
         
-        /// <summary>
-        /// The total duration of the test assembly execution.
-        /// </summary>
-        public TimeSpan Duration { get; }
-    }
+    /// <summary>
+    /// The total duration of the test assembly execution.
+    /// </summary>
+    public TimeSpan Duration { get; }
 }

--- a/src/Fixie/Reports/ExecutionStarted.cs
+++ b/src/Fixie/Reports/ExecutionStarted.cs
@@ -1,12 +1,11 @@
-﻿namespace Fixie.Reports
+﻿namespace Fixie.Reports;
+
+/// <summary>
+/// Fired once at the start of the execution phase for the test assembly.
+/// </summary>
+public class ExecutionStarted : IMessage
 {
-    /// <summary>
-    /// Fired once at the start of the execution phase for the test assembly.
-    /// </summary>
-    public class ExecutionStarted : IMessage
+    internal ExecutionStarted()
     {
-        internal ExecutionStarted()
-        {
-        }
     }
 }

--- a/src/Fixie/Reports/IHandler.cs
+++ b/src/Fixie/Reports/IHandler.cs
@@ -1,9 +1,8 @@
-﻿namespace Fixie.Reports
-{
-    using System.Threading.Tasks;
+﻿namespace Fixie.Reports;
 
-    public interface IHandler<in TMessage> : IReport where TMessage : IMessage
-    {
-        Task Handle(TMessage message);
-    }
+using System.Threading.Tasks;
+
+public interface IHandler<in TMessage> : IReport where TMessage : IMessage
+{
+    Task Handle(TMessage message);
 }

--- a/src/Fixie/Reports/IMessage.cs
+++ b/src/Fixie/Reports/IMessage.cs
@@ -1,4 +1,3 @@
-﻿namespace Fixie.Reports
-{
-    public interface IMessage { }
-}
+﻿namespace Fixie.Reports;
+
+public interface IMessage { }

--- a/src/Fixie/Reports/IReport.cs
+++ b/src/Fixie/Reports/IReport.cs
@@ -1,4 +1,3 @@
-﻿namespace Fixie.Reports
-{
-    public interface IReport { }
-}
+﻿namespace Fixie.Reports;
+
+public interface IReport { }

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -1,133 +1,132 @@
-﻿namespace Fixie.Reports
+﻿namespace Fixie.Reports;
+
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static System.Environment;
+
+class TeamCityReport :
+    IHandler<ExecutionStarted>,
+    IHandler<TestSkipped>,
+    IHandler<TestPassed>,
+    IHandler<TestFailed>,
+    IHandler<ExecutionCompleted>
 {
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using static System.Environment;
+    readonly TestEnvironment environment;
 
-    class TeamCityReport :
-        IHandler<ExecutionStarted>,
-        IHandler<TestSkipped>,
-        IHandler<TestPassed>,
-        IHandler<TestFailed>,
-        IHandler<ExecutionCompleted>
+    internal static TeamCityReport? Create(TestEnvironment environment)
     {
-        readonly TestEnvironment environment;
+        if (GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null)
+            return new TeamCityReport(environment);
 
-        internal static TeamCityReport? Create(TestEnvironment environment)
-        {
-            if (GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null)
-                return new TeamCityReport(environment);
-
-            return null;
-        }
-
-        public TeamCityReport(TestEnvironment environment)
-        {
-            this.environment = environment;
-        }
-
-        public Task Handle(ExecutionStarted message)
-        {
-            Message("testSuiteStarted name='{0}'", environment.Assembly.GetName().Name);
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestSkipped message)
-        {
-            TestStarted(message);
-            Output(message);
-            Message("testIgnored name='{0}' message='{1}'", message.TestCase, message.Reason);
-            TestFinished(message);
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestPassed message)
-        {
-            TestStarted(message);
-            Output(message);
-            TestFinished(message);
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestFailed message)
-        {
-            var details =
-                message.Reason.GetType().FullName +
-                NewLine +
-                message.Reason.StackTraceSummary();
-
-            TestStarted(message);
-            Output(message);
-            Message("testFailed name='{0}' message='{1}' details='{2}'", message.TestCase, message.Reason.Message, details);
-            TestFinished(message);
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(ExecutionCompleted message)
-        {
-            Message("testSuiteFinished name='{0}'", environment.Assembly.GetName().Name);
-            return Task.CompletedTask;
-        }
-
-        void TestStarted(TestCompleted message)
-        {
-            Message("testStarted name='{0}'", message.TestCase);
-        }
-
-        void TestFinished(TestCompleted message)
-        {
-            Message("testFinished name='{0}' duration='{1}'", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
-        }
-
-        void Message(string format, params string?[] args)
-        {
-            var encodedArgs = args.Select(Encode).Cast<object>().ToArray();
-            environment.Console.WriteLine("##teamcity[" + format + "]", encodedArgs);
-        }
-
-        void Output(TestCompleted message)
-        {
-            if (!string.IsNullOrEmpty(message.Output))
-                Message("testStdOut name='{0}' out='{1}'", message.TestCase, message.Output);
-        }
-
-        static string Encode(string? value)
-        {
-            if (value == null)
-                return "";
-
-            var builder = new StringBuilder();
-
-            foreach (var ch in value)
-            {
-                switch (ch)
-                {
-                    case '|': builder.Append("||"); break;
-                    case '\'': builder.Append("|'"); break;
-                    case '[': builder.Append("|["); break;
-                    case ']': builder.Append("|]"); break;
-                    case '\n': builder.Append("|n"); break;
-                    case '\r': builder.Append("|r"); break;
-                    default:
-                        if (RequiresHexEscape(ch))
-                        {
-                            builder.Append("|0x");
-                            builder.Append(((int) ch).ToString("x4"));
-                        }
-                        else
-                        {
-                            builder.Append(ch);
-                        }
-
-                        break;
-                }
-            }
-
-            return builder.ToString();
-        }
-
-        static bool RequiresHexEscape(char ch)
-            => ch > '\x007f';
+        return null;
     }
+
+    public TeamCityReport(TestEnvironment environment)
+    {
+        this.environment = environment;
+    }
+
+    public Task Handle(ExecutionStarted message)
+    {
+        Message("testSuiteStarted name='{0}'", environment.Assembly.GetName().Name);
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestSkipped message)
+    {
+        TestStarted(message);
+        Output(message);
+        Message("testIgnored name='{0}' message='{1}'", message.TestCase, message.Reason);
+        TestFinished(message);
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestPassed message)
+    {
+        TestStarted(message);
+        Output(message);
+        TestFinished(message);
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestFailed message)
+    {
+        var details =
+            message.Reason.GetType().FullName +
+            NewLine +
+            message.Reason.StackTraceSummary();
+
+        TestStarted(message);
+        Output(message);
+        Message("testFailed name='{0}' message='{1}' details='{2}'", message.TestCase, message.Reason.Message, details);
+        TestFinished(message);
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(ExecutionCompleted message)
+    {
+        Message("testSuiteFinished name='{0}'", environment.Assembly.GetName().Name);
+        return Task.CompletedTask;
+    }
+
+    void TestStarted(TestCompleted message)
+    {
+        Message("testStarted name='{0}'", message.TestCase);
+    }
+
+    void TestFinished(TestCompleted message)
+    {
+        Message("testFinished name='{0}' duration='{1}'", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
+    }
+
+    void Message(string format, params string?[] args)
+    {
+        var encodedArgs = args.Select(Encode).Cast<object>().ToArray();
+        environment.Console.WriteLine("##teamcity[" + format + "]", encodedArgs);
+    }
+
+    void Output(TestCompleted message)
+    {
+        if (!string.IsNullOrEmpty(message.Output))
+            Message("testStdOut name='{0}' out='{1}'", message.TestCase, message.Output);
+    }
+
+    static string Encode(string? value)
+    {
+        if (value == null)
+            return "";
+
+        var builder = new StringBuilder();
+
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                case '|': builder.Append("||"); break;
+                case '\'': builder.Append("|'"); break;
+                case '[': builder.Append("|["); break;
+                case ']': builder.Append("|]"); break;
+                case '\n': builder.Append("|n"); break;
+                case '\r': builder.Append("|r"); break;
+                default:
+                    if (RequiresHexEscape(ch))
+                    {
+                        builder.Append("|0x");
+                        builder.Append(((int) ch).ToString("x4"));
+                    }
+                    else
+                    {
+                        builder.Append(ch);
+                    }
+
+                    break;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    static bool RequiresHexEscape(char ch)
+        => ch > '\x007f';
 }

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -1,86 +1,85 @@
-﻿namespace Fixie.Reports
+﻿namespace Fixie.Reports;
+
+using System;
+using System.Threading.Tasks;
+using Internal;
+
+class TestAdapterReport :
+    IHandler<TestDiscovered>,
+    IHandler<TestStarted>,
+    IHandler<TestSkipped>,
+    IHandler<TestPassed>,
+    IHandler<TestFailed>
 {
-    using System;
-    using System.Threading.Tasks;
-    using Internal;
+    readonly TestAdapterPipe pipe;
 
-    class TestAdapterReport :
-        IHandler<TestDiscovered>,
-        IHandler<TestStarted>,
-        IHandler<TestSkipped>,
-        IHandler<TestPassed>,
-        IHandler<TestFailed>
+    public TestAdapterReport(TestAdapterPipe pipe)
     {
-        readonly TestAdapterPipe pipe;
-
-        public TestAdapterReport(TestAdapterPipe pipe)
-        {
-            this.pipe = pipe;
-        }
-
-        public Task Handle(TestDiscovered message)
-        {
-            Write(new PipeMessage.TestDiscovered
-            {
-                Test = message.Test
-            });
-
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestStarted message)
-        {
-            Write(new PipeMessage.TestStarted
-            {
-                Test = message.Test
-            });
-
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestSkipped message)
-        {
-            Write<PipeMessage.TestSkipped>(message, x =>
-            {
-                x.Reason = message.Reason;
-            });
-
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestPassed message)
-        {
-            Write<PipeMessage.TestPassed>(message);
-
-            return Task.CompletedTask;
-        }
-
-        public Task Handle(TestFailed message)
-        {
-            Write<PipeMessage.TestFailed>(message, x =>
-            {
-                x.Reason = new PipeMessage.Exception(message.Reason);
-            });
-
-            return Task.CompletedTask;
-        }
-
-        void Write<TTestResult>(TestCompleted message, Action<TTestResult>? customize = null)
-            where TTestResult : PipeMessage.TestCompleted, new()
-        {
-            var result = new TTestResult
-            {
-                Test = message.Test,
-                TestCase = message.TestCase,
-                DurationInMilliseconds = message.Duration.TotalMilliseconds,
-                Output = message.Output
-            };
-
-            customize?.Invoke(result);
-
-            Write(result);
-        }
-
-        void Write<T>(T message) => pipe.Send(message);
+        this.pipe = pipe;
     }
+
+    public Task Handle(TestDiscovered message)
+    {
+        Write(new PipeMessage.TestDiscovered
+        {
+            Test = message.Test
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestStarted message)
+    {
+        Write(new PipeMessage.TestStarted
+        {
+            Test = message.Test
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestSkipped message)
+    {
+        Write<PipeMessage.TestSkipped>(message, x =>
+        {
+            x.Reason = message.Reason;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestPassed message)
+    {
+        Write<PipeMessage.TestPassed>(message);
+
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(TestFailed message)
+    {
+        Write<PipeMessage.TestFailed>(message, x =>
+        {
+            x.Reason = new PipeMessage.Exception(message.Reason);
+        });
+
+        return Task.CompletedTask;
+    }
+
+    void Write<TTestResult>(TestCompleted message, Action<TTestResult>? customize = null)
+        where TTestResult : PipeMessage.TestCompleted, new()
+    {
+        var result = new TTestResult
+        {
+            Test = message.Test,
+            TestCase = message.TestCase,
+            DurationInMilliseconds = message.Duration.TotalMilliseconds,
+            Output = message.Output
+        };
+
+        customize?.Invoke(result);
+
+        Write(result);
+    }
+
+    void Write<T>(T message) => pipe.Send(message);
 }

--- a/src/Fixie/Reports/TestCompleted.cs
+++ b/src/Fixie/Reports/TestCompleted.cs
@@ -1,39 +1,38 @@
-namespace Fixie.Reports
-{
-    using System;
+namespace Fixie.Reports;
 
-    public abstract class TestCompleted : IMessage
+using System;
+
+public abstract class TestCompleted : IMessage
+{
+    internal TestCompleted(string test, string testCase, TimeSpan duration, string output)
     {
-        internal TestCompleted(string test, string testCase, TimeSpan duration, string output)
-        {
             Test = test;
             TestCase = testCase;
             Duration = duration;
             Output = output;
         }
 
-        /// <summary>
-        /// The name of the test.
-        /// </summary>
-        public string Test { get; }
+    /// <summary>
+    /// The name of the test.
+    /// </summary>
+    public string Test { get; }
         
-        /// <summary>
-        /// The name of the specific invocation of the test.
-        /// For most tests, this is the same as the `Test` property. For
-        /// parameterized tests, the test case includes additional information
-        /// about the input parameters in effect for this invocation of the
-        /// `Test`.
-        /// </summary>
-        public string TestCase { get; }
+    /// <summary>
+    /// The name of the specific invocation of the test.
+    /// For most tests, this is the same as the `Test` property. For
+    /// parameterized tests, the test case includes additional information
+    /// about the input parameters in effect for this invocation of the
+    /// `Test`.
+    /// </summary>
+    public string TestCase { get; }
         
-        /// <summary>
-        /// The duration of the test execution.
-        /// </summary>
-        public TimeSpan Duration { get; }
+    /// <summary>
+    /// The duration of the test execution.
+    /// </summary>
+    public TimeSpan Duration { get; }
         
-        /// <summary>
-        /// Console output captured during test execution.
-        /// </summary>
-        public string Output { get; }
-    }
+    /// <summary>
+    /// Console output captured during test execution.
+    /// </summary>
+    public string Output { get; }
 }

--- a/src/Fixie/Reports/TestCompleted.cs
+++ b/src/Fixie/Reports/TestCompleted.cs
@@ -6,11 +6,11 @@ public abstract class TestCompleted : IMessage
 {
     internal TestCompleted(string test, string testCase, TimeSpan duration, string output)
     {
-            Test = test;
-            TestCase = testCase;
-            Duration = duration;
-            Output = output;
-        }
+        Test = test;
+        TestCase = testCase;
+        Duration = duration;
+        Output = output;
+    }
 
     /// <summary>
     /// The name of the test.

--- a/src/Fixie/Reports/TestDiscovered.cs
+++ b/src/Fixie/Reports/TestDiscovered.cs
@@ -1,16 +1,15 @@
-﻿namespace Fixie.Reports
-{
-    /// <summary>
-    /// Fired once per discovered test.
-    /// </summary>
-    public class TestDiscovered : IMessage
-    {
-        internal TestDiscovered(string test)
-            => Test = test;
+﻿namespace Fixie.Reports;
 
-        /// <summary>
-        /// The name of the discovered test.
-        /// </summary>
-        public string Test { get; }
-    }
+/// <summary>
+/// Fired once per discovered test.
+/// </summary>
+public class TestDiscovered : IMessage
+{
+    internal TestDiscovered(string test)
+        => Test = test;
+
+    /// <summary>
+    /// The name of the discovered test.
+    /// </summary>
+    public string Test { get; }
 }

--- a/src/Fixie/Reports/TestFailed.cs
+++ b/src/Fixie/Reports/TestFailed.cs
@@ -10,8 +10,8 @@ public class TestFailed : TestCompleted
     internal TestFailed(string test, string testCase, TimeSpan duration, string output, Exception reason)
         : base(test, testCase, duration, output)
     {
-            Reason = reason;
-        }
+        Reason = reason;
+    }
 
     /// <summary>
     /// The uncaught exception indicating test failure, such as from a failed assertion.

--- a/src/Fixie/Reports/TestFailed.cs
+++ b/src/Fixie/Reports/TestFailed.cs
@@ -1,21 +1,20 @@
-﻿namespace Fixie.Reports
-{
-    using System;
+﻿namespace Fixie.Reports;
 
-    /// <summary>
-    /// Fired when an individual test has failed.
-    /// </summary>
-    public class TestFailed : TestCompleted
+using System;
+
+/// <summary>
+/// Fired when an individual test has failed.
+/// </summary>
+public class TestFailed : TestCompleted
+{
+    internal TestFailed(string test, string testCase, TimeSpan duration, string output, Exception reason)
+        : base(test, testCase, duration, output)
     {
-        internal TestFailed(string test, string testCase, TimeSpan duration, string output, Exception reason)
-            : base(test, testCase, duration, output)
-        {
             Reason = reason;
         }
 
-        /// <summary>
-        /// The uncaught exception indicating test failure, such as from a failed assertion.
-        /// </summary>
-        public Exception Reason { get; }
-    }
+    /// <summary>
+    /// The uncaught exception indicating test failure, such as from a failed assertion.
+    /// </summary>
+    public Exception Reason { get; }
 }

--- a/src/Fixie/Reports/TestPassed.cs
+++ b/src/Fixie/Reports/TestPassed.cs
@@ -1,15 +1,14 @@
-﻿namespace Fixie.Reports
-{
-    using System;
+﻿namespace Fixie.Reports;
 
-    /// <summary>
-    /// Fired when an individual test has passed.
-    /// </summary>
-    public class TestPassed : TestCompleted
+using System;
+
+/// <summary>
+/// Fired when an individual test has passed.
+/// </summary>
+public class TestPassed : TestCompleted
+{
+    internal TestPassed(string test, string testCase, TimeSpan duration, string output)
+        : base(test, testCase, duration, output)
     {
-        internal TestPassed(string test, string testCase, TimeSpan duration, string output)
-            : base(test, testCase, duration, output)
-        {
-        }
     }
 }

--- a/src/Fixie/Reports/TestSkipped.cs
+++ b/src/Fixie/Reports/TestSkipped.cs
@@ -1,21 +1,20 @@
-﻿namespace Fixie.Reports
+﻿namespace Fixie.Reports;
+
+using System;
+
+/// <summary>
+/// Fired when an individual test has been skipped.
+/// </summary>
+public class TestSkipped : TestCompleted
 {
-    using System;
+    internal TestSkipped(string test, string testCase, TimeSpan duration, string output, string reason)
+        : base(test, testCase, duration, output)
+    {
+        Reason = reason;
+    }
 
     /// <summary>
-    /// Fired when an individual test has been skipped.
+    /// An explanation for why the test was skipped.
     /// </summary>
-    public class TestSkipped : TestCompleted
-    {
-        internal TestSkipped(string test, string testCase, TimeSpan duration, string output, string reason)
-            : base(test, testCase, duration, output)
-        {
-            Reason = reason;
-        }
-
-        /// <summary>
-        /// An explanation for why the test was skipped.
-        /// </summary>
-        public string Reason { get; }
-    }
+    public string Reason { get; }
 }

--- a/src/Fixie/Reports/TestStarted.cs
+++ b/src/Fixie/Reports/TestStarted.cs
@@ -1,16 +1,15 @@
-﻿namespace Fixie.Reports
-{
-    /// <summary>
-    /// Fired when an individual test has started execution.
-    /// </summary>
-    public class TestStarted : IMessage
-    {
-        internal TestStarted(Test test)
-            => Test = test.Name;
+﻿namespace Fixie.Reports;
 
-        /// <summary>
-        /// The name of the test being executed.
-        /// </summary>
-        public string Test { get; }
-    }
+/// <summary>
+/// Fired when an individual test has started execution.
+/// </summary>
+public class TestStarted : IMessage
+{
+    internal TestStarted(Test test)
+        => Test = test.Name;
+
+    /// <summary>
+    /// The name of the test being executed.
+    /// </summary>
+    public string Test { get; }
 }

--- a/src/Fixie/Reports/XmlReport.cs
+++ b/src/Fixie/Reports/XmlReport.cs
@@ -1,202 +1,201 @@
-﻿namespace Fixie.Reports
-{
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using System.Xml.Linq;
-    using Internal;
+﻿namespace Fixie.Reports;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Internal;
     
-    /// <summary>
-    /// Writes test results to the specified path, using the xUnit XML format.
-    /// </summary>
-    public class XmlReport :
-        IHandler<TestSkipped>,
-        IHandler<TestPassed>,
-        IHandler<TestFailed>,
-        IHandler<ExecutionCompleted>
+/// <summary>
+/// Writes test results to the specified path, using the xUnit XML format.
+/// </summary>
+public class XmlReport :
+    IHandler<TestSkipped>,
+    IHandler<TestPassed>,
+    IHandler<TestFailed>,
+    IHandler<ExecutionCompleted>
+{
+    readonly TestEnvironment environment;
+    readonly Action<XDocument> save;
+
+    readonly SortedDictionary<string, ClassResult> report = new SortedDictionary<string, ClassResult>();
+
+    public XmlReport(TestEnvironment environment, string absoluteOrRelativePath)
+        : this(environment, SaveReport(environment, absoluteOrRelativePath))
     {
-        readonly TestEnvironment environment;
-        readonly Action<XDocument> save;
+    }
 
-        readonly SortedDictionary<string, ClassResult> report = new SortedDictionary<string, ClassResult>();
+    static Action<XDocument> SaveReport(TestEnvironment environment, string absoluteOrRelativePath)
+    {
+        return report => Save(report, FullPath(environment, absoluteOrRelativePath));
+    }
 
-        public XmlReport(TestEnvironment environment, string absoluteOrRelativePath)
-            : this(environment, SaveReport(environment, absoluteOrRelativePath))
-        {
-        }
+    static string FullPath(TestEnvironment environment, string absoluteOrRelativePath)
+    {
+        return Path.Combine(environment.RootPath, absoluteOrRelativePath);
+    }
 
-        static Action<XDocument> SaveReport(TestEnvironment environment, string absoluteOrRelativePath)
-        {
-            return report => Save(report, FullPath(environment, absoluteOrRelativePath));
-        }
+    internal XmlReport(TestEnvironment environment, Action<XDocument> save)
+    {
+        this.environment = environment;
+        this.save = save;
+    }
 
-        static string FullPath(TestEnvironment environment, string absoluteOrRelativePath)
-        {
-            return Path.Combine(environment.RootPath, absoluteOrRelativePath);
-        }
+    public Task Handle(TestSkipped message)
+    {
+        ForClass(message).Add(message);
+        return Task.CompletedTask;
+    }
 
-        internal XmlReport(TestEnvironment environment, Action<XDocument> save)
-        {
-            this.environment = environment;
-            this.save = save;
-        }
+    public Task Handle(TestPassed message)
+    {
+        ForClass(message).Add(message);
+        return Task.CompletedTask;
+    }
 
-        public Task Handle(TestSkipped message)
-        {
-            ForClass(message).Add(message);
-            return Task.CompletedTask;
-        }
+    public Task Handle(TestFailed message)
+    {
+        ForClass(message).Add(message);
+        return Task.CompletedTask;
+    }
 
-        public Task Handle(TestPassed message)
-        {
-            ForClass(message).Add(message);
-            return Task.CompletedTask;
-        }
+    ClassResult ForClass(TestCompleted message)
+    {
+        Parse(message.Test, out var type, out _);
 
-        public Task Handle(TestFailed message)
-        {
-            ForClass(message).Add(message);
-            return Task.CompletedTask;
-        }
+        if (!report.ContainsKey(type))
+            report.Add(type, new ClassResult(type));
 
-        ClassResult ForClass(TestCompleted message)
-        {
-            Parse(message.Test, out var type, out _);
+        return report[type];
+    }
 
-            if (!report.ContainsKey(type))
-                report.Add(type, new ClassResult(type));
+    public Task Handle(ExecutionCompleted message)
+    {
+        var now = DateTime.UtcNow;
 
-            return report[type];
-        }
+        save(new XDocument(
+            new XElement("assemblies",
+                new XElement("assembly",
+                    new XAttribute("name", environment.Assembly.Location),
+                    new XAttribute("run-date", now.ToString("yyyy-MM-dd")),
+                    new XAttribute("run-time", now.ToString("HH:mm:ss")),
+                    new XAttribute("time", Seconds(message.Duration)),
+                    new XAttribute("total", message.Total),
+                    new XAttribute("passed", message.Passed),
+                    new XAttribute("failed", message.Failed),
+                    new XAttribute("skipped", message.Skipped),
+                    new XAttribute("environment", $"{IntPtr.Size * 8}-bit {environment.TargetFramework}"),
+                    new XAttribute("test-framework", Internal.Framework.Version),
+                    report.Values.Select(x => x.ToElement())))));
 
-        public Task Handle(ExecutionCompleted message)
-        {
-            var now = DateTime.UtcNow;
+        report.Clear();
 
-            save(new XDocument(
-                new XElement("assemblies",
-                    new XElement("assembly",
-                        new XAttribute("name", environment.Assembly.Location),
-                        new XAttribute("run-date", now.ToString("yyyy-MM-dd")),
-                        new XAttribute("run-time", now.ToString("HH:mm:ss")),
-                        new XAttribute("time", Seconds(message.Duration)),
-                        new XAttribute("total", message.Total),
-                        new XAttribute("passed", message.Passed),
-                        new XAttribute("failed", message.Failed),
-                        new XAttribute("skipped", message.Skipped),
-                        new XAttribute("environment", $"{IntPtr.Size * 8}-bit {environment.TargetFramework}"),
-                        new XAttribute("test-framework", Internal.Framework.Version),
-                        report.Values.Select(x => x.ToElement())))));
+        return Task.CompletedTask;
+    }
 
-            report.Clear();
+    static string Seconds(TimeSpan duration)
+    {
+        //The XML Schema spec requires decimal values to use a culture-ignorant format.
+        return FormattableString.Invariant($"{duration.TotalSeconds:0.000}");
+    }
 
-            return Task.CompletedTask;
-        }
+    static void Save(XDocument report, string path)
+    {
+        var directory = Path.GetDirectoryName(path);
 
-        static string Seconds(TimeSpan duration)
-        {
-            //The XML Schema spec requires decimal values to use a culture-ignorant format.
-            return FormattableString.Invariant($"{duration.TotalSeconds:0.000}");
-        }
+        if (string.IsNullOrEmpty(directory))
+            return;
 
-        static void Save(XDocument report, string path)
-        {
-            var directory = Path.GetDirectoryName(path);
+        Directory.CreateDirectory(directory);
 
-            if (string.IsNullOrEmpty(directory))
-                return;
+        using var stream = new FileStream(path, FileMode.Create);
+        using var writer = new StreamWriter(stream);
+        report.Save(writer, SaveOptions.None);
+    }
 
-            Directory.CreateDirectory(directory);
+    class ClassResult
+    {
+        readonly string name;
+        TimeSpan duration = TimeSpan.Zero;
+        readonly List<XElement> results = new List<XElement>();
+        readonly ExecutionSummary summary = new ExecutionSummary();
 
-            using var stream = new FileStream(path, FileMode.Create);
-            using var writer = new StreamWriter(stream);
-            report.Save(writer, SaveOptions.None);
-        }
-
-        class ClassResult
-        {
-            readonly string name;
-            TimeSpan duration = TimeSpan.Zero;
-            readonly List<XElement> results = new List<XElement>();
-            readonly ExecutionSummary summary = new ExecutionSummary();
-
-            public ClassResult(string name) => this.name = name;
+        public ClassResult(string name) => this.name = name;
             
-            public void Add(TestSkipped message)
-            {
-                duration += message.Duration;
-                summary.Add(message);
-
-                Parse(message.Test, out var type, out var method);
-
-                var test = new XElement("test",
-                        new XAttribute("name", message.TestCase),
-                        new XAttribute("type", type),
-                        new XAttribute("method", method),
-                        new XAttribute("result", "Skip"),
-                        new XAttribute("time", Seconds(message.Duration)));
-
-                test.Add(new XElement("reason", new XCData(message.Reason)));
-
-                results.Add(test);
-            }
-
-            public void Add(TestPassed message)
-            {
-                duration += message.Duration;
-                summary.Add(message);
-
-                Parse(message.Test, out var type, out var method);
-
-                results.Add(
-                    new XElement("test",
-                        new XAttribute("name", message.TestCase),
-                        new XAttribute("type", type),
-                        new XAttribute("method", method),
-                        new XAttribute("result", "Pass"),
-                        new XAttribute("time", Seconds(message.Duration))));
-            }
-
-            public void Add(TestFailed message)
-            {
-                duration += message.Duration;
-                summary.Add(message);
-
-                Parse(message.Test, out var type, out var method);
-
-                results.Add(
-                    new XElement("test",
-                        new XAttribute("name", message.TestCase),
-                        new XAttribute("type", type),
-                        new XAttribute("method", method),
-                        new XAttribute("result", "Fail"),
-                        new XAttribute("time", Seconds(message.Duration)),
-                        new XElement("failure",
-                            new XAttribute("exception-type", message.Reason.GetType().FullName!),
-                            new XElement("message", new XCData(message.Reason.Message)),
-                            new XElement("stack-trace", new XCData(message.Reason.StackTraceSummary())))));
-            }
-
-            public XElement ToElement()
-            {
-                return new XElement("collection",
-                    new XAttribute("time", Seconds(duration)),
-                    new XAttribute("name", name),
-                    new XAttribute("total", summary.Total),
-                    new XAttribute("passed", summary.Passed),
-                    new XAttribute("failed", summary.Failed),
-                    new XAttribute("skipped", summary.Skipped),
-                    results);
-            }
-        }
-
-        static void Parse(string fullName, out string className, out string methodName)
+        public void Add(TestSkipped message)
         {
-            var indexOfMemberSeparator = fullName.LastIndexOf(".");
-            className = fullName.Substring(0, indexOfMemberSeparator);
-            methodName = fullName.Substring(indexOfMemberSeparator + 1);
+            duration += message.Duration;
+            summary.Add(message);
+
+            Parse(message.Test, out var type, out var method);
+
+            var test = new XElement("test",
+                new XAttribute("name", message.TestCase),
+                new XAttribute("type", type),
+                new XAttribute("method", method),
+                new XAttribute("result", "Skip"),
+                new XAttribute("time", Seconds(message.Duration)));
+
+            test.Add(new XElement("reason", new XCData(message.Reason)));
+
+            results.Add(test);
         }
+
+        public void Add(TestPassed message)
+        {
+            duration += message.Duration;
+            summary.Add(message);
+
+            Parse(message.Test, out var type, out var method);
+
+            results.Add(
+                new XElement("test",
+                    new XAttribute("name", message.TestCase),
+                    new XAttribute("type", type),
+                    new XAttribute("method", method),
+                    new XAttribute("result", "Pass"),
+                    new XAttribute("time", Seconds(message.Duration))));
+        }
+
+        public void Add(TestFailed message)
+        {
+            duration += message.Duration;
+            summary.Add(message);
+
+            Parse(message.Test, out var type, out var method);
+
+            results.Add(
+                new XElement("test",
+                    new XAttribute("name", message.TestCase),
+                    new XAttribute("type", type),
+                    new XAttribute("method", method),
+                    new XAttribute("result", "Fail"),
+                    new XAttribute("time", Seconds(message.Duration)),
+                    new XElement("failure",
+                        new XAttribute("exception-type", message.Reason.GetType().FullName!),
+                        new XElement("message", new XCData(message.Reason.Message)),
+                        new XElement("stack-trace", new XCData(message.Reason.StackTraceSummary())))));
+        }
+
+        public XElement ToElement()
+        {
+            return new XElement("collection",
+                new XAttribute("time", Seconds(duration)),
+                new XAttribute("name", name),
+                new XAttribute("total", summary.Total),
+                new XAttribute("passed", summary.Passed),
+                new XAttribute("failed", summary.Failed),
+                new XAttribute("skipped", summary.Skipped),
+                results);
+        }
+    }
+
+    static void Parse(string fullName, out string className, out string methodName)
+    {
+        var indexOfMemberSeparator = fullName.LastIndexOf(".");
+        className = fullName.Substring(0, indexOfMemberSeparator);
+        methodName = fullName.Substring(indexOfMemberSeparator + 1);
     }
 }

--- a/src/Fixie/ShuffleExtensions.cs
+++ b/src/Fixie/ShuffleExtensions.cs
@@ -1,41 +1,40 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class ShuffleExtensions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
-    public static class ShuffleExtensions
+    /// <summary>
+    /// Randomizes the order of the given items.
+    /// </summary>
+    public static IReadOnlyList<T> Shuffle<T>(this IEnumerable<T> items)
     {
-        /// <summary>
-        /// Randomizes the order of the given items.
-        /// </summary>
-        public static IReadOnlyList<T> Shuffle<T>(this IEnumerable<T> items)
+        return items.Shuffle(new Random());
+    }
+
+    /// <summary>
+    /// Randomizes the order of the given items, using the given pseudo-random number generator.
+    /// </summary>
+    public static IReadOnlyList<T> Shuffle<T>(this IEnumerable<T> items, Random random)
+    {
+        var array = items.ToList();
+
+        FisherYatesShuffle(array, random);
+
+        return array;
+    }
+
+    static void FisherYatesShuffle<T>(IList<T> array, Random random)
+    {
+        int n = array.Count;
+        while (n > 1)
         {
-            return items.Shuffle(new Random());
-        }
-
-        /// <summary>
-        /// Randomizes the order of the given items, using the given pseudo-random number generator.
-        /// </summary>
-        public static IReadOnlyList<T> Shuffle<T>(this IEnumerable<T> items, Random random)
-        {
-            var array = items.ToList();
-
-            FisherYatesShuffle(array, random);
-
-            return array;
-        }
-
-        static void FisherYatesShuffle<T>(IList<T> array, Random random)
-        {
-            int n = array.Count;
-            while (n > 1)
-            {
-                int k = random.Next(n--);
-                T temp = array[n];
-                array[n] = array[k];
-                array[k] = temp;
-            }
+            int k = random.Next(n--);
+            T temp = array[n];
+            array[n] = array[k];
+            array[k] = temp;
         }
     }
 }

--- a/src/Fixie/Test.cs
+++ b/src/Fixie/Test.cs
@@ -1,220 +1,219 @@
-namespace Fixie
+namespace Fixie;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using Internal;
+
+public class Test
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
-    using System.Reflection;
-    using System.Runtime.ExceptionServices;
-    using System.Threading.Tasks;
-    using Internal;
+    static readonly object[] EmptyParameters = {};
 
-    public class Test
+    readonly ExecutionRecorder recorder;
+
+    internal Test(ExecutionRecorder recorder, MethodInfo method)
     {
-        static readonly object[] EmptyParameters = {};
-
-        readonly ExecutionRecorder recorder;
-
-        internal Test(ExecutionRecorder recorder, MethodInfo method)
-        {
-            this.recorder = recorder;
-            Name = method.TestName();
-            Method = method;
-            RecordedResult = false;
-        }
-
-        /// <summary>
-        /// Gets the full name of the test. Note that the full name of an individual test
-        /// <em>case</em> may further clarify this name with parameters and/or generic type
-        /// parameters.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Gets the parameters of the test.
-        /// </summary>
-        public ParameterInfo[] Parameters => cachedParameters ??= Method.GetParameters();
-        ParameterInfo[]? cachedParameters;
-
-        /// <summary>
-        /// Determines whether the test is parameterized.
-        /// </summary>
-        public bool HasParameters => Parameters.Length > 0;
-
-        /// <summary>
-        /// The method that defines this test.
-        /// </summary>
-        public MethodInfo Method { get; }
-
-        internal bool RecordedResult { get; private set; }
-
-        /// <summary>
-        /// Determines whether any attributes of the specified type are applied to the test declaration.
-        /// </summary>
-        public bool Has<TAttribute>() where TAttribute : Attribute
-            => Method.Has<TAttribute>();
-
-        /// <summary>
-        /// Determines whether an attribute of the specified type is applied to the test declaration,
-        /// providing that attribute as an `out` parameter when found.
-        /// </summary>
-        public bool Has<TAttribute>([NotNullWhen(true)] out TAttribute? matchingAttribute) where TAttribute : Attribute
-            => Method.Has(out matchingAttribute);
-
-        /// <summary>
-        /// Gets all attributes of the specified type that are applied to the test declaration.
-        /// </summary>
-        public TAttribute[] GetAll<TAttribute>() where TAttribute : Attribute
-            => Method.GetCustomAttributes<TAttribute>(true).ToArray();
-
-        /// <summary>
-        /// Runs the test. The test will be run against a new instance of the test class, using
-        /// its default constructor.
-        /// </summary> 
-        public Task<TestResult> Run()
-        {
-            return RunCore(instance: null, EmptyParameters);
-        }
-
-        /// <summary>
-        /// Runs the test, using the given input parameters. The test will be run against a new
-        /// instance of the test class, using its default constructor.
-        /// </summary>
-        public Task<TestResult> Run(object?[] parameters)
-        {
-            return RunCore(instance: null, parameters);
-        }
-
-        /// <summary>
-        /// Runs the test against the given test class instance.
-        /// </summary>
-        public Task<TestResult> Run(object instance)
-        {
-            return RunCore(instance, EmptyParameters);
-        }
-
-        /// <summary>
-        /// Runs the test against the given test class instance, using
-        /// the given input parameters.
-        /// </summary>
-        public Task<TestResult> Run(object instance, object?[] parameters)
-        {
-            return RunCore(instance, parameters);
-        }
-
-        /// <summary>
-        /// Emits a start event for this test.
-        /// </summary>
-        public async Task Start()
-        {
-            await recorder.Start(this);
-        }
-
-        /// <summary>
-        /// Emits a pass result for this test.
-        /// </summary>
-        public async Task Pass()
-        {
-            await Pass(EmptyParameters);
-        }
-
-        /// <summary>
-        /// Emits a pass result for this test case.
-        /// </summary>
-        public async Task Pass(object?[] parameters)
-        {
-            var name = GetName(Method, parameters);
-
-            await recorder.Pass(this, name);
-
-            RecordedResult = true;
-        }
-
-        /// <summary>
-        /// Emits a skip result for this test, with the given reason.
-        /// </summary>
-        public async Task Skip(string reason)
-        {
-            await Skip(EmptyParameters, reason);
-        }
-
-        /// <summary>
-        /// Emits a skip result for this test case, with the given reason.
-        /// </summary>
-        public async Task Skip(object?[] parameters, string reason)
-        {
-            var name = GetName(Method, parameters);
-
-            if (string.IsNullOrWhiteSpace(reason))
-                reason = "This test was explicitly skipped, but no reason was provided.";
-
-            await recorder.Skip(this, name, reason);
-
-            RecordedResult = true;
-        }
-
-        /// <summary>
-        /// Emits a failure result for this test, with the given reason.
-        /// </summary>
-        public async Task Fail(Exception reason)
-        {
-            await Fail(EmptyParameters, reason);
-        }
-
-        /// <summary>
-        /// Emits a failure result for this test case, with the given reason.
-        /// </summary>
-        public async Task Fail(object?[] parameters, Exception reason)
-        {
-            if (reason == null)
-                throw new ArgumentNullException(nameof(reason));
-
-            var name = GetName(Method, parameters);
-
-            await recorder.Fail(this, name, reason);
-
-            RecordedResult = true;
-        }
-
-        async Task<TestResult> RunCore(object? instance, object?[] parameters)
-        {
-            var resolvedMethod = Method.TryResolveTypeArguments(parameters);
-            var name = CaseNameBuilder.GetName(resolvedMethod, parameters);
-
-            await recorder.Start(this);
-
-            try
-            {
-                if (instance == null && !resolvedMethod.IsStatic)
-                    instance = Construct(resolvedMethod.ReflectedType!);
-
-                await resolvedMethod.CallResolvedMethod(instance, parameters);
-            }
-            catch (Exception failureReason)
-            {
-                await recorder.Fail(this, name, failureReason);
-                RecordedResult = true;
-                return TestResult.Failed(failureReason);
-            }
-
-            await recorder.Pass(this, name);
-            RecordedResult = true;
-            return TestResult.Passed;
-        }
-
-        static object? Construct(Type testClass)
-        {
-            try
-            {
-                return Activator.CreateInstance(testClass);
-            }
-            catch (TargetInvocationException exception)
-            {
-                ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
-                throw; // Unreachable.
-            }
-        }
-
-        static string GetName(MethodInfo method, object?[] parameters)
-            => CaseNameBuilder.GetName(method.TryResolveTypeArguments(parameters), parameters);
+        this.recorder = recorder;
+        Name = method.TestName();
+        Method = method;
+        RecordedResult = false;
     }
+
+    /// <summary>
+    /// Gets the full name of the test. Note that the full name of an individual test
+    /// <em>case</em> may further clarify this name with parameters and/or generic type
+    /// parameters.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the parameters of the test.
+    /// </summary>
+    public ParameterInfo[] Parameters => cachedParameters ??= Method.GetParameters();
+    ParameterInfo[]? cachedParameters;
+
+    /// <summary>
+    /// Determines whether the test is parameterized.
+    /// </summary>
+    public bool HasParameters => Parameters.Length > 0;
+
+    /// <summary>
+    /// The method that defines this test.
+    /// </summary>
+    public MethodInfo Method { get; }
+
+    internal bool RecordedResult { get; private set; }
+
+    /// <summary>
+    /// Determines whether any attributes of the specified type are applied to the test declaration.
+    /// </summary>
+    public bool Has<TAttribute>() where TAttribute : Attribute
+        => Method.Has<TAttribute>();
+
+    /// <summary>
+    /// Determines whether an attribute of the specified type is applied to the test declaration,
+    /// providing that attribute as an `out` parameter when found.
+    /// </summary>
+    public bool Has<TAttribute>([NotNullWhen(true)] out TAttribute? matchingAttribute) where TAttribute : Attribute
+        => Method.Has(out matchingAttribute);
+
+    /// <summary>
+    /// Gets all attributes of the specified type that are applied to the test declaration.
+    /// </summary>
+    public TAttribute[] GetAll<TAttribute>() where TAttribute : Attribute
+        => Method.GetCustomAttributes<TAttribute>(true).ToArray();
+
+    /// <summary>
+    /// Runs the test. The test will be run against a new instance of the test class, using
+    /// its default constructor.
+    /// </summary> 
+    public Task<TestResult> Run()
+    {
+        return RunCore(instance: null, EmptyParameters);
+    }
+
+    /// <summary>
+    /// Runs the test, using the given input parameters. The test will be run against a new
+    /// instance of the test class, using its default constructor.
+    /// </summary>
+    public Task<TestResult> Run(object?[] parameters)
+    {
+        return RunCore(instance: null, parameters);
+    }
+
+    /// <summary>
+    /// Runs the test against the given test class instance.
+    /// </summary>
+    public Task<TestResult> Run(object instance)
+    {
+        return RunCore(instance, EmptyParameters);
+    }
+
+    /// <summary>
+    /// Runs the test against the given test class instance, using
+    /// the given input parameters.
+    /// </summary>
+    public Task<TestResult> Run(object instance, object?[] parameters)
+    {
+        return RunCore(instance, parameters);
+    }
+
+    /// <summary>
+    /// Emits a start event for this test.
+    /// </summary>
+    public async Task Start()
+    {
+        await recorder.Start(this);
+    }
+
+    /// <summary>
+    /// Emits a pass result for this test.
+    /// </summary>
+    public async Task Pass()
+    {
+        await Pass(EmptyParameters);
+    }
+
+    /// <summary>
+    /// Emits a pass result for this test case.
+    /// </summary>
+    public async Task Pass(object?[] parameters)
+    {
+        var name = GetName(Method, parameters);
+
+        await recorder.Pass(this, name);
+
+        RecordedResult = true;
+    }
+
+    /// <summary>
+    /// Emits a skip result for this test, with the given reason.
+    /// </summary>
+    public async Task Skip(string reason)
+    {
+        await Skip(EmptyParameters, reason);
+    }
+
+    /// <summary>
+    /// Emits a skip result for this test case, with the given reason.
+    /// </summary>
+    public async Task Skip(object?[] parameters, string reason)
+    {
+        var name = GetName(Method, parameters);
+
+        if (string.IsNullOrWhiteSpace(reason))
+            reason = "This test was explicitly skipped, but no reason was provided.";
+
+        await recorder.Skip(this, name, reason);
+
+        RecordedResult = true;
+    }
+
+    /// <summary>
+    /// Emits a failure result for this test, with the given reason.
+    /// </summary>
+    public async Task Fail(Exception reason)
+    {
+        await Fail(EmptyParameters, reason);
+    }
+
+    /// <summary>
+    /// Emits a failure result for this test case, with the given reason.
+    /// </summary>
+    public async Task Fail(object?[] parameters, Exception reason)
+    {
+        if (reason == null)
+            throw new ArgumentNullException(nameof(reason));
+
+        var name = GetName(Method, parameters);
+
+        await recorder.Fail(this, name, reason);
+
+        RecordedResult = true;
+    }
+
+    async Task<TestResult> RunCore(object? instance, object?[] parameters)
+    {
+        var resolvedMethod = Method.TryResolveTypeArguments(parameters);
+        var name = CaseNameBuilder.GetName(resolvedMethod, parameters);
+
+        await recorder.Start(this);
+
+        try
+        {
+            if (instance == null && !resolvedMethod.IsStatic)
+                instance = Construct(resolvedMethod.ReflectedType!);
+
+            await resolvedMethod.CallResolvedMethod(instance, parameters);
+        }
+        catch (Exception failureReason)
+        {
+            await recorder.Fail(this, name, failureReason);
+            RecordedResult = true;
+            return TestResult.Failed(failureReason);
+        }
+
+        await recorder.Pass(this, name);
+        RecordedResult = true;
+        return TestResult.Passed;
+    }
+
+    static object? Construct(Type testClass)
+    {
+        try
+        {
+            return Activator.CreateInstance(testClass);
+        }
+        catch (TargetInvocationException exception)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
+            throw; // Unreachable.
+        }
+    }
+
+    static string GetName(MethodInfo method, object?[] parameters)
+        => CaseNameBuilder.GetName(method.TryResolveTypeArguments(parameters), parameters);
 }

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -1,66 +1,65 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+
+public class TestClass
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Reflection;
-    using System.Runtime.ExceptionServices;
-    using System.Threading.Tasks;
-
-    public class TestClass
+    internal TestClass(Type type, IReadOnlyList<Test> tests)
     {
-        internal TestClass(Type type, IReadOnlyList<Test> tests)
+        Type = type;
+        Tests = tests;
+    }
+
+    /// <summary>
+    /// The test class under execution.
+    /// </summary>
+    public Type Type { get; }
+
+    /// <summary>
+    /// The tests under execution as discovered on this test class.
+    /// </summary>
+    public IReadOnlyList<Test> Tests { get; }
+
+    /// <summary>
+    /// Constructs an instance of the test class using
+    /// the constructor that best matches the specified
+    /// parameters.
+    /// </summary>
+    public object Construct(params object?[] parameters)
+    {
+        object? instance;
+
+        try
         {
-            Type = type;
-            Tests = tests;
+            instance = Activator.CreateInstance(Type, parameters);
+        }
+        catch (TargetInvocationException exception)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
+            throw; // Unreachable.
         }
 
-        /// <summary>
-        /// The test class under execution.
-        /// </summary>
-        public Type Type { get; }
-
-        /// <summary>
-        /// The tests under execution as discovered on this test class.
-        /// </summary>
-        public IReadOnlyList<Test> Tests { get; }
-
-        /// <summary>
-        /// Constructs an instance of the test class using
-        /// the constructor that best matches the specified
-        /// parameters.
-        /// </summary>
-        public object Construct(params object?[] parameters)
+        if (instance == null)
         {
-            object? instance;
-
-            try
-            {
-                instance = Activator.CreateInstance(Type, parameters);
-            }
-            catch (TargetInvocationException exception)
-            {
-                ExceptionDispatchInfo.Capture(exception.InnerException!).Throw();
-                throw; // Unreachable.
-            }
-
-            if (instance == null)
-            {
-                throw new InvalidOperationException(
-                    "An attempt to construct an instance of test class '" +
-                    Type.FullName +
-                    "' unexpectedly resulted in null.");
-            }
-
-            return instance;
+            throw new InvalidOperationException(
+                "An attempt to construct an instance of test class '" +
+                Type.FullName +
+                "' unexpectedly resulted in null.");
         }
 
-        /// <summary>
-        /// Emits failure results for all tests in the test class, with the given reason.
-        /// </summary>
-        public async Task Fail(Exception reason)
-        {
-            foreach (var test in Tests)
-                await test.Fail(reason);
-        }
+        return instance;
+    }
+
+    /// <summary>
+    /// Emits failure results for all tests in the test class, with the given reason.
+    /// </summary>
+    public async Task Fail(Exception reason)
+    {
+        foreach (var test in Tests)
+            await test.Fail(reason);
     }
 }

--- a/src/Fixie/TestConfiguration.cs
+++ b/src/Fixie/TestConfiguration.cs
@@ -1,8 +1,7 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+public class TestConfiguration
 {
-    public class TestConfiguration
-    {
-        public ConventionCollection Conventions { get; } = new ConventionCollection();
-        public ReportCollection Reports { get; } = new ReportCollection();
-    }
+    public ConventionCollection Conventions { get; } = new ConventionCollection();
+    public ReportCollection Reports { get; } = new ReportCollection();
 }

--- a/src/Fixie/TestEnvironment.cs
+++ b/src/Fixie/TestEnvironment.cs
@@ -1,74 +1,73 @@
-﻿namespace Fixie
+﻿namespace Fixie;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Versioning;
+using static System.Environment;
+
+public class TestEnvironment
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Reflection;
-    using System.Runtime.Versioning;
-    using static System.Environment;
+    internal TestEnvironment(Assembly assembly, TextWriter console, string rootPath)
+        : this(assembly, console, rootPath, Array.Empty<string>()) { }
 
-    public class TestEnvironment
+    internal TestEnvironment(Assembly assembly, TextWriter console, string rootPath,
+        IReadOnlyList<string> customArguments)
     {
-        internal TestEnvironment(Assembly assembly, TextWriter console, string rootPath)
-            : this(assembly, console, rootPath, Array.Empty<string>()) { }
-
-        internal TestEnvironment(Assembly assembly, TextWriter console, string rootPath,
-            IReadOnlyList<string> customArguments)
-        {
             Assembly = assembly;
             CustomArguments = customArguments;
             Console = console;
             RootPath = rootPath;
         }
 
-        /// <summary>
-        /// The test assembly being executed.
-        /// </summary>
-        public Assembly Assembly { get; }
+    /// <summary>
+    /// The test assembly being executed.
+    /// </summary>
+    public Assembly Assembly { get; }
 
-        /// <summary>
-        /// Identifies the target framework value that the test assembly was compiled against.
-        /// </summary>
-        public string? TargetFramework
-            => Assembly
-                .GetCustomAttribute<TargetFrameworkAttribute>()?
-                .FrameworkName;
+    /// <summary>
+    /// Identifies the target framework value that the test assembly was compiled against.
+    /// </summary>
+    public string? TargetFramework
+        => Assembly
+            .GetCustomAttribute<TargetFrameworkAttribute>()?
+            .FrameworkName;
 
-        /// <summary>
-        /// Optional custom command line arguments provided to the test runner.
-        /// </summary>
-        public IReadOnlyList<string> CustomArguments { get; }
+    /// <summary>
+    /// Optional custom command line arguments provided to the test runner.
+    /// </summary>
+    public IReadOnlyList<string> CustomArguments { get; }
 
-        /// <summary>
-        /// The standard output stream. Use this to reliably write to the test
-        /// runner's original standard output stream, even if tests or the
-        /// system under test have redirected System.Console.Out.
-        /// </summary>
-        public TextWriter Console { get; }
+    /// <summary>
+    /// The standard output stream. Use this to reliably write to the test
+    /// runner's original standard output stream, even if tests or the
+    /// system under test have redirected System.Console.Out.
+    /// </summary>
+    public TextWriter Console { get; }
         
-        /// <summary>
-        /// The absolute path to the directory containing the test assembly.
-        /// </summary>
-        public string RootPath { get; }
+    /// <summary>
+    /// The absolute path to the directory containing the test assembly.
+    /// </summary>
+    public string RootPath { get; }
 
-        /// <summary>
-        /// Returns true when running in a local development environment. See its
-        /// inverse, IsContinuousIntegration().
-        /// </summary>
-        /// <returns></returns>
-        public bool IsDevelopment() => !IsContinuousIntegration();
+    /// <summary>
+    /// Returns true when running in a local development environment. See its
+    /// inverse, IsContinuousIntegration().
+    /// </summary>
+    /// <returns></returns>
+    public bool IsDevelopment() => !IsContinuousIntegration();
 
-        /// <summary>
-        /// Returns true when running in a recognized Continuous Integration environment:
-        /// AppVeyor, Azure DevOps, GitHub Actions, or TeamCity.
-        /// </summary>
-        public bool IsContinuousIntegration()
-        {
+    /// <summary>
+    /// Returns true when running in a recognized Continuous Integration environment:
+    /// AppVeyor, Azure DevOps, GitHub Actions, or TeamCity.
+    /// </summary>
+    public bool IsContinuousIntegration()
+    {
             return 
                 GetEnvironmentVariable("APPVEYOR") == "True" ||          // AppVeyor
                 GetEnvironmentVariable("TF_BUILD") == "True" ||          // Azure DevOps
                 GetEnvironmentVariable("GITHUB_ACTIONS") == "true" ||    // GitHub Actions
                 GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null; // TeamCity
         }
-    }
 }

--- a/src/Fixie/TestEnvironment.cs
+++ b/src/Fixie/TestEnvironment.cs
@@ -15,11 +15,11 @@ public class TestEnvironment
     internal TestEnvironment(Assembly assembly, TextWriter console, string rootPath,
         IReadOnlyList<string> customArguments)
     {
-            Assembly = assembly;
-            CustomArguments = customArguments;
-            Console = console;
-            RootPath = rootPath;
-        }
+        Assembly = assembly;
+        CustomArguments = customArguments;
+        Console = console;
+        RootPath = rootPath;
+    }
 
     /// <summary>
     /// The test assembly being executed.
@@ -64,10 +64,10 @@ public class TestEnvironment
     /// </summary>
     public bool IsContinuousIntegration()
     {
-            return 
-                GetEnvironmentVariable("APPVEYOR") == "True" ||          // AppVeyor
-                GetEnvironmentVariable("TF_BUILD") == "True" ||          // Azure DevOps
-                GetEnvironmentVariable("GITHUB_ACTIONS") == "true" ||    // GitHub Actions
-                GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null; // TeamCity
-        }
+        return 
+            GetEnvironmentVariable("APPVEYOR") == "True" ||          // AppVeyor
+            GetEnvironmentVariable("TF_BUILD") == "True" ||          // Azure DevOps
+            GetEnvironmentVariable("GITHUB_ACTIONS") == "true" ||    // GitHub Actions
+            GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null; // TeamCity
+    }
 }

--- a/src/Fixie/TestResult.cs
+++ b/src/Fixie/TestResult.cs
@@ -1,39 +1,38 @@
-namespace Fixie
+namespace Fixie;
+
+using System;
+
+/// <summary>
+/// A discriminated union representing the result of a single run of a test.
+/// <para>Use pattern matching to inspect:</para>
+/// <list type="bullet">
+///     <item>Passed</item>
+///     <item>Failed (Exception Reason)</item>
+/// </list>
+/// </summary>
+public abstract class TestResult
 {
-    using System;
+    internal static readonly Passed Passed = new Passed();
+    internal static Failed Failed(Exception reason) => new Failed(reason);
+}
+
+/// <summary>
+/// Represents the fact that a test has passed.
+/// </summary>
+public class Passed : TestResult
+{
+    internal Passed() { }
+}
+
+/// <summary>
+/// Represents the fact that a test has failed due to its throwing an exception.
+/// </summary>
+public class Failed : TestResult
+{
+    internal Failed(Exception reason) => Reason = reason;
 
     /// <summary>
-    /// A discriminated union representing the result of a single run of a test.
-    /// <para>Use pattern matching to inspect:</para>
-    /// <list type="bullet">
-    ///     <item>Passed</item>
-    ///     <item>Failed (Exception Reason)</item>
-    /// </list>
+    /// The exception thrown by a failing test.
     /// </summary>
-    public abstract class TestResult
-    {
-        internal static readonly Passed Passed = new Passed();
-        internal static Failed Failed(Exception reason) => new Failed(reason);
-    }
-
-    /// <summary>
-    /// Represents the fact that a test has passed.
-    /// </summary>
-    public class Passed : TestResult
-    {
-        internal Passed() { }
-    }
-
-    /// <summary>
-    /// Represents the fact that a test has failed due to its throwing an exception.
-    /// </summary>
-    public class Failed : TestResult
-    {
-        internal Failed(Exception reason) => Reason = reason;
-
-        /// <summary>
-        /// The exception thrown by a failing test.
-        /// </summary>
-        public Exception Reason { get; }
-    }
+    public Exception Reason { get; }
 }

--- a/src/Fixie/TestSuite.cs
+++ b/src/Fixie/TestSuite.cs
@@ -1,23 +1,22 @@
-namespace Fixie
+namespace Fixie;
+
+using System.Collections.Generic;
+using System.Linq;
+
+public class TestSuite
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
-    public class TestSuite
+    internal TestSuite(IReadOnlyList<TestClass> testClasses)
     {
-        internal TestSuite(IReadOnlyList<TestClass> testClasses)
-        {
-            TestClasses = testClasses;
-        }
-
-        /// <summary>
-        /// The test classes under execution.
-        /// </summary>
-        public IReadOnlyList<TestClass> TestClasses { get; }
-
-        /// <summary>
-        /// The tests under execution.
-        /// </summary>
-        public IEnumerable<Test> Tests => TestClasses.SelectMany(x => x.Tests);
+        TestClasses = testClasses;
     }
+
+    /// <summary>
+    /// The test classes under execution.
+    /// </summary>
+    public IReadOnlyList<TestClass> TestClasses { get; }
+
+    /// <summary>
+    /// The tests under execution.
+    /// </summary>
+    public IEnumerable<Test> Tests => TestClasses.SelectMany(x => x.Tests);
 }


### PR DESCRIPTION
This applies file-scoped namespace syntax solution-wide. Commits identify which changes were made in bulk by automated refactorings.

Several files required manual adjustment in dedicated commits after the initial automated refactoring commits. All manual changes were indentation fixes missed by the automated refactorings. The overall diff of each file was reviewed with a diff viewer toggling between the normal full diff and a diff ignoring whitespace differences, to be sure no substantive changes were mixed in.

The calculated line changes are `+9,909 -10,032`, a difference of -123 corresponding with 123 C# files touched (each reduces by 1 due to the old namespace closing brace). 124 files were affected: the single other file to account for is the ReSharper settings file where we set the inclusion of using directives to go *before* namespaces from now on.