### PR TITLE
Test Adapter Performance

### DIFF
--- a/src/Fixie.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.TestAdapter/VsTestDiscoverer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Pipes;
+﻿using System.Diagnostics;
+using System.IO.Pipes;
 using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -14,6 +15,9 @@ class VsTestDiscoverer : ITestDiscoverer
 {
     public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger log, ITestCaseDiscoverySink discoverySink)
     {
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+
         try
         {
             log.Version();
@@ -25,6 +29,9 @@ class VsTestDiscoverer : ITestDiscoverer
         {
             throw new RunnerException(exception);
         }
+
+        stopwatch.Stop();
+        log.Info($"DiscoverTests took {stopwatch.Elapsed}");
     }
 
     static void DiscoverTests(IMessageLogger log, ITestCaseDiscoverySink discoverySink, string assemblyPath)

--- a/src/Fixie.TestAdapter/VsTestExecutor.cs
+++ b/src/Fixie.TestAdapter/VsTestExecutor.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Pipes;
+﻿using System.Diagnostics;
+using System.IO.Pipes;
 using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -26,13 +27,16 @@ public class VsTestExecutor : ITestExecutor
     /// </summary>
     public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
     {
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+
         ArgumentNullException.ThrowIfNull(sources);
         ArgumentNullException.ThrowIfNull(frameworkHandle);
 
+        IMessageLogger log = frameworkHandle;
+        
         try
         {
-            IMessageLogger log = frameworkHandle;
-
             log.Version();
 
             HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
@@ -49,6 +53,9 @@ public class VsTestExecutor : ITestExecutor
         {
             throw new RunnerException(exception);
         }
+
+        stopwatch.Stop();
+        log.Info($"RunTests[All] took {stopwatch.Elapsed}");
     }
 
     /// <summary>
@@ -63,13 +70,16 @@ public class VsTestExecutor : ITestExecutor
     /// </summary>
     public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
     {
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
+
         ArgumentNullException.ThrowIfNull(tests);
         ArgumentNullException.ThrowIfNull(frameworkHandle);
 
+        IMessageLogger log = frameworkHandle;
+        
         try
         {
-            IMessageLogger log = frameworkHandle;
-
             log.Version();
 
             HandlePoorVsTestImplementationDetails(runContext, frameworkHandle);
@@ -92,6 +102,9 @@ public class VsTestExecutor : ITestExecutor
         {
             throw new RunnerException(exception);
         }
+
+        stopwatch.Stop();
+        log.Info($"RunTests[Selected] took {stopwatch.Elapsed}");
     }
 
     public void Cancel() { }

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using Fixie.Tests.Reports;
 
 namespace Fixie.Tests.Internal;
@@ -127,7 +126,7 @@ public class JsonSerializationTests : MessagingTests
 
     static void Expect<TMessage>(TMessage message, string expectedJson)
     {
-        JsonSerializer.Serialize(JsonSerializer.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
-        JsonSerializer.Serialize(message).ShouldBe(expectedJson);
+        PipeMessage.Serialize(PipeMessage.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
+        PipeMessage.Serialize(message).ShouldBe(expectedJson);
     }
 }

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -124,7 +124,13 @@ public class JsonSerializationTests : MessagingTests
         Expect(new PipeMessage.EndOfPipe(), "{}");
     }
 
-    static void Expect<TMessage>(TMessage message, string expectedJson) where TMessage : class
+    public void ShouldThrowForNullDeserialization()
+    {
+        Action nullMessage = () => PipeMessage.Deserialize<PipeMessage.TestFailed>("null");
+        nullMessage.ShouldThrow<Exception>("Message of type Fixie.Internal.PipeMessage+TestFailed was unexpectedly null.");
+    }
+
+    static void Expect<TMessage>(TMessage message, string expectedJson)
     {
         PipeMessage.Serialize(PipeMessage.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
         PipeMessage.Serialize(message).ShouldBe(expectedJson);

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -1,6 +1,6 @@
-﻿using Fixie.Internal;
+﻿using System.Text.Json;
+using Fixie.Internal;
 using Fixie.Tests.Reports;
-using static System.Text.Json.JsonSerializer;
 
 namespace Fixie.Tests.Internal;
 
@@ -127,7 +127,7 @@ public class JsonSerializationTests : MessagingTests
 
     static void Expect<TMessage>(TMessage message, string expectedJson)
     {
-        Serialize(Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
-        Serialize(message).ShouldBe(expectedJson);
+        JsonSerializer.Serialize(JsonSerializer.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
+        JsonSerializer.Serialize(message).ShouldBe(expectedJson);
     }
 }

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -124,7 +124,7 @@ public class JsonSerializationTests : MessagingTests
         Expect(new PipeMessage.EndOfPipe(), "{}");
     }
 
-    static void Expect<TMessage>(TMessage message, string expectedJson)
+    static void Expect<TMessage>(TMessage message, string expectedJson) where TMessage : class
     {
         PipeMessage.Serialize(PipeMessage.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
         PipeMessage.Serialize(message).ShouldBe(expectedJson);

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using Fixie.Internal;
 using static Fixie.Tests.Utility;
 
@@ -49,7 +50,7 @@ public class RunnerTests
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);
 
-        await runner.Run(candidateTypes, configuration, []);
+        await runner.Run(candidateTypes, configuration, FrozenSet<string>.Empty);
 
         report.Entries.ShouldBe(
             Self + "+PassTestClass.PassA passed",

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -261,7 +261,7 @@ public class VsExecutionRecorderTests : MessagingTests
         }));
     }
 
-    static T Deserialized<T>(T original)
+    static T Deserialized<T>(T original) where T : class
     {
         // Because the inter-process communication between the VsTest process
         // and the test assembly process is not exercised in these single-process

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -1,11 +1,11 @@
-﻿using Fixie.TestAdapter;
+﻿using System.Text.Json;
+using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Fixie.Internal;
 using Fixie.Tests.Reports;
 using static System.Environment;
-using static System.Text.Json.JsonSerializer;
 
 namespace Fixie.Tests.TestAdapter;
 
@@ -269,7 +269,7 @@ public class VsExecutionRecorderTests : MessagingTests
         // tests, put a given sample message through the same serialization round
         // trip that would be applied at runtime, in order to detect data loss.
 
-        return Deserialize<T>(Serialize(original))!;
+        return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(original))!;
     }
 
     class StubExecutionRecorder : ITestExecutionRecorder

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using Fixie.TestAdapter;
+﻿using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -269,7 +268,7 @@ public class VsExecutionRecorderTests : MessagingTests
         // tests, put a given sample message through the same serialization round
         // trip that would be applied at runtime, in order to detect data loss.
 
-        return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(original))!;
+        return PipeMessage.Deserialize<T>(PipeMessage.Serialize(original))!;
     }
 
     class StubExecutionRecorder : ITestExecutionRecorder

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -261,14 +261,14 @@ public class VsExecutionRecorderTests : MessagingTests
         }));
     }
 
-    static T Deserialized<T>(T original) where T : class
+    static T Deserialized<T>(T original)
     {
         // Because the inter-process communication between the VsTest process
         // and the test assembly process is not exercised in these single-process
         // tests, put a given sample message through the same serialization round
         // trip that would be applied at runtime, in order to detect data loss.
 
-        return PipeMessage.Deserialize<T>(PipeMessage.Serialize(original))!;
+        return PipeMessage.Deserialize<T>(PipeMessage.Serialize(original));
     }
 
     class StubExecutionRecorder : ITestExecutionRecorder

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Frozen;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Fixie.Internal;
 using Fixie.Reports;
@@ -78,7 +79,7 @@ public static class Utility
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);
 
-        await runner.Run(candidateTypes, configuration, []);
+        await runner.Run(candidateTypes, configuration, FrozenSet<string>.Empty);
     }
 
     public static IEnumerable<object?[]> FromInputAttributes(Test test)

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Pipes;
+﻿using System.Collections.Frozen;
+using System.IO.Pipes;
 using System.Reflection;
 using Fixie.Reports;
 using static System.Environment;
@@ -65,7 +66,7 @@ public class EntryPoint
 
                     exitCode = executeTests.Filter.Length == 0
                         ? await Run(environment, reports, async runner => await runner.Run())
-                        : await Run(environment, reports, async runner => await runner.Run([..executeTests.Filter]));
+                        : await Run(environment, reports, async runner => await runner.Run(executeTests.Filter.ToFrozenSet()));
                 }
                 else
                 {

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 using Fixie.Reports;
 
 namespace Fixie.Internal;
@@ -9,16 +10,29 @@ namespace Fixie.Internal;
  * deserialization from corresponding serialization where no nulls are in play.
  */
 
+[JsonSerializable(typeof(PipeMessage.DiscoverTests))]
+[JsonSerializable(typeof(PipeMessage.ExecuteTests))]
+[JsonSerializable(typeof(PipeMessage.TestDiscovered))]
+[JsonSerializable(typeof(PipeMessage.TestStarted))]
+[JsonSerializable(typeof(PipeMessage.TestSkipped))]
+[JsonSerializable(typeof(PipeMessage.TestPassed))]
+[JsonSerializable(typeof(PipeMessage.TestFailed))]
+[JsonSerializable(typeof(PipeMessage.Exception))]
+[JsonSerializable(typeof(PipeMessage.EndOfPipe))]
+partial class PipeMessageContext : JsonSerializerContext
+{
+}
+
 static class PipeMessage
 {
     public static string Serialize<TMessage>(TMessage message)
     {
-        return JsonSerializer.Serialize(message);
+        return JsonSerializer.Serialize(message, typeof(TMessage), PipeMessageContext.Default);
     }
 
-    public static TMessage? Deserialize<TMessage>(string json)
+    public static TMessage? Deserialize<TMessage>(string json) where TMessage: class
     {
-        return JsonSerializer.Deserialize<TMessage>(json);
+        return JsonSerializer.Deserialize(json, typeof(TMessage), PipeMessageContext.Default) as TMessage;
     }
 
     public class DiscoverTests { }

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -1,4 +1,5 @@
-﻿using Fixie.Reports;
+﻿using System.Text.Json;
+using Fixie.Reports;
 
 namespace Fixie.Internal;
 
@@ -10,6 +11,16 @@ namespace Fixie.Internal;
 
 static class PipeMessage
 {
+    public static string Serialize<TMessage>(TMessage message)
+    {
+        return JsonSerializer.Serialize(message);
+    }
+
+    public static TMessage? Deserialize<TMessage>(string json)
+    {
+        return JsonSerializer.Deserialize<TMessage>(json);
+    }
+
     public class DiscoverTests { }
 
     public class ExecuteTests

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -30,9 +30,14 @@ static class PipeMessage
         return JsonSerializer.Serialize(message, typeof(TMessage), PipeMessageContext.Default);
     }
 
-    public static TMessage? Deserialize<TMessage>(string json) where TMessage: class
+    public static TMessage Deserialize<TMessage>(string json)
     {
-        return JsonSerializer.Deserialize(json, typeof(TMessage), PipeMessageContext.Default) as TMessage;
+        var message = JsonSerializer.Deserialize(json, typeof(TMessage), PipeMessageContext.Default);
+
+        if (message == null)
+            throw new System.Exception($"Message of type {typeof(TMessage).FullName} was unexpectedly null.");
+        
+        return (TMessage)message;
     }
 
     public class DiscoverTests { }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Collections.Frozen;
+using System.Reflection;
 using Fixie.Reports;
 
 namespace Fixie.Internal;
@@ -28,20 +29,20 @@ class Runner
 
     public Task<ExecutionSummary> Run()
     {
-        return Run(assembly.GetTypes(), []);
+        return Run(assembly.GetTypes(), FrozenSet<string>.Empty);
     }
 
-    public Task<ExecutionSummary> Run(HashSet<string> selectedTests)
+    public Task<ExecutionSummary> Run(FrozenSet<string> selectedTests)
     {
         return Run(assembly.GetTypes(), selectedTests);
     }
 
     public Task<ExecutionSummary> Run(TestPattern testPattern)
     {
-        return Run(assembly.GetTypes(), [], testPattern);
+        return Run(assembly.GetTypes(), FrozenSet<string>.Empty, testPattern);
     }
 
-    async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, HashSet<string> selectedTests, TestPattern? testPattern = null)
+    async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, FrozenSet<string> selectedTests, TestPattern? testPattern = null)
     {
         var configuration = BuildConfiguration();
             
@@ -61,7 +62,7 @@ class Runner
                 await bus.Publish(new TestDiscovered(testMethod.TestName()));
     }
 
-    internal async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, TestConfiguration configuration, HashSet<string> selectedTests, TestPattern? testPattern = null)
+    internal async Task<ExecutionSummary> Run(IReadOnlyList<Type> candidateTypes, TestConfiguration configuration, FrozenSet<string> selectedTests, TestPattern? testPattern = null)
     {
         var conventions = configuration.Conventions.Items;
         var bus = new Bus(console, defaultReports.Concat(configuration.Reports.Items).ToArray());
@@ -84,7 +85,7 @@ class Runner
         }
     }
 
-    static TestSuite BuildTestSuite(IReadOnlyList<Type> candidateTypes, IDiscovery discovery, HashSet<string> selectedTests, TestPattern? testPattern, ExecutionRecorder recorder)
+    static TestSuite BuildTestSuite(IReadOnlyList<Type> candidateTypes, IDiscovery discovery, FrozenSet<string> selectedTests, TestPattern? testPattern, ExecutionRecorder recorder)
     {
         var classDiscoverer = new ClassDiscoverer(discovery);
         var classes = classDiscoverer.TestClasses(candidateTypes);

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -30,7 +30,7 @@ class TestAdapterPipe : IDisposable
         return reader.ReadLine();
     }
 
-    public TMessage Receive<TMessage>()
+    public TMessage Receive<TMessage>() where TMessage : class
     {
         return PipeMessage.Deserialize<TMessage>(ReceiveMessageBody())!;
     }

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -30,9 +30,9 @@ class TestAdapterPipe : IDisposable
         return reader.ReadLine();
     }
 
-    public TMessage Receive<TMessage>() where TMessage : class
+    public TMessage Receive<TMessage>()
     {
-        return PipeMessage.Deserialize<TMessage>(ReceiveMessageBody())!;
+        return PipeMessage.Deserialize<TMessage>(ReceiveMessageBody());
     }
 
     public string ReceiveMessageBody()

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO.Pipes;
 using System.Text;
-using static System.Text.Json.JsonSerializer;
+using System.Text.Json;
 
 namespace Fixie.Internal;
 
@@ -33,7 +33,7 @@ class TestAdapterPipe : IDisposable
 
     public TMessage Receive<TMessage>()
     {
-        return Deserialize<TMessage>(ReceiveMessageBody())!;
+        return JsonSerializer.Deserialize<TMessage>(ReceiveMessageBody())!;
     }
 
     public string ReceiveMessageBody()
@@ -68,7 +68,7 @@ class TestAdapterPipe : IDisposable
         var messageType = typeof(TMessage).FullName!;
 
         writer.WriteLine(messageType);
-        writer.WriteLine(Serialize(message));
+        writer.WriteLine(JsonSerializer.Serialize(message));
         writer.WriteLine(EndOfMessage);
         writer.Flush();
     }

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO.Pipes;
 using System.Text;
-using System.Text.Json;
 
 namespace Fixie.Internal;
 
@@ -33,7 +32,7 @@ class TestAdapterPipe : IDisposable
 
     public TMessage Receive<TMessage>()
     {
-        return JsonSerializer.Deserialize<TMessage>(ReceiveMessageBody())!;
+        return PipeMessage.Deserialize<TMessage>(ReceiveMessageBody())!;
     }
 
     public string ReceiveMessageBody()
@@ -68,7 +67,7 @@ class TestAdapterPipe : IDisposable
         var messageType = typeof(TMessage).FullName!;
 
         writer.WriteLine(messageType);
-        writer.WriteLine(JsonSerializer.Serialize(message));
+        writer.WriteLine(PipeMessage.Serialize(message));
         writer.WriteLine(EndOfMessage);
         writer.Flush();
     }


### PR DESCRIPTION
This was a failed experiment with a few features, to determine if they were worthwhile for Test Adapter performance. I'll be experimenting with parallelism soon, and wanted this experiment in first in case it improved the single-threaded case. If it had, then the subsequent benchmarking around parallelism would be more meaningful if this got in first: a missed opportunity to speed up the single threaded case would needlessly hide measurable changes once threads are involved.

# Background

Originally, VSTest would call one of two entry points in the Test Adapter to run tests: one that has a very small request and indicates that all tests should be executed, and one that has a detailed list of all selected test names to be run. The intention was that when you pick a few tests in the tree, their fully qualified names would be passed to us and we could cross reference that against discovered available tests during the run, skipping anything else.

Unfortunately, VSTest stopped calling the efficient small-payload method when the user selects to "Run All". Instead, the entire list of all fully qualified test names in the entire tree is sent cross-process to the test adapter. Since Fixie deliberately uses a distinct process for test runs, that whole list has to be passed yet again to the test assembly process, where the full list is laboriously cross referenced against each discovered test method. So, the worst case is also a common case, and if we had divine foresight a lot of that work could be omitted.

When this bug was reported to VSTest, it was closed as designed. The change was done on purpose, "for performance reasons". I do not believe that claim, but it does mean there will be no traction there.

# This Experiment

The changes in this experimental branch fell into two categories:

1. Using source generation of well-known types for the interprocess communication payloads.
2. Using `FrozenSet<string>` instead of `HashSet<string>` within the test assembly during the frequent wasteful lookups.

Measurements were taken before and after each change.

There was some hope that the first would dramatically reduce time spent on mundane reflection of payload types, and that the "fast path" mode of serialization in System.Text.Json would add up.

There was some hope that since fully qualified test names often share many prefixes, FrozenSet<string>'s up front analysis would prove worthwhile during frequent lookups.

# Results

Unfortunately, both optimizations had no benefit, even in a representative solution with 25000 tests. Thankfully, this benchmark is still notably faster than xunit running in the same solution despite xunit's parallelism (~7s faster on my machine in a very unscientific measurement), so the opportunity for fine tuning wasn't realistically large in the first place.

The measurable downside of this change was in the size of the build. The source generated serialization code made the Release build of `Fixie.dll` grow by 25%.

Our use case just isn't quite what these tools were made for. We perform approximately one lookup per item in the set, and the number of messages in a typical test run simply doesn't hold a candle to a high-traffic long-running API endpoint.

This won't be merged, but is being preserved anyway since some of the organizational changes will be imitated in a code cleanup branch.