### PR TITLE
Apply collection literal [...] for all compatible populated collection initialization.

### DIFF
--- a/src/Fixie.Console/Parser.cs
+++ b/src/Fixie.Console/Parser.cs
@@ -154,7 +154,7 @@ class Parser<T>
                 .Select(p => new NamedArgument(p.ParameterType, p.Name!))
                 .ToArray();
 
-        var dictionary = new Dictionary<string, NamedArgument>();
+        Dictionary<string, NamedArgument> dictionary = [];
 
         foreach (var namedArgument in namedArguments)
         {

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -145,7 +145,7 @@ class Program
             new FileInfo(testProject).Directory!.FullName,
             outputPath);
 
-        var environmentVariables = new Dictionary<string, string>();
+        Dictionary<string, string> environmentVariables = [];
 
         if (options.Tests != null)
             environmentVariables["FIXIE_TESTS_PATTERN"] = options.Tests;

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -112,7 +112,7 @@ class Program
             return targetFrameworks;
 
         if (targetFrameworks.Contains(options.Framework))
-            return new[] {options.Framework};
+            return [options.Framework];
 
         var availableFrameworks = string.Join(", ", targetFrameworks.Select(x => $"'{x}'"));
 

--- a/src/Fixie.Console/Shell.cs
+++ b/src/Fixie.Console/Shell.cs
@@ -53,14 +53,14 @@ static class Shell
 
     static int MsBuild(string project, string target, string? configuration = null, string? targetFramework = null, string? outputPath = null)
     {
-        var arguments = new List<string>
-        {
+        List<string> arguments =
+        [
             "msbuild",
             project,
             "/nologo",
             "/verbosity:minimal",
             "/t:" + target
-        };
+        ];
 
         if (configuration != null)
             arguments.Add($"/p:Configuration={configuration}");

--- a/src/Fixie.TestAdapter/SourceLocationProvider.cs
+++ b/src/Fixie.TestAdapter/SourceLocationProvider.cs
@@ -59,7 +59,7 @@ class SourceLocationProvider
 
     static Dictionary<string, SourceLocation> MethodLocations(TypeDefinition type)
     {
-        var methodLocations = new Dictionary<string, SourceLocation>();
+        Dictionary<string, SourceLocation> methodLocations = [];
 
         foreach (var method in type.GetMethods())
         {

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -9,10 +9,10 @@ static class TestAssembly
 {
     public static bool IsTestAssembly(string assemblyPath)
     {
-        var fixieAssemblies = new[]
-        {
+        string[] fixieAssemblies =
+        [
             "Fixie.dll", "Fixie.TestAdapter.dll"
-        };
+        ];
 
         if (fixieAssemblies.Contains(Path.GetFileName(assemblyPath)))
             return false;
@@ -48,7 +48,7 @@ static class TestAssembly
 
     static Process Run(string assemblyPath)
     {
-        var arguments = new[] { assemblyPath };
+        string[] arguments = [assemblyPath];
 
         var startInfo = new ProcessStartInfo
         {
@@ -80,7 +80,7 @@ static class TestAssembly
         // pass along new environment variables and resolve the
         // full path for the `dotnet` executable.
 
-        var arguments = new[] { assemblyPath };
+        string[] arguments = [assemblyPath];
 
         var environmentVariables = new Dictionary<string, string?>
         {

--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -51,7 +51,7 @@ public class AssertException : Exception
         if (stackTrace == null)
             return null;
 
-        var results = new List<string>();
+        List<string> results = [];
 
         foreach (var line in Lines(stackTrace))
         {

--- a/src/Fixie.Tests/Console/ParserTests.cs
+++ b/src/Fixie.Tests/Console/ParserTests.cs
@@ -321,7 +321,7 @@ public class ParserTests
         Parse<ModelWithArrays>(
             "--integer", "1", "--integer", "2",
             "--string", "three", "--string", "four")
-            .ShouldSucceed(new ModelWithArrays(new[] { 1, 2 }, new[] { "three", "four" }));
+            .ShouldSucceed(new ModelWithArrays([1, 2], ["three", "four"]));
     }
 
     public void ShouldSetEmptyArraysForMissingArrayArguments()
@@ -428,8 +428,8 @@ public class ParserTests
             "--integers", "90")
             .ShouldSucceed(new Complex(
                     "def", 34, true, 56, false,
-                    new[] { "first", "second" },
-                    new[] { 78, 90 }));
+                    ["first", "second"],
+                    [78, 90]));
     }
 
     class ComplexWithParams
@@ -484,8 +484,8 @@ public class ParserTests
             "positionalArgumentC")
             .ShouldSucceed(new ComplexWithParams(
                     "def", 34, true, 56, false,
-                    new[] { "first", "second" },
-                    new[] { 78, 90 },
+                    ["first", "second"],
+                    [78, 90],
                     "positionalArgumentA", "positionalArgumentB", "positionalArgumentC"));
     }
 

--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -79,12 +79,12 @@ public abstract class InstrumentedExecutionTests
     protected Task<Output> Run<TSampleTestClass1, TSampleTestClass2, TExecution>()
         where TExecution : IExecution, new()
         => Run(
-            new[] {typeof(TSampleTestClass1), typeof(TSampleTestClass2)},
+            [typeof(TSampleTestClass1), typeof(TSampleTestClass2)],
             new TExecution());
 
     protected Task<Output> Run<TSampleTestClass1, TSampleTestClass2>(IExecution execution)
         => Run(
-            new[] {typeof(TSampleTestClass1), typeof(TSampleTestClass2)},
+            [typeof(TSampleTestClass1), typeof(TSampleTestClass2)],
             execution);
    
     protected Task<Output> Run<TSampleTestClass>()

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -8,12 +8,12 @@ public class BusTests
 {
     public async Task ShouldPublishEventsToAllReports()
     {
-        var reports = new IReport[]
-        {
+        IReport[] reports =
+        [
             new EventHandler(),
             new AnotherEventHandler(),
             new CombinationEventHandler()
-        };
+        ];
 
         using var console = new RedirectedConsole();
 
@@ -34,11 +34,11 @@ public class BusTests
 
     public async Task ShouldCatchAndLogExceptionsThrowByProblematicReportsRatherThanInterruptExecution()
     {
-        var reports = new IReport[]
-        {
+        IReport[] reports =
+        [
             new EventHandler(),
             new FailingEventHandler()
-        };
+        ];
 
         using var console = new RedirectedConsole();
 

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -7,7 +7,7 @@ namespace Fixie.Tests.Internal;
 public class ClassDiscovererTests
 {
     static readonly Type[] CandidateTypes =
-    {
+    [
         typeof(Decimal),
         typeof(StaticClass),
         typeof(AbstractClass),
@@ -19,7 +19,7 @@ public class ClassDiscovererTests
         typeof(Interface),
         typeof(InheritanceSampleBase),
         typeof(InheritanceSample)
-    };
+    ];
 
     class MaximumDiscovery : IDiscovery
     {

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -20,11 +20,11 @@ public class JsonSerializationTests : MessagingTests
         Expect(new PipeMessage.ExecuteTests { Filter = [] },
             "{\"Filter\":[]}");
 
-        Expect(new PipeMessage.ExecuteTests { Filter = new[]
-            {
+        Expect(new PipeMessage.ExecuteTests { Filter =
+            [
                 TestClass + ".Pass",
                 GenericTestClass + ".ShouldBeString"
-            } },
+            ] },
             "{\"Filter\":[\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\",\"Fixie.Tests.Reports.MessagingTests\\u002BSampleGenericTestClass.ShouldBeString\"]}");
     }
 

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -11,11 +11,11 @@ public class RunnerTests
     {
         var report = new StubReport();
 
-        var candidateTypes = new[]
-        {
+        Type[] candidateTypes =
+        [
             typeof(SampleIrrelevantClass), typeof(PassTestClass), typeof(int),
             typeof(PassFailTestClass), typeof(SkipTestClass)
-        };
+        ];
         var discovery = new SelfTestDiscovery();
         
         var environment = new TestEnvironment(GetType().Assembly, System.Console.Out, Directory.GetCurrentDirectory());
@@ -36,11 +36,11 @@ public class RunnerTests
     {
         var report = new StubReport();
 
-        var candidateTypes = new[]
-        {
+        Type[] candidateTypes =
+        [
             typeof(SampleIrrelevantClass), typeof(PassTestClass), typeof(int),
             typeof(PassFailTestClass), typeof(SkipTestClass)
-        };
+        ];
         var discovery = new SelfTestDiscovery();
         var execution = new CreateInstancePerCase();
 

--- a/src/Fixie.Tests/ParameterizationTests.cs
+++ b/src/Fixie.Tests/ParameterizationTests.cs
@@ -235,8 +235,8 @@ public class ParameterizationTests : InstrumentedExecutionTests
 
     static IEnumerable<object[]> BuggyParameterSource(Test test)
     {
-        yield return new object[] { 0 };
-        yield return new object[] { 1 };
+        yield return [0];
+        yield return [1];
         throw new Exception("Exception thrown while attempting to yield input parameters for method: " + test.Method.Name);
     }
 
@@ -244,14 +244,14 @@ public class ParameterizationTests : InstrumentedExecutionTests
     {
         if (test.Name.EndsWith(".CompoundGenericParameter"))
         {
-            yield return new object[] {new KeyValuePair<int, string>(1, "A"), "System.Int32", "System.String"};
-            yield return new object[] {new KeyValuePair<string, int>("B", 2), "System.String", "System.Int32"};
+            yield return [new KeyValuePair<int, string>(1, "A"), "System.Int32", "System.String"];
+            yield return [new KeyValuePair<string, int>("B", 2), "System.String", "System.Int32"];
         }
         else if (test.Name.EndsWith(".GenericFuncParameter"))
         {
-            yield return new object[] {5, new Func<int, int>(i => i * 2), 10};
-            yield return new object[] {5, new Func<int, string>(i => i.ToString()), "5"};
-            yield return new object[] {5, new Func<int, string>(i => i.ToString()), '5'};
+            yield return [5, new Func<int, int>(i => i * 2), 10];
+            yield return [5, new Func<int, string>(i => i.ToString()), "5"];
+            yield return [5, new Func<int, string>(i => i.ToString()), '5'];
         }
     }
 

--- a/src/Fixie.Tests/ParameterizationTests.cs
+++ b/src/Fixie.Tests/ParameterizationTests.cs
@@ -58,13 +58,13 @@ public class ParameterizationTests : InstrumentedExecutionTests
 
     public async Task ShouldFailWithClearExplanationWhenParameterCountsAreMismatched()
     {
-        var execution = new ParameterizedExecution(method => new[]
+        var execution = new ParameterizedExecution(method => new object[][]
         {
-            new object[] { },
-            new object[] {0},
-            new object[] {0, 1},
-            new object[] {0, 1, 2},
-            new object[] {0, 1, 2, 3}
+            [],
+            [0],
+            [0, 1],
+            [0, 1, 2],
+            [0, 1, 2, 3]
         });
         var output = await Run<ParameterizedTestClass>(execution);
 

--- a/src/Fixie.Tests/ResultEmittingTests.cs
+++ b/src/Fixie.Tests/ResultEmittingTests.cs
@@ -20,9 +20,9 @@ public class ResultEmittingTests : InstrumentedExecutionTests
                 await test.Fail(exception);
                 await test.Skip("Explicit skip reason.");
 
-                await test.Pass(new object[] {0, 'A'});
-                await test.Fail(new object[] {1, 'B'}, exception);
-                await test.Skip(new object[] {2, 'C'}, reason: "");
+                await test.Pass([0, 'A']);
+                await test.Fail([1, 'B'], exception);
+                await test.Skip([2, 'C'], reason: "");
             }
         }
     }

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -89,5 +89,5 @@ public static class Utility
     }
 
     static readonly object[] EmptyParameters = [];
-    static readonly object[][] InvokeOnceWithZeroParameters = { EmptyParameters };
+    static readonly object[][] InvokeOnceWithZeroParameters = [EmptyParameters];
 }

--- a/src/Fixie/Internal/GenericArgumentResolver.cs
+++ b/src/Fixie/Internal/GenericArgumentResolver.cs
@@ -44,7 +44,7 @@ static class GenericArgumentResolver
             arguments = arguments.Take(parameterTypes.Length).ToArray();
         }
 
-        var genericToSpecific = new Dictionary<Type, Type>();
+        Dictionary<Type, Type> genericToSpecific = [];
 
         for (int i = 0; i < parameterTypes.Length; i++)
         {

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -171,7 +171,7 @@ public static class MethodInfoExtensions
 
         try
         {
-            return (Task) genericStartAsTask.Invoke(null, new[] { result, null, null })!;
+            return (Task) genericStartAsTask.Invoke(null, [result, null, null])!;
         }
         catch (TargetInvocationException exception)
         {


### PR DESCRIPTION
This applies collection literals across the solution, but only for cases where the populated literal `[item, item, ...]` applies.

It is meant to be reviewed one commit at a time, as each commit is dedicated to a single syntax pattern being transformed. Each commit identifies that it was made entirely by automated refactorings.