### PR TITLE
Modernize pipe message models' nullability declarations.

### DIFF
--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -13,10 +13,6 @@ public class JsonSerializationTests : MessagingTests
 
     public void ShouldSerializeExecuteTestsMessage()
     {
-        // Unintended case allowed by the type system.
-        Expect(new PipeMessage.ExecuteTests(),
-            "{\"Filter\":null}");
-
         Expect(new PipeMessage.ExecuteTests { Filter = [] },
             "{\"Filter\":[]}");
 
@@ -30,28 +26,18 @@ public class JsonSerializationTests : MessagingTests
 
     public void ShouldSerializeTestDiscoveredMessage()
     {
-        // Unintended case allowed by the type system.
-        Expect(new PipeMessage.TestDiscovered(), "{\"Test\":null}");
-
         Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass" },
             "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
     }
 
     public void ShouldSerializeTestStartedMessage()
     {
-        // Unintended case allowed by the type system.
-        Expect(new PipeMessage.TestStarted(), "{\"Test\":null}");
-
         Expect(new PipeMessage.TestStarted { Test = TestClass + ".Pass" },
             "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
     }
 
     public void ShouldSerializeTestSkippedMessage()
     {
-        // Unintended case allowed by the type system.
-        Expect(new PipeMessage.TestSkipped(),
-            "{\"Reason\":null,\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
-
         Expect(new PipeMessage.TestSkipped
             {
                 Reason = "⚠ Skipped!",
@@ -65,10 +51,6 @@ public class JsonSerializationTests : MessagingTests
 
     public void ShouldSerializeTestPassedMessage()
     {
-        // Unintended case allowed by the type system.
-        Expect(new PipeMessage.TestPassed(),
-            "{\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
-
         Expect(new PipeMessage.TestPassed
             {
                 Test = GenericTestClass + ".ShouldBeString",
@@ -81,10 +63,6 @@ public class JsonSerializationTests : MessagingTests
 
     public void ShouldSerializeTestFailedMessage()
     {
-        // Unintended case allowed by the type system.
-        Expect(new PipeMessage.TestFailed(),
-            "{\"Reason\":null,\"Test\":null,\"TestCase\":null,\"DurationInMilliseconds\":0,\"Output\":null}");
-
         var at = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)").Replace("\\", "\\\\");
 
         Expect(new PipeMessage.TestFailed
@@ -105,10 +83,6 @@ public class JsonSerializationTests : MessagingTests
 
     public void ShouldSerializeExceptionMessage()
     {
-        // Unintended case allowed by the type system.
-        Expect(new PipeMessage.Exception(),
-            "{\"Type\":null,\"Message\":null,\"StackTrace\":null}");
-
         var at = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)").Replace("\\", "\\\\");
 
         Expect(new PipeMessage.Exception

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -14,30 +14,30 @@ static class PipeMessage
 
     public class ExecuteTests
     {
-        public string[] Filter { get; set; } = default!;
+        public string[] Filter { get; init; } = default!;
     }
 
     public class TestDiscovered
     {
-        public string Test { get; set; } = default!;
+        public string Test { get; init; } = default!;
     }
 
     public class TestStarted
     {
-        public string Test { get; set; } = default!;
+        public string Test { get; init; } = default!;
     }
 
     public abstract class TestCompleted
     {
-        public string Test { get; set; } = default!;
-        public string TestCase { get; set; } = default!;
-        public double DurationInMilliseconds { get; set; }
-        public string Output { get; set; } = default!;
+        public string Test { get; init; } = default!;
+        public string TestCase { get; init; } = default!;
+        public double DurationInMilliseconds { get; init; }
+        public string Output { get; init; } = default!;
     }
 
     public class TestSkipped : TestCompleted
     {
-        public string Reason { get; set; } = default!;
+        public string Reason { get; init; } = default!;
     }
 
     public class TestPassed : TestCompleted
@@ -46,7 +46,7 @@ static class PipeMessage
 
     public class TestFailed : TestCompleted
     {
-        public Exception Reason { get; set; } = default!;
+        public Exception Reason { get; init; } = default!;
     }
 
     public class Exception
@@ -62,9 +62,9 @@ static class PipeMessage
             StackTrace = exception.StackTraceSummary();
         }
 
-        public string Type { get; set; } = default!;
-        public string Message { get; set; } = default!;
-        public string StackTrace { get; set; } = default!;
+        public string Type { get; init; } = default!;
+        public string Message { get; init; } = default!;
+        public string StackTrace { get; init; } = default!;
     }
 
     public class EndOfPipe { }

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -1,12 +1,7 @@
-﻿using Fixie.Reports;
+﻿using System.Diagnostics.CodeAnalysis;
+using Fixie.Reports;
 
 namespace Fixie.Internal;
-
-/*
- * Nullability hints here are informed by usages. Although these types are serialized and deserialized
- * to and from JSON, and in theory could be null upon deserialization, we can trace all real
- * deserialization from corresponding serialization where no nulls are in play.
- */
 
 static class PipeMessage
 {
@@ -14,30 +9,30 @@ static class PipeMessage
 
     public class ExecuteTests
     {
-        public string[] Filter { get; init; } = default!;
+        public required string[] Filter { get; init; }
     }
 
     public class TestDiscovered
     {
-        public string Test { get; init; } = default!;
+        public required string Test { get; init; }
     }
 
     public class TestStarted
     {
-        public string Test { get; init; } = default!;
+        public required string Test { get; init; }
     }
 
     public abstract class TestCompleted
     {
-        public string Test { get; init; } = default!;
-        public string TestCase { get; init; } = default!;
-        public double DurationInMilliseconds { get; init; }
-        public string Output { get; init; } = default!;
+        public required string Test { get; init; }
+        public required string TestCase { get; init; }
+        public required double DurationInMilliseconds { get; init; }
+        public required string Output { get; init; }
     }
 
     public class TestSkipped : TestCompleted
     {
-        public string Reason { get; init; } = default!;
+        public required string Reason { get; init; }
     }
 
     public class TestPassed : TestCompleted
@@ -46,7 +41,7 @@ static class PipeMessage
 
     public class TestFailed : TestCompleted
     {
-        public Exception Reason { get; init; } = default!;
+        public required Exception Reason { get; init; }
     }
 
     public class Exception
@@ -55,6 +50,7 @@ static class PipeMessage
         {
         }
 
+        [SetsRequiredMembers]
         public Exception(System.Exception exception)
         {
             Type = exception.GetType().FullName!;
@@ -62,9 +58,9 @@ static class PipeMessage
             StackTrace = exception.StackTraceSummary();
         }
 
-        public string Type { get; init; } = default!;
-        public string Message { get; init; } = default!;
-        public string StackTrace { get; init; } = default!;
+        public required string Type { get; init; }
+        public required string Message { get; init; }
+        public required string StackTrace { get; init; }
     }
 
     public class EndOfPipe { }

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -11,7 +11,7 @@ class TestAdapterReport(TestAdapterPipe pipe) :
 {
     public Task Handle(TestDiscovered message)
     {
-        Write(new PipeMessage.TestDiscovered
+        pipe.Send(new PipeMessage.TestDiscovered
         {
             Test = message.Test
         });
@@ -21,7 +21,7 @@ class TestAdapterReport(TestAdapterPipe pipe) :
 
     public Task Handle(TestStarted message)
     {
-        Write(new PipeMessage.TestStarted
+        pipe.Send(new PipeMessage.TestStarted
         {
             Test = message.Test
         });
@@ -31,7 +31,7 @@ class TestAdapterReport(TestAdapterPipe pipe) :
 
     public Task Handle(TestSkipped message)
     {
-        Write(new PipeMessage.TestSkipped
+        pipe.Send(new PipeMessage.TestSkipped
         {
             Test = message.Test,
             TestCase = message.TestCase,
@@ -45,7 +45,7 @@ class TestAdapterReport(TestAdapterPipe pipe) :
 
     public Task Handle(TestPassed message)
     {
-        Write(new PipeMessage.TestPassed
+        pipe.Send(new PipeMessage.TestPassed
         {
             Test = message.Test,
             TestCase = message.TestCase,
@@ -58,7 +58,7 @@ class TestAdapterReport(TestAdapterPipe pipe) :
 
     public Task Handle(TestFailed message)
     {
-        Write(new PipeMessage.TestFailed
+        pipe.Send(new PipeMessage.TestFailed
         {
             Test = message.Test,
             TestCase = message.TestCase,
@@ -69,6 +69,4 @@ class TestAdapterReport(TestAdapterPipe pipe) :
 
         return Task.CompletedTask;
     }
-
-    void Write<T>(T message) => pipe.Send(message);
 }

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -46,10 +46,7 @@ class TestAdapterReport :
             Output = message.Output
         };
 
-        ((Action<PipeMessage.TestSkipped>?)(x =>
-        {
-            x.Reason = message.Reason;
-        }))?.Invoke(result);
+        result.Reason = message.Reason;
 
         Write(result);
 
@@ -66,8 +63,6 @@ class TestAdapterReport :
             Output = message.Output
         };
 
-        ((Action<PipeMessage.TestPassed>?)null)?.Invoke(result);
-
         Write(result);
 
         return Task.CompletedTask;
@@ -83,10 +78,7 @@ class TestAdapterReport :
             Output = message.Output
         };
 
-        ((Action<PipeMessage.TestFailed>?)(x =>
-        {
-            x.Reason = new PipeMessage.Exception(message.Reason);
-        }))?.Invoke(result);
+        result.Reason = new PipeMessage.Exception(message.Reason);
 
         Write(result);
 

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -38,47 +38,41 @@ class TestAdapterReport :
 
     public Task Handle(TestSkipped message)
     {
-        var result = new PipeMessage.TestSkipped
+        Write(new PipeMessage.TestSkipped
         {
             Test = message.Test,
             TestCase = message.TestCase,
             DurationInMilliseconds = message.Duration.TotalMilliseconds,
             Output = message.Output,
             Reason = message.Reason
-        };
-
-        Write(result);
+        });
 
         return Task.CompletedTask;
     }
 
     public Task Handle(TestPassed message)
     {
-        var result = new PipeMessage.TestPassed
+        Write(new PipeMessage.TestPassed
         {
             Test = message.Test,
             TestCase = message.TestCase,
             DurationInMilliseconds = message.Duration.TotalMilliseconds,
             Output = message.Output
-        };
-
-        Write(result);
+        });
 
         return Task.CompletedTask;
     }
 
     public Task Handle(TestFailed message)
     {
-        var result = new PipeMessage.TestFailed
+        Write(new PipeMessage.TestFailed
         {
             Test = message.Test,
             TestCase = message.TestCase,
             DurationInMilliseconds = message.Duration.TotalMilliseconds,
             Output = message.Output,
             Reason = new PipeMessage.Exception(message.Reason)
-        };
-
-        Write(result);
+        });
 
         return Task.CompletedTask;
     }

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -2,20 +2,13 @@
 
 namespace Fixie.Reports;
 
-class TestAdapterReport :
+class TestAdapterReport(TestAdapterPipe pipe) :
     IHandler<TestDiscovered>,
     IHandler<TestStarted>,
     IHandler<TestSkipped>,
     IHandler<TestPassed>,
     IHandler<TestFailed>
 {
-    readonly TestAdapterPipe pipe;
-
-    public TestAdapterReport(TestAdapterPipe pipe)
-    {
-        this.pipe = pipe;
-    }
-
     public Task Handle(TestDiscovered message)
     {
         Write(new PipeMessage.TestDiscovered

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -43,10 +43,9 @@ class TestAdapterReport :
             Test = message.Test,
             TestCase = message.TestCase,
             DurationInMilliseconds = message.Duration.TotalMilliseconds,
-            Output = message.Output
+            Output = message.Output,
+            Reason = message.Reason
         };
-
-        result.Reason = message.Reason;
 
         Write(result);
 
@@ -75,10 +74,9 @@ class TestAdapterReport :
             Test = message.Test,
             TestCase = message.TestCase,
             DurationInMilliseconds = message.Duration.TotalMilliseconds,
-            Output = message.Output
+            Output = message.Output,
+            Reason = new PipeMessage.Exception(message.Reason)
         };
-
-        result.Reason = new PipeMessage.Exception(message.Reason);
 
         Write(result);
 


### PR DESCRIPTION
When nullable reference types were first enabled, the `PipeMessage` message types presented an annoyance. Their setters were naturally public `{ get; set; }`, though we wanted to declare the property types as non-null. Careful tracing of code paths confirmed that by the time they would be inspected, they really would be non-null. Having to mark them with `?` would have needlessly spread unrealistic warnings to their usages, so instead we marked them all with the "confident assertion" `{ get; set; } = default!`.

Since then C# has added two useful keywords which better help express and enforce the intention of these "serializable property bucket" types. Here we apply both of them:

1. `init` as an alternative to `set`, communicating that they are intended to be populated during construction/initialization.
2. `required` as an alternative to ` = default!`, communicating that there is no need for a weak nullability assertion as the value *will verifiably* be assigned non-null upon initialization.