### PR TITLE
Apply collection literals in nontrivial situations.

### DIFF
--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -137,9 +137,7 @@ class Program
         Heading($"Running {assemblyName}{context}");
         WriteLine();
 
-        var arguments = new List<string> { targetFileName };
-
-        arguments.AddRange(customArguments);
+        List<string> arguments = [targetFileName, ..customArguments];
 
         var workingDirectory = Path.Combine(
             new FileInfo(testProject).Directory!.FullName,

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -137,8 +137,6 @@ class Program
         Heading($"Running {assemblyName}{context}");
         WriteLine();
 
-        List<string> arguments = [targetFileName, ..customArguments];
-
         var workingDirectory = Path.Combine(
             new FileInfo(testProject).Directory!.FullName,
             outputPath);
@@ -148,7 +146,7 @@ class Program
         if (options.Tests != null)
             environmentVariables["FIXIE_TESTS_PATTERN"] = options.Tests;
 
-        return Run("dotnet", workingDirectory, arguments.ToArray(), environmentVariables);
+        return Run("dotnet", workingDirectory, [targetFileName, ..customArguments], environmentVariables);
     }
 
     static void Help()

--- a/src/Fixie.Console/Shell.cs
+++ b/src/Fixie.Console/Shell.cs
@@ -6,15 +6,11 @@ static class Shell
 {
     public static int Run(string executable, string workingDirectory, string[] arguments, IDictionary<string, string>? environmentVariables = null)
     {
-        var startInfo = new ProcessStartInfo
+        var startInfo = new ProcessStartInfo(executable, arguments)
         {
-            FileName = executable,
             WorkingDirectory = workingDirectory,
             UseShellExecute = false
         };
-
-        foreach (var argument in arguments)
-            startInfo.ArgumentList.Add(argument);
 
         if (environmentVariables != null)
             foreach (var pair in environmentVariables)

--- a/src/Fixie.TestAdapter/TestAssembly.cs
+++ b/src/Fixie.TestAdapter/TestAssembly.cs
@@ -48,19 +48,11 @@ static class TestAssembly
 
     static Process Run(string assemblyPath)
     {
-        string[] arguments = [assemblyPath];
-
-        var startInfo = new ProcessStartInfo
+        return Start(new ProcessStartInfo("dotnet", [assemblyPath])
         {
             WorkingDirectory = WorkingDirectory(assemblyPath),
-            FileName = "dotnet",
             UseShellExecute = false
-        };
-
-        foreach (var argument in arguments)
-            startInfo.ArgumentList.Add(argument);
-
-        return Start(startInfo);
+        });
     }
 
     static Process? RunAttemptingDebuggerAttachment(string assemblyPath, IFrameworkHandle frameworkHandle,
@@ -80,8 +72,6 @@ static class TestAssembly
         // pass along new environment variables and resolve the
         // full path for the `dotnet` executable.
 
-        string[] arguments = [assemblyPath];
-
         var environmentVariables = new Dictionary<string, string?>
         {
             ["FIXIE_NAMED_PIPE"] = Environment.GetEnvironmentVariable("FIXIE_NAMED_PIPE")
@@ -95,7 +85,7 @@ static class TestAssembly
                 .LaunchProcessWithDebuggerAttached(
                     filePath,
                     WorkingDirectory(assemblyPath),
-                    Serialize(arguments),
+                    Serialize([assemblyPath]),
                     environmentVariables);
 
             return null;

--- a/src/Fixie.Tests/ParameterizationTests.cs
+++ b/src/Fixie.Tests/ParameterizationTests.cs
@@ -58,14 +58,14 @@ public class ParameterizationTests : InstrumentedExecutionTests
 
     public async Task ShouldFailWithClearExplanationWhenParameterCountsAreMismatched()
     {
-        var execution = new ParameterizedExecution(method => new object[][]
-        {
+        var execution = new ParameterizedExecution(method =>
+        [
             [],
             [0],
             [0, 1],
             [0, 1, 2],
             [0, 1, 2, 3]
-        });
+        ]);
         var output = await Run<ParameterizedTestClass>(execution);
 
         output.ShouldHaveResults(

--- a/src/Fixie/Internal/Bus.cs
+++ b/src/Fixie/Internal/Bus.cs
@@ -10,7 +10,7 @@ class Bus
     public Bus(TextWriter console, IReadOnlyList<IReport> reports)
     {
         this.console = console;
-        this.reports = new List<IReport>(reports);
+        this.reports = [..reports];
     }
 
     public async Task Publish<TMessage>(TMessage message) where TMessage : IMessage

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -65,7 +65,7 @@ public class EntryPoint
 
                     exitCode = executeTests.Filter.Length == 0
                         ? await Run(environment, reports, async runner => await runner.Run())
-                        : await Run(environment, reports, async runner => await runner.Run(new HashSet<string>(executeTests.Filter)));
+                        : await Run(environment, reports, async runner => await runner.Run([..executeTests.Filter]));
                 }
                 else
                 {


### PR DESCRIPTION
This applies collection literals in nontrivial situations, where the overall result is a simplification for readability.

It is meant to be reviewed one commit at a time, as each commit is dedicated to a single transformation/concept.