### PR TITLE
Using Directive Placement

### DIFF
--- a/build/Fixie.Main.cs
+++ b/build/Fixie.Main.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
+
+namespace Fixie.Internal;
 
 // The 'Fixie' package includes this file in test projects so
 // that their tests can be executed. Do not modify this file.

--- a/src/Fixie.Console/CommandLine.cs
+++ b/src/Fixie.Console/CommandLine.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Console;
+﻿using System.Collections.Generic;
 
-using System.Collections.Generic;
+namespace Fixie.Console;
 
 public class CommandLine
 {

--- a/src/Fixie.Console/CommandLineException.cs
+++ b/src/Fixie.Console/CommandLineException.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Console;
+﻿using System;
 
-using System;
+namespace Fixie.Console;
 
 public class CommandLineException : Exception
 {

--- a/src/Fixie.Console/Foreground.cs
+++ b/src/Fixie.Console/Foreground.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Console;
+﻿using System;
 
-using System;
+namespace Fixie.Console;
 
 class Foreground : IDisposable
 {
@@ -8,11 +8,11 @@ class Foreground : IDisposable
 
     public Foreground(ConsoleColor color)
     {
-        before = Console.ForegroundColor;
-        Console.ForegroundColor = color;
+        before = System.Console.ForegroundColor;
+        System.Console.ForegroundColor = color;
     }
 
-    public void Dispose() => Console.ForegroundColor = before;
+    public void Dispose() => System.Console.ForegroundColor = before;
 
     public static Foreground Red => new Foreground(ConsoleColor.Red);
 

--- a/src/Fixie.Console/NamedArgument.cs
+++ b/src/Fixie.Console/NamedArgument.cs
@@ -1,7 +1,7 @@
-namespace Fixie.Console;
-
 using System;
 using System.Collections.Generic;
+
+namespace Fixie.Console;
 
 class NamedArgument
 {

--- a/src/Fixie.Console/Parser.cs
+++ b/src/Fixie.Console/Parser.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Console;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
+namespace Fixie.Console;
 
 class Parser<T>
 {

--- a/src/Fixie.Console/PositionalArgument.cs
+++ b/src/Fixie.Console/PositionalArgument.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Console;
-
-using System;
+﻿using System;
 using System.Reflection;
+
+namespace Fixie.Console;
 
 class PositionalArgument
 {

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -1,12 +1,12 @@
-﻿namespace Fixie.Console;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using static System.Console;
 using static System.IO.Directory;
-using static Shell;
+using static Fixie.Console.Shell;
+
+namespace Fixie.Console;
 
 class Program
 {

--- a/src/Fixie.Console/Shell.cs
+++ b/src/Fixie.Console/Shell.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Console;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+
+namespace Fixie.Console;
 
 static class Shell
 {

--- a/src/Fixie.TestAdapter/DebuggerAttachmentFailure.cs
+++ b/src/Fixie.TestAdapter/DebuggerAttachmentFailure.cs
@@ -1,8 +1,8 @@
-namespace Fixie.TestAdapter;
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
+namespace Fixie.TestAdapter;
 
 class DebuggerAttachmentFailure
 {

--- a/src/Fixie.TestAdapter/LoggingExtensions.cs
+++ b/src/Fixie.TestAdapter/LoggingExtensions.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie.TestAdapter;
-
-using System;
-using Internal;
+﻿using System;
+using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+namespace Fixie.TestAdapter;
 
 static class LoggingExtensions
 {

--- a/src/Fixie.TestAdapter/RunnerException.cs
+++ b/src/Fixie.TestAdapter/RunnerException.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie.TestAdapter;
-
-using System;
+﻿using System;
 using System.Text;
-using Internal;
+using Fixie.Internal;
+
+namespace Fixie.TestAdapter;
 
 class RunnerException : Exception
 {

--- a/src/Fixie.TestAdapter/SourceLocationProvider.cs
+++ b/src/Fixie.TestAdapter/SourceLocationProvider.cs
@@ -1,5 +1,3 @@
-namespace Fixie.TestAdapter;
-
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -7,6 +5,8 @@ using System.Runtime.CompilerServices;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
+
+namespace Fixie.TestAdapter;
 
 class SourceLocationProvider
 {

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -1,5 +1,3 @@
-namespace Fixie.TestAdapter;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -8,6 +6,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Fixie.TestAdapter;
 
 static class TestAssembly
 {

--- a/src/Fixie.TestAdapter/TestProcessExitException.cs
+++ b/src/Fixie.TestAdapter/TestProcessExitException.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.TestAdapter;
+﻿using System;
 
-using System;
+namespace Fixie.TestAdapter;
 
 public class TestProcessExitException : Exception
 {

--- a/src/Fixie.TestAdapter/VsDiscoveryRecorder.cs
+++ b/src/Fixie.TestAdapter/VsDiscoveryRecorder.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.TestAdapter;
-
-using System;
-using Internal;
+﻿using System;
+using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+namespace Fixie.TestAdapter;
 
 class VsDiscoveryRecorder
 {

--- a/src/Fixie.TestAdapter/VsExecutionRecorder.cs
+++ b/src/Fixie.TestAdapter/VsExecutionRecorder.cs
@@ -1,10 +1,12 @@
-﻿namespace Fixie.TestAdapter;
-
-using System;
-using Internal;
+﻿using System;
+using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using static System.Environment;
+
+namespace Fixie.TestAdapter;
+
+using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 class VsExecutionRecorder
 {

--- a/src/Fixie.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.TestAdapter/VsTestDiscoverer.cs
@@ -1,13 +1,13 @@
-﻿namespace Fixie.TestAdapter;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO.Pipes;
-using Internal;
+using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using static TestAssembly;
+using static Fixie.TestAdapter.TestAssembly;
+
+namespace Fixie.TestAdapter;
 
 [DefaultExecutorUri(VsTestExecutor.Id)]
 [FileExtension(".exe")]

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -1,14 +1,14 @@
-﻿namespace Fixie.TestAdapter;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO.Pipes;
 using System.Linq;
-using Internal;
+using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using static TestAssembly;
+using static Fixie.TestAdapter.TestAssembly;
+
+namespace Fixie.TestAdapter;
 
 [ExtensionUri(Id)]
 public class VsTestExecutor : ITestExecutor

--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -1,8 +1,8 @@
-namespace Fixie.Tests.Assertions;
-
 using System;
 using System.Collections.Generic;
 using static System.Environment;
+
+namespace Fixie.Tests.Assertions;
 
 public class AssertException : Exception
 {

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -1,5 +1,3 @@
-namespace Fixie.Tests.Assertions;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -7,6 +5,8 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+
+namespace Fixie.Tests.Assertions;
 
 public static class AssertionExtensions
 {

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
+
+namespace Fixie.Tests;
 
 public class CaseNameTests
 {

--- a/src/Fixie.Tests/Console/ParserTests.cs
+++ b/src/Fixie.Tests/Console/ParserTests.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie.Tests.Console;
-
-using System;
-using Assertions;
+﻿using System;
+using Fixie.Tests.Assertions;
 using Fixie.Console;
+
+namespace Fixie.Tests.Console;
 
 public class ParserTests
 {

--- a/src/Fixie.Tests/DiffToolReport.cs
+++ b/src/Fixie.Tests/DiffToolReport.cs
@@ -1,11 +1,11 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using DiffEngine;
+
+namespace Fixie.Tests;
 
 class DiffToolReport : IHandler<TestFailed>, IHandler<ExecutionCompleted>
 {

--- a/src/Fixie.Tests/FSharpAsync.cs
+++ b/src/Fixie.Tests/FSharpAsync.cs
@@ -2,11 +2,11 @@
 // reflect on it in the same way as we can against
 // the real implementation during F# test runs.
 
-namespace Microsoft.FSharp.Control;
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
+namespace Microsoft.FSharp.Control;
 
 public class FSharpAsync<TResult>
 {

--- a/src/Fixie.Tests/FailureException.cs
+++ b/src/Fixie.Tests/FailureException.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
+
+namespace Fixie.Tests;
 
 public class FailureException : Exception
 {

--- a/src/Fixie.Tests/GitHubReport.cs
+++ b/src/Fixie.Tests/GitHubReport.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Tests;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Fixie.Reports;
 using static System.Environment;
+
+namespace Fixie.Tests;
 
 class GitHubReport :
     IHandler<ExecutionStarted>,

--- a/src/Fixie.Tests/InputAttribute.cs
+++ b/src/Fixie.Tests/InputAttribute.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Tests;
+﻿using System;
 
-using System;
+namespace Fixie.Tests;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public class InputAttribute : Attribute

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -1,10 +1,10 @@
-namespace Fixie.Tests;
-
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
+
+namespace Fixie.Tests;
 
 public abstract class InstrumentedExecutionTests
 {

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -7,8 +7,6 @@ using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.Internal;
 
-using Console = System.Console;
-
 public class BusTests
 {
     public async Task ShouldPublishEventsToAllReports()
@@ -22,7 +20,7 @@ public class BusTests
 
         using var console = new RedirectedConsole();
 
-        var bus = new Bus(Console.Out, reports);
+        var bus = new Bus(System.Console.Out, reports);
         await bus.Publish(new Event(1));
         await bus.Publish(new AnotherEvent(2));
         await bus.Publish(new Event(3));
@@ -47,7 +45,7 @@ public class BusTests
 
         using var console = new RedirectedConsole();
 
-        var bus = new Bus(Console.Out, reports);
+        var bus = new Bus(System.Console.Out, reports);
         await bus.Publish(new Event(1));
         await bus.Publish(new AnotherEvent(2));
         await bus.Publish(new Event(3));
@@ -119,7 +117,7 @@ public class BusTests
     }
 
     static void Log<THandler, TEvent>(int id)
-        => Console.WriteLine($"{typeof(THandler).FullName} handled {typeof(TEvent).Name} {id}");
+        => System.Console.WriteLine($"{typeof(THandler).FullName} handled {typeof(TEvent).Name} {id}");
 
     class StubException : Exception
     {

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -1,11 +1,13 @@
-﻿namespace Fixie.Tests.Internal;
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Internal;
 using Fixie.Reports;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests.Internal;
+
+using Console = System.Console;
 
 public class BusTests
 {

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -1,13 +1,13 @@
-﻿namespace Fixie.Tests.Internal;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Internal;
+
+namespace Fixie.Tests.Internal;
 
 public class ClassDiscovererTests
 {

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Tests.Internal;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests.Internal;
 
 public class ExecutionSummaryTests
 {

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Tests.Internal;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Internal;
+
+namespace Fixie.Tests.Internal;
 
 public class GenericArgumentResolverTests
 {

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Tests.Internal;
-
-using Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Internal;
-using Reports;
+using Fixie.Tests.Reports;
 using static System.Text.Json.JsonSerializer;
+
+namespace Fixie.Tests.Internal;
 
 public class JsonSerializationTests : MessagingTests
 {

--- a/src/Fixie.Tests/Internal/MaybeTests.cs
+++ b/src/Fixie.Tests/Internal/MaybeTests.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie.Tests.Internal;
-
-using System;
-using Assertions;
+﻿using System;
+using Fixie.Tests.Assertions;
 using static Fixie.Internal.Maybe;
+
+namespace Fixie.Tests.Internal;
 
 public class MaybeTests
 {

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -1,12 +1,12 @@
-﻿namespace Fixie.Tests.Internal;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Internal;
+
+namespace Fixie.Tests.Internal;
 
 public class MethodDiscovererTests
 {

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -8,8 +8,6 @@ using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.Internal;
 
-using Console = System.Console;
-
 public class RunnerTests
 {
     static readonly string Self = FullName<RunnerTests>();
@@ -25,7 +23,7 @@ public class RunnerTests
         };
         var discovery = new SelfTestDiscovery();
         
-        var environment = new TestEnvironment(GetType().Assembly, Console.Out, Directory.GetCurrentDirectory());
+        var environment = new TestEnvironment(GetType().Assembly, System.Console.Out, Directory.GetCurrentDirectory());
         var runner = new Runner(environment, report);
 
         await runner.Discover(candidateTypes, discovery);
@@ -51,7 +49,7 @@ public class RunnerTests
         var discovery = new SelfTestDiscovery();
         var execution = new CreateInstancePerCase();
 
-        var environment = new TestEnvironment(GetType().Assembly, Console.Out, Directory.GetCurrentDirectory());
+        var environment = new TestEnvironment(GetType().Assembly, System.Console.Out, Directory.GetCurrentDirectory());
         var runner = new Runner(environment, report);
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -1,12 +1,14 @@
-namespace Fixie.Tests.Internal;
-
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Internal;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests.Internal;
+
+using Console = System.Console;
 
 public class RunnerTests
 {

--- a/src/Fixie.Tests/Internal/TestPatternTests.cs
+++ b/src/Fixie.Tests/Internal/TestPatternTests.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Tests.Internal;
-
-using Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Internal;
+
+namespace Fixie.Tests.Internal;
 
 public class TestPatternTests
 {

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -1,13 +1,13 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Microsoft.FSharp.Control;
 using static System.Environment;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests;
 
 public class MethodInfoExtensionsTests : InstrumentedExecutionTests
 {

--- a/src/Fixie.Tests/ParameterizationTests.cs
+++ b/src/Fixie.Tests/ParameterizationTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
+
+namespace Fixie.Tests;
 
 public class ParameterizationTests : InstrumentedExecutionTests
 {

--- a/src/Fixie.Tests/RedirectedConsole.cs
+++ b/src/Fixie.Tests/RedirectedConsole.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.IO;
+
+namespace Fixie.Tests;
 
 class RedirectedConsole : IDisposable
 {

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Reflection;
-using Assertions;
+using Fixie.Tests.Assertions;
+
+namespace Fixie.Tests;
 
 public class ReflectionExtensionsTests
 {

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Tests.Reports;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests.Reports;
 
 public class AppVeyorReportTests : MessagingTests
 {

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -1,14 +1,14 @@
-﻿namespace Fixie.Tests.Reports;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
-using static Utility;
+using static Fixie.Tests.Utility;
 using static System.Text.Json.JsonSerializer;
+
+namespace Fixie.Tests.Reports;
 
 public class AzureReportTests : MessagingTests
 {

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -1,11 +1,11 @@
-﻿namespace Fixie.Tests.Reports;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
+
+namespace Fixie.Tests.Reports;
 
 public class ConsoleReportTests : MessagingTests
 {

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Tests.Reports;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
+
+namespace Fixie.Tests.Reports;
 
 public class LifecycleMessageTests : MessagingTests
 {

--- a/src/Fixie.Tests/Reports/MessagingTests.cs
+++ b/src/Fixie.Tests/Reports/MessagingTests.cs
@@ -1,12 +1,12 @@
-﻿namespace Fixie.Tests.Reports;
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests.Reports;
 
 public abstract class MessagingTests
 {
@@ -98,7 +98,7 @@ public abstract class MessagingTests
         }
 
         protected static void WhereAmI([CallerMemberName] string member = default!)
-            => Console.WriteLine("Standard Out: " + member);
+            => System.Console.WriteLine("Standard Out: " + member);
     }
 
     class SampleTestClass : Base

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -1,11 +1,11 @@
-﻿namespace Fixie.Tests.Reports;
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
+
+namespace Fixie.Tests.Reports;
 
 public class TeamCityReportTests : MessagingTests
 {

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -1,13 +1,13 @@
-﻿namespace Fixie.Tests.Reports;
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests.Reports;
 
 public class XmlReportTests : MessagingTests
 {

--- a/src/Fixie.Tests/ResultEmittingTests.cs
+++ b/src/Fixie.Tests/ResultEmittingTests.cs
@@ -1,8 +1,8 @@
-namespace Fixie.Tests;
-
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+
+namespace Fixie.Tests;
 
 public class ResultEmittingTests : InstrumentedExecutionTests
 {

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -1,11 +1,11 @@
-﻿namespace Fixie.Tests;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Microsoft.FSharp.Control;
 using static System.Environment;
+
+namespace Fixie.Tests;
 
 public class ReturnTypeTests : InstrumentedExecutionTests
 {

--- a/src/Fixie.Tests/SelfTestDiscovery.cs
+++ b/src/Fixie.Tests/SelfTestDiscovery.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
+namespace Fixie.Tests;
 
 public class SelfTestDiscovery : IDiscovery
 {

--- a/src/Fixie.Tests/ShouldBeUnreachableException.cs
+++ b/src/Fixie.Tests/ShouldBeUnreachableException.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
+
+namespace Fixie.Tests;
 
 public class ShouldBeUnreachableException : Exception
 {

--- a/src/Fixie.Tests/ShuffleExtensionsTests.cs
+++ b/src/Fixie.Tests/ShuffleExtensionsTests.cs
@@ -1,7 +1,7 @@
-namespace Fixie.Tests;
-
 using System;
-using Assertions;
+using Fixie.Tests.Assertions;
+
+namespace Fixie.Tests;
 
 public class ShuffleExtensionsTests
 {

--- a/src/Fixie.Tests/SkipAttribute.cs
+++ b/src/Fixie.Tests/SkipAttribute.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Tests;
+﻿using System;
 
-using System;
+namespace Fixie.Tests;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 public class SkipAttribute : Attribute

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -1,13 +1,13 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Reports;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests;
 
 public class StackTracePresentationTests
 {

--- a/src/Fixie.Tests/StubReport.cs
+++ b/src/Fixie.Tests/StubReport.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie.Tests;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fixie.Reports;
+
+namespace Fixie.Tests;
 
 public class StubReport :
     IHandler<TestDiscovered>,

--- a/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Tests.TestAdapter;
-
-using System;
+﻿using System;
 using Fixie.TestAdapter;
-using Assertions;
-using static Utility;
+using Fixie.Tests.Assertions;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests.TestAdapter;
 
 public class SourceLocationProviderTests
 {

--- a/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Tests.TestAdapter;
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
+
+namespace Fixie.Tests.TestAdapter;
 
 public class SourceLocationSamples
 {
@@ -19,26 +19,26 @@ public class SourceLocationSamples
     public void Simple()
     { // Debug = 20
         int answer = 42; // Release = 21
-        Console.Write(answer);
+        System.Console.Write(answer);
     }
 
     public void Generic<T>(T x)
     { // Debug = 26
-        Console.WriteLine(); // Release = 27
+        System.Console.WriteLine(); // Release = 27
     }
 
     public async void AsyncMethod_Void()
     { // Debug = 31
         int answer = 42; // Release = 32
         await Task.Delay(0);
-        Console.Write(answer);
+        System.Console.Write(answer);
     }
 
     public async Task AsyncMethod_Task()
     { // Debug = 38
         int answer = 42; // Release = 39
         await Task.Delay(0);
-        Console.Write(answer);
+        System.Console.Write(answer);
     }
 
     public async Task<int> AsyncMethod_TaskOfT()
@@ -53,7 +53,7 @@ public class SourceLocationSamples
         public void NestedMethod()
         { // Debug = 54
             int answer = 42; // Release = 55
-            Console.Write(answer);
+            System.Console.Write(answer);
         }
     }
 

--- a/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
+++ b/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Tests.TestAdapter;
-
-using Assertions;
+﻿using Fixie.Tests.Assertions;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Fixie.Tests.TestAdapter;
 
 public static class TestCaseMappingAssertions
 {

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -1,15 +1,15 @@
-﻿namespace Fixie.Tests.TestAdapter;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Internal;
 using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using Reports;
+using Fixie.Tests.Reports;
 using static System.IO.Directory;
+
+namespace Fixie.Tests.TestAdapter;
 
 public class VsDiscoveryRecorderTests : MessagingTests
 {

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -1,16 +1,18 @@
-﻿namespace Fixie.Tests.TestAdapter;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using Assertions;
+using Fixie.Tests.Assertions;
 using Fixie.Internal;
-using Reports;
+using Fixie.Tests.Reports;
 using static System.Environment;
 using static System.Text.Json.JsonSerializer;
+
+namespace Fixie.Tests.TestAdapter;
+
+using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 public class VsExecutionRecorderTests : MessagingTests
 {

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -1,8 +1,8 @@
 namespace Fixie.Tests;
 
 using System.Threading.Tasks;
-using static Utility;
-    
+using static Fixie.Tests.Utility;
+
 public class TestClassConstructionTests : InstrumentedExecutionTests
 {
     class SampleTestClass

--- a/src/Fixie.Tests/TestClassLifecycleTests.cs
+++ b/src/Fixie.Tests/TestClassLifecycleTests.cs
@@ -1,9 +1,9 @@
-namespace Fixie.Tests;
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using static Utility;
+using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests;
 
 public class TestClassLifecycleTests : InstrumentedExecutionTests
 {

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -1,11 +1,11 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+
+namespace Fixie.Tests;
 
 static class TestExtensions
 {

--- a/src/Fixie.Tests/TestNameTests.cs
+++ b/src/Fixie.Tests/TestNameTests.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Tests;
+﻿using Fixie.Tests.Assertions;
 
-using Assertions;
+namespace Fixie.Tests;
 
 public class TestNameTests
 {

--- a/src/Fixie.Tests/UntrustworthyAwaitable.cs
+++ b/src/Fixie.Tests/UntrustworthyAwaitable.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
+
+namespace Fixie.Tests;
 
 // This provides enough structural support for the async/await keywords
 // to be satisfied at compile time, but is not expected to behave well.

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -1,6 +1,4 @@
-﻿namespace Fixie.Tests;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,6 +7,8 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Fixie.Internal;
 using Fixie.Reports;
+
+namespace Fixie.Tests;
 
 public static class Utility
 {

--- a/src/Fixie/ConventionCollection.cs
+++ b/src/Fixie/ConventionCollection.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie;
+﻿using System.Collections.Generic;
+using Fixie.Internal;
 
-using System.Collections.Generic;
-using Internal;
+namespace Fixie;
 
 public class ConventionCollection
 {

--- a/src/Fixie/DefaultDiscovery.cs
+++ b/src/Fixie/DefaultDiscovery.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
+namespace Fixie;
 
 public sealed class DefaultDiscovery : IDiscovery
 {

--- a/src/Fixie/DefaultExecution.cs
+++ b/src/Fixie/DefaultExecution.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie;
+﻿using System.Threading.Tasks;
 
-using System.Threading.Tasks;
+namespace Fixie;
 
 public sealed class DefaultExecution : IExecution
 {

--- a/src/Fixie/IDiscovery.cs
+++ b/src/Fixie/IDiscovery.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+
+namespace Fixie;
 
 public interface IDiscovery
 {

--- a/src/Fixie/IExecution.cs
+++ b/src/Fixie/IExecution.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie;
+﻿using System.Threading.Tasks;
 
-using System.Threading.Tasks;
+namespace Fixie;
 
 public interface IExecution
 {

--- a/src/Fixie/Internal/Bus.cs
+++ b/src/Fixie/Internal/Bus.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Reports;
+using Fixie.Reports;
+
+namespace Fixie.Internal;
 
 class Bus
 {

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+
+namespace Fixie.Internal;
 
 static class CaseNameBuilder
 {

--- a/src/Fixie/Internal/ClassDiscoverer.cs
+++ b/src/Fixie/Internal/ClassDiscoverer.cs
@@ -1,9 +1,9 @@
-namespace Fixie.Internal;
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+
+namespace Fixie.Internal;
 
 class ClassDiscoverer
 {

--- a/src/Fixie/Internal/ConsoleRedirectionBoundary.cs
+++ b/src/Fixie/Internal/ConsoleRedirectionBoundary.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.IO;
+
+namespace Fixie.Internal;
 
 class ConsoleRedirectionBoundary : IDisposable
 {

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -1,15 +1,15 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Reports;
+using Fixie.Reports;
 using static System.Environment;
-using static Maybe;
+using static Fixie.Internal.Maybe;
+
+namespace Fixie.Internal;
 
 public class EntryPoint
 {

--- a/src/Fixie/Internal/ExecutionRecorder.cs
+++ b/src/Fixie/Internal/ExecutionRecorder.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using Reports;
+using Fixie.Reports;
+
+namespace Fixie.Internal;
 
 class ExecutionRecorder
 {

--- a/src/Fixie/Internal/ExecutionSummary.cs
+++ b/src/Fixie/Internal/ExecutionSummary.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Internal;
+﻿using Fixie.Reports;
 
-using Reports;
+namespace Fixie.Internal;
 
 class ExecutionSummary
 {

--- a/src/Fixie/Internal/Foreground.cs
+++ b/src/Fixie/Internal/Foreground.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Internal;
+﻿using System;
 
-using System;
+namespace Fixie.Internal;
 
 class Foreground : IDisposable
 {

--- a/src/Fixie/Internal/Framework.cs
+++ b/src/Fixie/Internal/Framework.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Internal;
+﻿using System.Reflection;
 
-using System.Reflection;
+namespace Fixie.Internal;
 
 static class Framework
 {

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+
+namespace Fixie.Internal;
 
 static class GenericArgumentResolver
 {

--- a/src/Fixie/Internal/Maybe.cs
+++ b/src/Fixie/Internal/Maybe.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
+
+namespace Fixie.Internal;
 
 static class Maybe
 {

--- a/src/Fixie/Internal/MethodDiscoverer.cs
+++ b/src/Fixie/Internal/MethodDiscoverer.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
+namespace Fixie.Internal;
 
 class MethodDiscoverer
 {

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Internal;
+﻿using Fixie.Reports;
 
-using Reports;
+namespace Fixie.Internal;
 
 /*
  * Nullability hints here are informed by usages. Although these types are serialized and deserialized

--- a/src/Fixie/Internal/RecordingWriter.cs
+++ b/src/Fixie/Internal/RecordingWriter.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
+
+namespace Fixie.Internal;
 
 sealed class RecordingWriter : TextWriter
 {

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -1,12 +1,12 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Reports;
+using Fixie.Reports;
+
+namespace Fixie.Internal;
 
 class Runner
 {

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie.Internal;
-
-using System;
+﻿using System;
 using System.IO;
 using System.IO.Pipes;
 using System.Text;
 using static System.Text.Json.JsonSerializer;
+
+namespace Fixie.Internal;
 
 class TestAdapterPipe : IDisposable
 {

--- a/src/Fixie/Internal/TestPattern.cs
+++ b/src/Fixie/Internal/TestPattern.cs
@@ -1,6 +1,6 @@
-namespace Fixie.Internal;
-
 using System.Text.RegularExpressions;
+
+namespace Fixie.Internal;
 
 class TestPattern
 {

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -1,5 +1,3 @@
-namespace Fixie;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -8,7 +6,9 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-using Internal;
+using Fixie.Internal;
+
+namespace Fixie;
 
 public static class MethodInfoExtensions
 {

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie;
-
-using System;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using static Internal.Maybe;
+using static Fixie.Internal.Maybe;
+
+namespace Fixie;
 
 public static class ReflectionExtensions
 {

--- a/src/Fixie/ReportCollection.cs
+++ b/src/Fixie/ReportCollection.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie;
+﻿using System.Collections.Generic;
+using Fixie.Reports;
 
-using System.Collections.Generic;
-using Reports;
+namespace Fixie;
 
 public class ReportCollection
 {

--- a/src/Fixie/Reports/AppVeyorReport.cs
+++ b/src/Fixie/Reports/AppVeyorReport.cs
@@ -1,6 +1,4 @@
-﻿namespace Fixie.Reports;
-
-using System;
+﻿using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -8,6 +6,8 @@ using System.Text;
 using System.Threading.Tasks;
 using static System.Environment;
 using static System.Text.Json.JsonSerializer;
+
+namespace Fixie.Reports;
 
 class AppVeyorReport :
     IHandler<ExecutionStarted>,

--- a/src/Fixie/Reports/AzureReport.cs
+++ b/src/Fixie/Reports/AzureReport.cs
@@ -1,6 +1,4 @@
-﻿namespace Fixie.Reports;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -10,10 +8,12 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Internal;
+using Fixie.Internal;
 using static System.Environment;
 using static System.Text.Json.JsonSerializer;
-using static Internal.Maybe;
+using static Fixie.Internal.Maybe;
+
+namespace Fixie.Reports;
 
 class AzureReport :
     IHandler<ExecutionStarted>,

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -1,11 +1,11 @@
-﻿namespace Fixie.Reports;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Internal;
+using Fixie.Internal;
 using static System.Environment;
+
+namespace Fixie.Reports;
 
 class ConsoleReport :
     IHandler<TestSkipped>,

--- a/src/Fixie/Reports/ExceptionExtensions.cs
+++ b/src/Fixie/Reports/ExceptionExtensions.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie.Reports;
-
-using System;
+﻿using System;
 using System.Text;
 using static System.Environment;
+
+namespace Fixie.Reports;
 
 public static class ExceptionExtensions
 {

--- a/src/Fixie/Reports/ExecutionCompleted.cs
+++ b/src/Fixie/Reports/ExecutionCompleted.cs
@@ -1,7 +1,7 @@
-﻿namespace Fixie.Reports;
+﻿using System;
+using Fixie.Internal;
 
-using System;
-using Internal;
+namespace Fixie.Reports;
 
 /// <summary>
 /// Fired once at the end of the execution phase for the test assembly.

--- a/src/Fixie/Reports/IHandler.cs
+++ b/src/Fixie/Reports/IHandler.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Reports;
+﻿using System.Threading.Tasks;
 
-using System.Threading.Tasks;
+namespace Fixie.Reports;
 
 public interface IHandler<in TMessage> : IReport where TMessage : IMessage
 {

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -1,9 +1,9 @@
-﻿namespace Fixie.Reports;
-
-using System.Linq;
+﻿using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using static System.Environment;
+
+namespace Fixie.Reports;
 
 class TeamCityReport :
     IHandler<ExecutionStarted>,

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie.Reports;
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
-using Internal;
+using Fixie.Internal;
+
+namespace Fixie.Reports;
 
 class TestAdapterReport :
     IHandler<TestDiscovered>,

--- a/src/Fixie/Reports/TestCompleted.cs
+++ b/src/Fixie/Reports/TestCompleted.cs
@@ -1,6 +1,6 @@
-namespace Fixie.Reports;
-
 using System;
+
+namespace Fixie.Reports;
 
 public abstract class TestCompleted : IMessage
 {

--- a/src/Fixie/Reports/TestFailed.cs
+++ b/src/Fixie/Reports/TestFailed.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Reports;
+﻿using System;
 
-using System;
+namespace Fixie.Reports;
 
 /// <summary>
 /// Fired when an individual test has failed.

--- a/src/Fixie/Reports/TestPassed.cs
+++ b/src/Fixie/Reports/TestPassed.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Reports;
+﻿using System;
 
-using System;
+namespace Fixie.Reports;
 
 /// <summary>
 /// Fired when an individual test has passed.

--- a/src/Fixie/Reports/TestSkipped.cs
+++ b/src/Fixie/Reports/TestSkipped.cs
@@ -1,6 +1,6 @@
-﻿namespace Fixie.Reports;
+﻿using System;
 
-using System;
+namespace Fixie.Reports;
 
 /// <summary>
 /// Fired when an individual test has been skipped.

--- a/src/Fixie/Reports/XmlReport.cs
+++ b/src/Fixie/Reports/XmlReport.cs
@@ -1,13 +1,13 @@
-﻿namespace Fixie.Reports;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-using Internal;
-    
+using Fixie.Internal;
+
+namespace Fixie.Reports;
+
 /// <summary>
 /// Writes test results to the specified path, using the xUnit XML format.
 /// </summary>

--- a/src/Fixie/ShuffleExtensions.cs
+++ b/src/Fixie/ShuffleExtensions.cs
@@ -1,8 +1,8 @@
-﻿namespace Fixie;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
+namespace Fixie;
 
 public static class ShuffleExtensions
 {

--- a/src/Fixie/Test.cs
+++ b/src/Fixie/Test.cs
@@ -1,12 +1,12 @@
-namespace Fixie;
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-using Internal;
+using Fixie.Internal;
+
+namespace Fixie;
 
 public class Test
 {

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -1,10 +1,10 @@
-﻿namespace Fixie;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
+
+namespace Fixie;
 
 public class TestClass
 {

--- a/src/Fixie/TestEnvironment.cs
+++ b/src/Fixie/TestEnvironment.cs
@@ -1,11 +1,11 @@
-﻿namespace Fixie;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Versioning;
 using static System.Environment;
+
+namespace Fixie;
 
 public class TestEnvironment
 {

--- a/src/Fixie/TestResult.cs
+++ b/src/Fixie/TestResult.cs
@@ -1,6 +1,6 @@
-namespace Fixie;
-
 using System;
+
+namespace Fixie;
 
 /// <summary>
 /// A discriminated union representing the result of a single run of a test.

--- a/src/Fixie/TestSuite.cs
+++ b/src/Fixie/TestSuite.cs
@@ -1,7 +1,7 @@
-namespace Fixie;
-
 using System.Collections.Generic;
 using System.Linq;
+
+namespace Fixie;
 
 public class TestSuite
 {


### PR DESCRIPTION
This repo has been placing `using` directives within `namespace` blocks. The apparent benefit was occasional brevity for "nearby" namespaces: within the `Fixie.Tests` namespace, you could simply say `using Assertions` to bring in the nearby namespace `Fixie.Tests.Assertions`. This was the only benefit, and switching to it was a Pyrrhic victory for two reasons:

1. It does not play nicely with the more modern "global using" feature (explicit or implicit), forcing redundant directives and therefore *less* brevity.
2. Switching away from this meager brevity unskillfully is risky as the meaning of some type name in a code file might silently change if you merely relocate the `namespace` directive below existing `using` directives. Fortunately most such conflicts would coincidentally surface as a compiler error based on usages of the identifier, but still: here be dragons.

This reorders `using` vs `namespace` as a step towards cleanly applying implicit/global `using` directives in a subsequent PR. By applying this code change separately from the implicit/global `using` directives, each can be more easily reviewed in isolation.

This was done manually. For each visited file, already-abbreviated `using` directives were first expanded to their fully-qualified equivalent, letting the IDE first confirm what the implied full name was. Once all `using` directives in a code file were fully-qualified, they could be safely cut and pasted before the `namespace` with confidence that the move could not alter the meaning of the following code.

Two name conflicts were encountered and resolved:

1. `Console` tends to be ambiguous in the tests when we can alternately mean `System.Console` or `Fixie.Console`. We resolve this by always referring to `System.Console...` explicitly in the tests, and can mean `Fixie.Console` implicitly otherwise.
3. `TestResult` can mean either `Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult` or `Fixie.TestResult`. We resolve this in both `VsExecutionRecorder` and `VsExecutionRecorderTests` by including the following alias *after* the namespace declaration:

    ```cs
    using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
    ```