### PR TITLE
Apply global and implicit using directives

### DIFF
--- a/build/Fixie.Main.cs
+++ b/build/Fixie.Main.cs
@@ -1,4 +1,7 @@
-﻿namespace Fixie.Internal;
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Fixie.Internal;
 
 // The 'Fixie' package includes this file in test projects so
 // that their tests can be executed. Do not modify this file.

--- a/build/Fixie.Main.cs
+++ b/build/Fixie.Main.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace Fixie.Internal;
+﻿namespace Fixie.Internal;
 
 // The 'Fixie' package includes this file in test projects so
 // that their tests can be executed. Do not modify this file.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,7 @@
         <RepositoryUrl>https://github.com/fixie/fixie</RepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UseArtifactsOutput>true</UseArtifactsOutput>
         <MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
@@ -23,8 +24,8 @@
         -->
     </PropertyGroup>
 
-	<!-- Enable Deterministic Builds -->
-	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-	</PropertyGroup>
+    <!-- Enable Deterministic Builds -->
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
 </Project>

--- a/src/Fixie.Console/CommandLine.cs
+++ b/src/Fixie.Console/CommandLine.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Fixie.Console;
+﻿namespace Fixie.Console;
 
 public class CommandLine
 {

--- a/src/Fixie.Console/CommandLineException.cs
+++ b/src/Fixie.Console/CommandLineException.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.Console;
+﻿namespace Fixie.Console;
 
 public class CommandLineException : Exception
 {

--- a/src/Fixie.Console/Foreground.cs
+++ b/src/Fixie.Console/Foreground.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.Console;
+﻿namespace Fixie.Console;
 
 class Foreground : IDisposable
 {

--- a/src/Fixie.Console/NamedArgument.cs
+++ b/src/Fixie.Console/NamedArgument.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace Fixie.Console;
 
 class NamedArgument

--- a/src/Fixie.Console/Parser.cs
+++ b/src/Fixie.Console/Parser.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Fixie.Console;
 

--- a/src/Fixie.Console/PositionalArgument.cs
+++ b/src/Fixie.Console/PositionalArgument.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Fixie.Console;
 

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using static System.Console;
+﻿using static System.Console;
 using static System.IO.Directory;
 using static Fixie.Console.Shell;
 

--- a/src/Fixie.Console/Shell.cs
+++ b/src/Fixie.Console/Shell.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
+﻿using System.Diagnostics;
 
 namespace Fixie.Console;
 

--- a/src/Fixie.TestAdapter/DebuggerAttachmentFailure.cs
+++ b/src/Fixie.TestAdapter/DebuggerAttachmentFailure.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Fixie.TestAdapter;
 

--- a/src/Fixie.TestAdapter/LoggingExtensions.cs
+++ b/src/Fixie.TestAdapter/LoggingExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace Fixie.TestAdapter;

--- a/src/Fixie.TestAdapter/RunnerException.cs
+++ b/src/Fixie.TestAdapter/RunnerException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 using Fixie.Internal;
 
 namespace Fixie.TestAdapter;

--- a/src/Fixie.TestAdapter/SourceLocationProvider.cs
+++ b/src/Fixie.TestAdapter/SourceLocationProvider.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Mono.Cecil;
 using Mono.Cecil.Cil;

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;

--- a/src/Fixie.TestAdapter/TestProcessExitException.cs
+++ b/src/Fixie.TestAdapter/TestProcessExitException.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.TestAdapter;
+﻿namespace Fixie.TestAdapter;
 
 public class TestProcessExitException : Exception
 {

--- a/src/Fixie.TestAdapter/VsDiscoveryRecorder.cs
+++ b/src/Fixie.TestAdapter/VsDiscoveryRecorder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;

--- a/src/Fixie.TestAdapter/VsExecutionRecorder.cs
+++ b/src/Fixie.TestAdapter/VsExecutionRecorder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using static System.Environment;

--- a/src/Fixie.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.TestAdapter/VsTestDiscoverer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Pipes;
+﻿using System.IO.Pipes;
 using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Pipes;
-using System.Linq;
+﻿using System.IO.Pipes;
 using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;

--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using static System.Environment;
 
 namespace Fixie.Tests.Assertions;

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace Fixie.Tests.Assertions;
 

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -1,6 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-
-namespace Fixie.Tests;
+﻿namespace Fixie.Tests;
 
 public class CaseNameTests
 {

--- a/src/Fixie.Tests/Console/ParserTests.cs
+++ b/src/Fixie.Tests/Console/ParserTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Console;
 
 namespace Fixie.Tests.Console;

--- a/src/Fixie.Tests/Console/ParserTests.cs
+++ b/src/Fixie.Tests/Console/ParserTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Console;
+﻿using Fixie.Console;
 
 namespace Fixie.Tests.Console;
 

--- a/src/Fixie.Tests/DiffToolReport.cs
+++ b/src/Fixie.Tests/DiffToolReport.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 using DiffEngine;
 
 namespace Fixie.Tests;

--- a/src/Fixie.Tests/DiffToolReport.cs
+++ b/src/Fixie.Tests/DiffToolReport.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using DiffEngine;
 

--- a/src/Fixie.Tests/FSharpAsync.cs
+++ b/src/Fixie.Tests/FSharpAsync.cs
@@ -2,10 +2,6 @@
 // reflect on it in the same way as we can against
 // the real implementation during F# test runs.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Microsoft.FSharp.Control;
 
 public class FSharpAsync<TResult>

--- a/src/Fixie.Tests/FailureException.cs
+++ b/src/Fixie.Tests/FailureException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/GitHubReport.cs
+++ b/src/Fixie.Tests/GitHubReport.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 using static System.Environment;
 
 namespace Fixie.Tests;

--- a/src/Fixie.Tests/GlobalUsings.cs
+++ b/src/Fixie.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Fixie.Tests.Assertions;

--- a/src/Fixie.Tests/InputAttribute.cs
+++ b/src/Fixie.Tests/InputAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.Tests;
+﻿namespace Fixie.Tests;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public class InputAttribute : Attribute

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using Fixie.Tests.Assertions;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Fixie.Tests.Assertions;
 
 namespace Fixie.Tests;

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Internal;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
-using Fixie.Tests.Assertions;
 using Fixie.Internal;
 
 namespace Fixie.Tests.Internal;

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Fixie.Tests.Assertions;
 using Fixie.Internal;
 

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.Internal;

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Internal;
 
 namespace Fixie.Tests.Internal;

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 
 namespace Fixie.Tests.Internal;
 

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using Fixie.Tests.Reports;
 using static System.Text.Json.JsonSerializer;
 

--- a/src/Fixie.Tests/Internal/MaybeTests.cs
+++ b/src/Fixie.Tests/Internal/MaybeTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using static Fixie.Internal.Maybe;
+﻿using static Fixie.Internal.Maybe;
 
 namespace Fixie.Tests.Internal;
 

--- a/src/Fixie.Tests/Internal/MaybeTests.cs
+++ b/src/Fixie.Tests/Internal/MaybeTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using static Fixie.Internal.Maybe;
 
 namespace Fixie.Tests.Internal;

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using Fixie.Tests.Assertions;
 using Fixie.Internal;
 
 namespace Fixie.Tests.Internal;

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
+﻿using System.Reflection;
 using Fixie.Tests.Assertions;
 using Fixie.Internal;
 

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
 using Fixie.Tests.Assertions;
 using Fixie.Internal;
 using static Fixie.Tests.Utility;

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -1,4 +1,3 @@
-using Fixie.Tests.Assertions;
 using Fixie.Internal;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/Internal/TestPatternTests.cs
+++ b/src/Fixie.Tests/Internal/TestPatternTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 
 namespace Fixie.Tests.Internal;
 

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
 using Fixie.Tests.Assertions;
 using Microsoft.FSharp.Control;
 using static System.Environment;

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using Fixie.Tests.Assertions;
 using Microsoft.FSharp.Control;
 using static System.Environment;
 using static Fixie.Tests.Utility;

--- a/src/Fixie.Tests/ParameterizationTests.cs
+++ b/src/Fixie.Tests/ParameterizationTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/ParameterizationTests.cs
+++ b/src/Fixie.Tests/ParameterizationTests.cs
@@ -1,6 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-
-namespace Fixie.Tests;
+﻿namespace Fixie.Tests;
 
 public class ParameterizationTests : InstrumentedExecutionTests
 {

--- a/src/Fixie.Tests/RedirectedConsole.cs
+++ b/src/Fixie.Tests/RedirectedConsole.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-
-namespace Fixie.Tests;
+﻿namespace Fixie.Tests;
 
 class RedirectedConsole : IDisposable
 {

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using Fixie.Tests.Assertions;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/ReflectionExtensionsTests.cs
+++ b/src/Fixie.Tests/ReflectionExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Fixie.Tests.Assertions;
 
 namespace Fixie.Tests;

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.Reports;

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 using static System.Text.Json.JsonSerializer;

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 using static Fixie.Tests.Utility;
 using static System.Text.Json.JsonSerializer;
 

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using Fixie.Tests.Assertions;
 using Fixie.Reports;
 
 namespace Fixie.Tests.Reports;

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
+﻿using System.Reflection;
 using Fixie.Tests.Assertions;
 using Fixie.Reports;
 

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Reports;
 
 namespace Fixie.Tests.Reports;

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 
 namespace Fixie.Tests.Reports;
 

--- a/src/Fixie.Tests/Reports/MessagingTests.cs
+++ b/src/Fixie.Tests/Reports/MessagingTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
 using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;

--- a/src/Fixie.Tests/Reports/MessagingTests.cs
+++ b/src/Fixie.Tests/Reports/MessagingTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
 using Fixie.Tests.Assertions;
 using Fixie.Reports;
 

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.RegularExpressions;
-using Fixie.Tests.Assertions;
 using Fixie.Reports;
 
 namespace Fixie.Tests.Reports;

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Fixie.Tests.Assertions;
 using Fixie.Reports;

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.RegularExpressions;
 using System.Xml.Linq;
-using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/ResultEmittingTests.cs
+++ b/src/Fixie.Tests/ResultEmittingTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace Fixie.Tests;
 
 public class ResultEmittingTests : InstrumentedExecutionTests

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
 using Fixie.Tests.Assertions;
 using Microsoft.FSharp.Control;
 using static System.Environment;

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using Fixie.Tests.Assertions;
 using Microsoft.FSharp.Control;
 using static System.Environment;
 

--- a/src/Fixie.Tests/SelfTestDiscovery.cs
+++ b/src/Fixie.Tests/SelfTestDiscovery.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/ShouldBeUnreachableException.cs
+++ b/src/Fixie.Tests/ShouldBeUnreachableException.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/ShuffleExtensionsTests.cs
+++ b/src/Fixie.Tests/ShuffleExtensionsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Fixie.Tests.Assertions;
 
 namespace Fixie.Tests;

--- a/src/Fixie.Tests/ShuffleExtensionsTests.cs
+++ b/src/Fixie.Tests/ShuffleExtensionsTests.cs
@@ -1,5 +1,3 @@
-using Fixie.Tests.Assertions;
-
 namespace Fixie.Tests;
 
 public class ShuffleExtensionsTests

--- a/src/Fixie.Tests/SkipAttribute.cs
+++ b/src/Fixie.Tests/SkipAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.Tests;
+﻿namespace Fixie.Tests;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 public class SkipAttribute : Attribute

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests;

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/StubReport.cs
+++ b/src/Fixie.Tests/StubReport.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Fixie.TestAdapter;
+﻿using Fixie.TestAdapter;
 using Fixie.Tests.Assertions;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
@@ -1,5 +1,4 @@
 ﻿using Fixie.TestAdapter;
-using Fixie.Tests.Assertions;
 using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.TestAdapter;

--- a/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
@@ -1,5 +1,8 @@
 ﻿namespace Fixie.Tests.TestAdapter;
 
+// Avoid changes in this file that would move the well-known line numbers indicated in comments.
+// Otherwise, these comments and the associated assertions would need to be updated together
+
 public class SourceLocationSamples
 {
     public void Empty_OneLine() { } // Debug = Release = 8

--- a/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationSamples.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace Fixie.Tests.TestAdapter;
+﻿namespace Fixie.Tests.TestAdapter;
 
 public class SourceLocationSamples
 {

--- a/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
+++ b/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Fixie.Tests.TestAdapter;
 

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -1,5 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using Fixie.Tests.Assertions;
+﻿using Fixie.Tests.Assertions;
 using Fixie.Internal;
 using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Fixie.TestAdapter;
+﻿using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
-using Fixie.Tests.Assertions;
 using Fixie.Internal;
 using Fixie.Tests.Reports;
 using static System.Environment;

--- a/src/Fixie.Tests/TestClassConstructionTests.cs
+++ b/src/Fixie.Tests/TestClassConstructionTests.cs
@@ -1,7 +1,6 @@
-namespace Fixie.Tests;
-
-using System.Threading.Tasks;
 using static Fixie.Tests.Utility;
+
+namespace Fixie.Tests;
 
 public class TestClassConstructionTests : InstrumentedExecutionTests
 {

--- a/src/Fixie.Tests/TestClassLifecycleTests.cs
+++ b/src/Fixie.Tests/TestClassLifecycleTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests;

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 

--- a/src/Fixie.Tests/TestNameTests.cs
+++ b/src/Fixie.Tests/TestNameTests.cs
@@ -1,6 +1,4 @@
-﻿using Fixie.Tests.Assertions;
-
-namespace Fixie.Tests;
+﻿namespace Fixie.Tests;
 
 public class TestNameTests
 {

--- a/src/Fixie.Tests/UntrustworthyAwaitable.cs
+++ b/src/Fixie.Tests/UntrustworthyAwaitable.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Fixie.Tests;
 

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Fixie.Internal;
 using Fixie.Reports;
 

--- a/src/Fixie/ConventionCollection.cs
+++ b/src/Fixie/ConventionCollection.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 
 namespace Fixie;
 

--- a/src/Fixie/DefaultDiscovery.cs
+++ b/src/Fixie/DefaultDiscovery.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Fixie;
 

--- a/src/Fixie/DefaultExecution.cs
+++ b/src/Fixie/DefaultExecution.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading.Tasks;
-
-namespace Fixie;
+﻿namespace Fixie;
 
 public sealed class DefaultExecution : IExecution
 {

--- a/src/Fixie/IDiscovery.cs
+++ b/src/Fixie/IDiscovery.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Fixie;
 

--- a/src/Fixie/IExecution.cs
+++ b/src/Fixie/IExecution.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading.Tasks;
-
-namespace Fixie;
+﻿namespace Fixie;
 
 public interface IExecution
 {

--- a/src/Fixie/Internal/Bus.cs
+++ b/src/Fixie/Internal/Bus.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 
 namespace Fixie.Internal;
 

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Reflection;
 using System.Text;
 

--- a/src/Fixie/Internal/ClassDiscoverer.cs
+++ b/src/Fixie/Internal/ClassDiscoverer.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Fixie.Internal;

--- a/src/Fixie/Internal/ConsoleRedirectionBoundary.cs
+++ b/src/Fixie/Internal/ConsoleRedirectionBoundary.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-
-namespace Fixie.Internal;
+﻿namespace Fixie.Internal;
 
 class ConsoleRedirectionBoundary : IDisposable
 {

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Pipes;
-using System.Linq;
+﻿using System.IO.Pipes;
 using System.Reflection;
-using System.Threading.Tasks;
 using Fixie.Reports;
 using static System.Environment;
 using static Fixie.Internal.Maybe;

--- a/src/Fixie/Internal/ExecutionRecorder.cs
+++ b/src/Fixie/Internal/ExecutionRecorder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using Fixie.Reports;
 
 namespace Fixie.Internal;

--- a/src/Fixie/Internal/Foreground.cs
+++ b/src/Fixie/Internal/Foreground.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.Internal;
+﻿namespace Fixie.Internal;
 
 class Foreground : IDisposable
 {

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Fixie.Internal;

--- a/src/Fixie/Internal/Maybe.cs
+++ b/src/Fixie/Internal/Maybe.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace Fixie.Internal;
 

--- a/src/Fixie/Internal/MethodDiscoverer.cs
+++ b/src/Fixie/Internal/MethodDiscoverer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Fixie.Internal;
 

--- a/src/Fixie/Internal/RecordingWriter.cs
+++ b/src/Fixie/Internal/RecordingWriter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Fixie.Internal;

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
+﻿using System.Reflection;
 using Fixie.Reports;
 
 namespace Fixie.Internal;

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.IO.Pipes;
+﻿using System.IO.Pipes;
 using System.Text;
 using static System.Text.Json.JsonSerializer;
 

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
 using Fixie.Internal;
 
 namespace Fixie;

--- a/src/Fixie/ReflectionExtensions.cs
+++ b/src/Fixie/ReflectionExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using static Fixie.Internal.Maybe;
 

--- a/src/Fixie/ReportCollection.cs
+++ b/src/Fixie/ReportCollection.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Fixie.Reports;
+﻿using Fixie.Reports;
 
 namespace Fixie;
 

--- a/src/Fixie/Reports/AppVeyorReport.cs
+++ b/src/Fixie/Reports/AppVeyorReport.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.IO;
-using System.Net.Http;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 using System.Text;
-using System.Threading.Tasks;
 using static System.Environment;
 using static System.Text.Json.JsonSerializer;
 

--- a/src/Fixie/Reports/AzureReport.cs
+++ b/src/Fixie/Reports/AzureReport.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Fixie.Internal;
 using static System.Environment;
 using static System.Text.Json.JsonSerializer;

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using static System.Environment;
 
 namespace Fixie.Reports;

--- a/src/Fixie/Reports/ExceptionExtensions.cs
+++ b/src/Fixie/Reports/ExceptionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 using static System.Environment;
 
 namespace Fixie.Reports;

--- a/src/Fixie/Reports/ExecutionCompleted.cs
+++ b/src/Fixie/Reports/ExecutionCompleted.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 
 namespace Fixie.Reports;
 

--- a/src/Fixie/Reports/IHandler.cs
+++ b/src/Fixie/Reports/IHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading.Tasks;
-
-namespace Fixie.Reports;
+﻿namespace Fixie.Reports;
 
 public interface IHandler<in TMessage> : IReport where TMessage : IMessage
 {

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 using static System.Environment;
 
 namespace Fixie.Reports;

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 
 namespace Fixie.Reports;
 

--- a/src/Fixie/Reports/TestCompleted.cs
+++ b/src/Fixie/Reports/TestCompleted.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Fixie.Reports;
 
 public abstract class TestCompleted : IMessage

--- a/src/Fixie/Reports/TestFailed.cs
+++ b/src/Fixie/Reports/TestFailed.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.Reports;
+﻿namespace Fixie.Reports;
 
 /// <summary>
 /// Fired when an individual test has failed.

--- a/src/Fixie/Reports/TestPassed.cs
+++ b/src/Fixie/Reports/TestPassed.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.Reports;
+﻿namespace Fixie.Reports;
 
 /// <summary>
 /// Fired when an individual test has passed.

--- a/src/Fixie/Reports/TestSkipped.cs
+++ b/src/Fixie/Reports/TestSkipped.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fixie.Reports;
+﻿namespace Fixie.Reports;
 
 /// <summary>
 /// Fired when an individual test has been skipped.

--- a/src/Fixie/Reports/XmlReport.cs
+++ b/src/Fixie/Reports/XmlReport.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using Fixie.Internal;
 
 namespace Fixie.Reports;

--- a/src/Fixie/ShuffleExtensions.cs
+++ b/src/Fixie/ShuffleExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace Fixie;
+﻿namespace Fixie;
 
 public static class ShuffleExtensions
 {

--- a/src/Fixie/Test.cs
+++ b/src/Fixie/Test.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
 using Fixie.Internal;
 
 namespace Fixie;

--- a/src/Fixie/TestClass.cs
+++ b/src/Fixie/TestClass.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
 
 namespace Fixie;
 

--- a/src/Fixie/TestEnvironment.cs
+++ b/src/Fixie/TestEnvironment.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.Versioning;
 using static System.Environment;
 

--- a/src/Fixie/TestResult.cs
+++ b/src/Fixie/TestResult.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Fixie;
 
 /// <summary>

--- a/src/Fixie/TestSuite.cs
+++ b/src/Fixie/TestSuite.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Fixie;
 
 public class TestSuite


### PR DESCRIPTION
This enables implicit `using` directives as well as one custom explicit `global using` directive.

As indicated in the commit messages, much of this work was performed by automated refactorings.

Manual Changes:

1. Applying `<ImplicitUsings>enable</ImplicitUsings>` to all projects.
2. Manually adjusted the directives at the top of `TestClassConstructionTests`, as the order of `namespace` vs `using` was unintentionally missed in #312 and prevented automated refactoring from being applicable.
3. `SourceLocationSamples` is by its nature brittle in the face of line number changes, so this adds a descriptive comment to that effect near the top, "coincidentally" returning all brittle-positioned lines back to their original location. Doing so prevents having to manually adjust all the line number comments and associated assertion constants in `SourceLocationProviderTests`.
4. Revert the automatic application of implicit `using` from the special file `Fixie.Main.cs`, which is included in the NuGet package and automatically included in end users' own test assemblies. Since end users may or may not have implicit `using` enabled, we have to err on the safe side to ensure all users can actually build their test projects.

Custom Global Using:

1. The `global using` feature could easily be overused to the point of regret, but I've included one in the tests project. Nearly all code files in the tests project naturally need to make assertions, and since they are of the `a.ShouldXyz(b)` extension method variety, implicitly including their namespace removes realistic friction when writing the first assertion in a new test file:
    ```cs
    global using Fixie.Tests.Assertions;
    ```