### PR TITLE
Apply collection literal `[]` for all empty collections.

### DIFF
--- a/src/Fixie.Console/CommandLine.cs
+++ b/src/Fixie.Console/CommandLine.cs
@@ -7,8 +7,8 @@ public class CommandLine
 
     public static void Partition(string[] arguments, out string[] runnerArguments, out string[] customArguments)
     {
-        var runnerArgumentsList = new List<string>();
-        var customArgumentsList = new List<string>();
+        List<string> runnerArgumentsList = [];
+        List<string> customArgumentsList = [];
 
         bool separatorFound = false;
         foreach (var arg in arguments)

--- a/src/Fixie.Console/NamedArgument.cs
+++ b/src/Fixie.Console/NamedArgument.cs
@@ -12,7 +12,7 @@ class NamedArgument
 
         Identifier = identifier;
         Name = Normalize(Identifier);
-        Values = new List<object?>();
+        Values = [];
     }
 
     public bool IsArray { get; }

--- a/src/Fixie.Console/Parser.cs
+++ b/src/Fixie.Console/Parser.cs
@@ -15,7 +15,7 @@ class Parser<T>
         var positionalArguments = ScanPositionalArguments(type);
         var namedArguments = ScanNamedArguments(type);
 
-        var paramsPositionalArgumentValues = new List<object?>();
+        List<object?> paramsPositionalArgumentValues = [];
 
         var queue = new Queue<string>(arguments);
         while (queue.Any())
@@ -201,7 +201,7 @@ class Parser<T>
 
         var declaredParameters = constructor.GetParameters();
 
-        var actualParameters = new List<object?>();
+        List<object?> actualParameters = [];
 
         foreach (var declaredParameter in declaredParameters)
         {

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -39,7 +39,7 @@ public class VsTestExecutor : ITestExecutor
 
             var executeTests = new PipeMessage.ExecuteTests
             {
-                Filter = new string[] { }
+                Filter = []
             };
 
             foreach (var assemblyPath in sources)

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -51,7 +51,7 @@ public static class AssertionExtensions
 
     public static void ShouldBeEmpty<T>(this IEnumerable<T> collection)
     {
-        collection.ShouldMatch(Array.Empty<T>());
+        collection.ShouldMatch([]);
     }
 
     public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage) where TException : Exception

--- a/src/Fixie.Tests/Console/ParserTests.cs
+++ b/src/Fixie.Tests/Console/ParserTests.cs
@@ -327,7 +327,7 @@ public class ParserTests
     public void ShouldSetEmptyArraysForMissingArrayArguments()
     {
         Parse<ModelWithArrays>()
-            .ShouldSucceed(new ModelWithArrays(new int[] { }, new string[] { }));
+            .ShouldSucceed(new ModelWithArrays([], []));
     }
 
     class AmbiguousParameters
@@ -414,8 +414,7 @@ public class ParserTests
     public void ShouldBindCommandLineArgumentsToComplexModels()
     {
         Parse<Complex>()
-            .ShouldSucceed(new Complex(null, 0, false, null, null,
-                new string[] { }, new int[] { }));
+            .ShouldSucceed(new Complex(null, 0, false, null, null, [], []));
 
         Parse<Complex>(
             "--string", "def",
@@ -468,8 +467,7 @@ public class ParserTests
     public void ShouldBindCommandLineArgumentsToComplexModelsWithParams()
     {
         Parse<ComplexWithParams>()
-            .ShouldSucceed(new ComplexWithParams(null, 0, false, null, null,
-                new string[] { }, new int[] { }));
+            .ShouldSucceed(new ComplexWithParams(null, 0, false, null, null, [], []));
 
         Parse<ComplexWithParams>(
             "--string", "def",

--- a/src/Fixie.Tests/GitHubReport.cs
+++ b/src/Fixie.Tests/GitHubReport.cs
@@ -34,7 +34,7 @@ class GitHubReport :
         {
             severity = "green";
 
-            var parts = new List<string>();
+            List<string> parts = [];
 
             if (message.Passed > 0)
                 parts.Add($"{message.Passed} passed");

--- a/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
+++ b/src/Fixie.Tests/Internal/ExecutionSummaryTests.cs
@@ -26,7 +26,7 @@ public class ExecutionSummaryTests
     class StubExecutionSummaryReport :
         IHandler<ExecutionCompleted>
     {
-        public List<ExecutionCompleted> ExecutionCompletions { get; } = new();
+        public List<ExecutionCompleted> ExecutionCompletions { get; } = [];
 
         public Task Handle(ExecutionCompleted message)
         {

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -4,7 +4,7 @@ namespace Fixie.Tests.Internal;
 
 public class GenericArgumentResolverTests
 {
-    static readonly Type[] Empty = { };
+    static readonly Type[] Empty = [];
 
     public void ShouldResolveNothingWhenThereAreNoInputParameters()
     {

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -17,7 +17,7 @@ public class JsonSerializationTests : MessagingTests
         Expect(new PipeMessage.ExecuteTests(),
             "{\"Filter\":null}");
 
-        Expect(new PipeMessage.ExecuteTests { Filter = new string[] { } },
+        Expect(new PipeMessage.ExecuteTests { Filter = [] },
             "{\"Filter\":[]}");
 
         Expect(new PipeMessage.ExecuteTests { Filter = new[]

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -49,7 +49,7 @@ public class RunnerTests
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);
 
-        await runner.Run(candidateTypes, configuration, new HashSet<string>());
+        await runner.Run(candidateTypes, configuration, []);
 
         report.Entries.ShouldBe(
             Self + "+PassTestClass.PassA passed",

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -7,7 +7,7 @@ public class AppVeyorReportTests : MessagingTests
 {
     public async Task ShouldReportResultsToAppVeyorBuildWorkerApi()
     {
-        var results = new List<AppVeyorReport.Result>();
+        List<AppVeyorReport.Result> results = [];
 
         var report = new AppVeyorReport(GetTestEnvironment(), "http://localhost:4567", (uri, content) =>
         {

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -26,7 +26,7 @@ public class AzureReportTests : MessagingTests
         var accessToken = Guid.NewGuid().ToString();
         var buildId = Guid.NewGuid().ToString();
         var runUrl = "http://localhost:4567/run/" + Guid.NewGuid();
-        var requests = new List<object>();
+        List<object> requests = [];
         var batchSize = 3;
 
         Action<HttpClient> assertCommonHttpConcerns = client =>

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -113,7 +113,7 @@ public class LifecycleMessageTests : MessagingTests
         IHandler<TestCompleted>,
         IHandler<ExecutionCompleted>
     {
-        public List<object> Messages { get; } = new();
+        public List<object> Messages { get; } = [];
 
         public Task Handle(ExecutionStarted message)
         {

--- a/src/Fixie.Tests/StubReport.cs
+++ b/src/Fixie.Tests/StubReport.cs
@@ -8,7 +8,7 @@ public class StubReport :
     IHandler<TestPassed>,
     IHandler<TestFailed>
 {
-    readonly List<string> log = new();
+    readonly List<string> log = [];
 
     public Task Handle(TestDiscovered message)
     {

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -90,7 +90,7 @@ public class VsDiscoveryRecorderTests : MessagingTests
 
     class StubMessageLogger : IMessageLogger
     {
-        public List<string> Messages { get; } = new();
+        public List<string> Messages { get; } = [];
 
         public void SendMessage(TestMessageLevel testMessageLevel, string message)
             => Messages.Add($"{testMessageLevel}: {message}");
@@ -98,7 +98,7 @@ public class VsDiscoveryRecorderTests : MessagingTests
 
     class StubTestCaseDiscoverySink : ITestCaseDiscoverySink
     {
-        public List<TestCase> TestCases { get; } = new();
+        public List<TestCase> TestCases { get; } = [];
 
         public void SendTestCase(TestCase discoveredTest)
             => TestCases.Add(discoveredTest);

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -274,7 +274,7 @@ public class VsExecutionRecorderTests : MessagingTests
 
     class StubExecutionRecorder : ITestExecutionRecorder
     {
-        public List<object> Messages { get; } = new();
+        public List<object> Messages { get; } = [];
 
         public void RecordStart(TestCase testCase)
             => Messages.Add(testCase);

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -88,6 +88,6 @@ public static class Utility
             : InvokeOnceWithZeroParameters;
     }
 
-    static readonly object[] EmptyParameters = {};
+    static readonly object[] EmptyParameters = [];
     static readonly object[][] InvokeOnceWithZeroParameters = { EmptyParameters };
 }

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -78,7 +78,7 @@ public static class Utility
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);
 
-        await runner.Run(candidateTypes, configuration, new HashSet<string>());
+        await runner.Run(candidateTypes, configuration, []);
     }
 
     public static IEnumerable<object?[]> FromInputAttributes(Test test)

--- a/src/Fixie/ConventionCollection.cs
+++ b/src/Fixie/ConventionCollection.cs
@@ -6,7 +6,7 @@ public class ConventionCollection
 {
     internal List<Convention> Items { get; }
 
-    internal ConventionCollection() => Items = new List<Convention>();
+    internal ConventionCollection() => Items = [];
 
     public void Add(IDiscovery discovery, IExecution execution)
         => Items.Add(new Convention(discovery, execution));

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -59,7 +59,7 @@ static class GenericArgumentResolver
             TraverseTypes(genericToSpecific, parameterType, argument.GetType());
         }
 
-        var results = new List<Type>();
+        List<Type> results = [];
         foreach (var genericArgument in genericArguments)
         {
             if (genericToSpecific.TryGetValue(genericArgument, out var specificType))

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -103,7 +103,7 @@ class Runner
 
                 if (selectionWorkingList.Count == 0)
                 {
-                    methods = Array.Empty<MethodInfo>();
+                    methods = [];
                 }
                 else
                 {

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -91,7 +91,7 @@ class Runner
         var methodDiscoverer = new MethodDiscoverer(discovery);
 
         var testClasses = new List<TestClass>(selectedTests.Count > 0 ? 0 : classes.Count);
-        var selectionWorkingList = new List<MethodInfo>();
+        List<MethodInfo> selectionWorkingList = [];
 
         foreach (var @class in classes)
         {

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -108,7 +108,7 @@ class Runner
                 else
                 {
                     methods = selectionWorkingList;
-                    selectionWorkingList = new List<MethodInfo>();
+                    selectionWorkingList = [];
                 }
             }
 

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -28,7 +28,7 @@ class Runner
 
     public Task<ExecutionSummary> Run()
     {
-        return Run(assembly.GetTypes(), new HashSet<string>());
+        return Run(assembly.GetTypes(), []);
     }
 
     public Task<ExecutionSummary> Run(HashSet<string> selectedTests)
@@ -38,7 +38,7 @@ class Runner
 
     public Task<ExecutionSummary> Run(TestPattern testPattern)
     {
-        return Run(assembly.GetTypes(), new HashSet<string>(), testPattern);
+        return Run(assembly.GetTypes(), [], testPattern);
     }
 
     async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, HashSet<string> selectedTests, TestPattern? testPattern = null)

--- a/src/Fixie/ReportCollection.cs
+++ b/src/Fixie/ReportCollection.cs
@@ -6,7 +6,7 @@ public class ReportCollection
 {
     internal List<IReport> Items { get; }
 
-    internal ReportCollection() => Items = new List<IReport>();
+    internal ReportCollection() => Items = [];
 
     public void Add(IReport report)
         => Items.Add(report);

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -107,7 +107,7 @@ class ConsoleReport :
 
     static string Summarize(ExecutionCompleted message)
     {
-        var parts = new List<string>();
+        List<string> parts = [];
 
         if (message.Passed > 0)
             parts.Add($"{message.Passed} passed");

--- a/src/Fixie/Reports/XmlReport.cs
+++ b/src/Fixie/Reports/XmlReport.cs
@@ -15,7 +15,7 @@ public class XmlReport :
     readonly TestEnvironment environment;
     readonly Action<XDocument> save;
 
-    readonly SortedDictionary<string, ClassResult> report = new();
+    readonly SortedDictionary<string, ClassResult> report = [];
 
     public XmlReport(TestEnvironment environment, string absoluteOrRelativePath)
         : this(environment, SaveReport(environment, absoluteOrRelativePath))
@@ -114,7 +114,7 @@ public class XmlReport :
     {
         readonly string name;
         TimeSpan duration = TimeSpan.Zero;
-        readonly List<XElement> results = new();
+        readonly List<XElement> results = [];
         readonly ExecutionSummary summary = new();
 
         public ClassResult(string name) => this.name = name;

--- a/src/Fixie/Test.cs
+++ b/src/Fixie/Test.cs
@@ -7,7 +7,7 @@ namespace Fixie;
 
 public class Test
 {
-    static readonly object[] EmptyParameters = {};
+    static readonly object[] EmptyParameters = [];
 
     readonly ExecutionRecorder recorder;
 

--- a/src/Fixie/TestEnvironment.cs
+++ b/src/Fixie/TestEnvironment.cs
@@ -7,7 +7,7 @@ namespace Fixie;
 public class TestEnvironment
 {
     internal TestEnvironment(Assembly assembly, TextWriter console, string rootPath)
-        : this(assembly, console, rootPath, Array.Empty<string>()) { }
+        : this(assembly, console, rootPath, []) { }
 
     internal TestEnvironment(Assembly assembly, TextWriter console, string rootPath,
         IReadOnlyList<string> customArguments)


### PR DESCRIPTION
This applies collection literals across the solution, but only for cases where the empty literal `[]` applies.

Limiting the scope to only empty collections keeps the scope of the PR within reason for review. Furthermore, it is meant to be reviewed one commit at a time, as each commit is dedicated to a single syntax pattern being transformed. Each commit identifies which parts were made by automated refactorings: the only manual change being commit 1 where the following pattern *could* have had an automated refactoring available, but simply doesn't: `Array.Empty<...>()` to `[]`.