### PR TITLE
Non null pipe deserialization

### DIFF
--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -1,6 +1,6 @@
-﻿using Fixie.Internal;
+﻿using System.Text.Json;
+using Fixie.Internal;
 using Fixie.Tests.Reports;
-using static System.Text.Json.JsonSerializer;
 
 namespace Fixie.Tests.Internal;
 
@@ -101,7 +101,7 @@ public class JsonSerializationTests : MessagingTests
 
     static void Expect<TMessage>(TMessage message, string expectedJson)
     {
-        Serialize(Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
-        Serialize(message).ShouldBe(expectedJson);
+        JsonSerializer.Serialize(JsonSerializer.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
+        JsonSerializer.Serialize(message).ShouldBe(expectedJson);
     }
 }

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -98,6 +98,12 @@ public class JsonSerializationTests : MessagingTests
         Expect(new PipeMessage.EndOfPipe(), "{}");
     }
 
+    public void ShouldThrowForNullDeserialization()
+    {
+        Action nullMessage = () => PipeMessage.Deserialize<PipeMessage.TestFailed>("null");
+        nullMessage.ShouldThrow<Exception>("Message of type Fixie.Internal.PipeMessage+TestFailed was unexpectedly null.");
+    }
+
     static void Expect<TMessage>(TMessage message, string expectedJson)
     {
         PipeMessage.Serialize(PipeMessage.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);

--- a/src/Fixie.Tests/Internal/JsonSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/JsonSerializationTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using Fixie.Internal;
+﻿using Fixie.Internal;
 using Fixie.Tests.Reports;
 
 namespace Fixie.Tests.Internal;
@@ -101,7 +100,7 @@ public class JsonSerializationTests : MessagingTests
 
     static void Expect<TMessage>(TMessage message, string expectedJson)
     {
-        JsonSerializer.Serialize(JsonSerializer.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
-        JsonSerializer.Serialize(message).ShouldBe(expectedJson);
+        PipeMessage.Serialize(PipeMessage.Deserialize<TMessage>(expectedJson)).ShouldBe(expectedJson);
+        PipeMessage.Serialize(message).ShouldBe(expectedJson);
     }
 }

--- a/src/Fixie.Tests/Internal/PipeMessageSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/PipeMessageSerializationTests.cs
@@ -3,7 +3,7 @@ using Fixie.Tests.Reports;
 
 namespace Fixie.Tests.Internal;
 
-public class JsonSerializationTests : MessagingTests
+public class PipeMessageSerializationTests : MessagingTests
 {
     public void ShouldSerializeDiscoverTestsMessage()
     {

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -1,11 +1,11 @@
-﻿using Fixie.TestAdapter;
+﻿using System.Text.Json;
+using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Fixie.Internal;
 using Fixie.Tests.Reports;
 using static System.Environment;
-using static System.Text.Json.JsonSerializer;
 
 namespace Fixie.Tests.TestAdapter;
 
@@ -269,7 +269,7 @@ public class VsExecutionRecorderTests : MessagingTests
         // tests, put a given sample message through the same serialization round
         // trip that would be applied at runtime, in order to detect data loss.
 
-        return Deserialize<T>(Serialize(original))!;
+        return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(original))!;
     }
 
     class StubExecutionRecorder : ITestExecutionRecorder

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using Fixie.TestAdapter;
+﻿using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -269,7 +268,7 @@ public class VsExecutionRecorderTests : MessagingTests
         // tests, put a given sample message through the same serialization round
         // trip that would be applied at runtime, in order to detect data loss.
 
-        return JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(original))!;
+        return PipeMessage.Deserialize<T>(PipeMessage.Serialize(original))!;
     }
 
     class StubExecutionRecorder : ITestExecutionRecorder

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -268,7 +268,7 @@ public class VsExecutionRecorderTests : MessagingTests
         // tests, put a given sample message through the same serialization round
         // trip that would be applied at runtime, in order to detect data loss.
 
-        return PipeMessage.Deserialize<T>(PipeMessage.Serialize(original))!;
+        return PipeMessage.Deserialize<T>(PipeMessage.Serialize(original));
     }
 
     class StubExecutionRecorder : ITestExecutionRecorder

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -1,10 +1,21 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Fixie.Reports;
 
 namespace Fixie.Internal;
 
 static class PipeMessage
 {
+    public static string Serialize<TMessage>(TMessage message)
+    {
+        return JsonSerializer.Serialize(message);
+    }
+
+    public static TMessage? Deserialize<TMessage>(string json)
+    {
+        return JsonSerializer.Deserialize<TMessage>(json);
+    }
+
     public class DiscoverTests { }
 
     public class ExecuteTests

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -11,9 +11,14 @@ static class PipeMessage
         return JsonSerializer.Serialize(message);
     }
 
-    public static TMessage? Deserialize<TMessage>(string json)
+    public static TMessage Deserialize<TMessage>(string json)
     {
-        return JsonSerializer.Deserialize<TMessage>(json);
+        var message = JsonSerializer.Deserialize<TMessage>(json);
+
+        if (message == null)
+            throw new System.Exception($"Message of type {typeof(TMessage).FullName} was unexpectedly null.");
+
+        return message;
     }
 
     public class DiscoverTests { }

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -32,7 +32,7 @@ class TestAdapterPipe : IDisposable
 
     public TMessage Receive<TMessage>()
     {
-        return PipeMessage.Deserialize<TMessage>(ReceiveMessageBody())!;
+        return PipeMessage.Deserialize<TMessage>(ReceiveMessageBody());
     }
 
     public string ReceiveMessageBody()

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO.Pipes;
 using System.Text;
-using static System.Text.Json.JsonSerializer;
+using System.Text.Json;
 
 namespace Fixie.Internal;
 
@@ -33,7 +33,7 @@ class TestAdapterPipe : IDisposable
 
     public TMessage Receive<TMessage>()
     {
-        return Deserialize<TMessage>(ReceiveMessageBody())!;
+        return JsonSerializer.Deserialize<TMessage>(ReceiveMessageBody())!;
     }
 
     public string ReceiveMessageBody()
@@ -68,7 +68,7 @@ class TestAdapterPipe : IDisposable
         var messageType = typeof(TMessage).FullName!;
 
         writer.WriteLine(messageType);
-        writer.WriteLine(Serialize(message));
+        writer.WriteLine(JsonSerializer.Serialize(message));
         writer.WriteLine(EndOfMessage);
         writer.Flush();
     }

--- a/src/Fixie/Internal/TestAdapterPipe.cs
+++ b/src/Fixie/Internal/TestAdapterPipe.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO.Pipes;
 using System.Text;
-using System.Text.Json;
 
 namespace Fixie.Internal;
 
@@ -33,7 +32,7 @@ class TestAdapterPipe : IDisposable
 
     public TMessage Receive<TMessage>()
     {
-        return JsonSerializer.Deserialize<TMessage>(ReceiveMessageBody())!;
+        return PipeMessage.Deserialize<TMessage>(ReceiveMessageBody())!;
     }
 
     public string ReceiveMessageBody()
@@ -68,7 +67,7 @@ class TestAdapterPipe : IDisposable
         var messageType = typeof(TMessage).FullName!;
 
         writer.WriteLine(messageType);
-        writer.WriteLine(JsonSerializer.Serialize(message));
+        writer.WriteLine(PipeMessage.Serialize(message));
         writer.WriteLine(EndOfMessage);
         writer.Flush();
     }


### PR DESCRIPTION
`PipeMessage` message deserialization has until now worked by calling `JsonSerializer.Deserialize<T>(string)` directly, which can return `null` in the case that the incoming string is the json literal "null". This has two unfortunate consequences:

1. Callers need to insist that the result for pipe messages in particular is not null by marking the call site with `!`, or else the nullability could spread from there.
2. In order to do so confidently, all calls to `JsonSerializer.Deserialize<T>(string)` need to be reviewed, whether relevant to these pipe messages or not, in order to instill the confidence to declare `!` accurately. In fact, all of the pipe messages deserialized come from sources that would not be null during serialization, but it's been a nontrivial analysis each time.

This PR formalizes the path to serialize and deserialize `PipeMessage` types, giving the opportunity to check for null and fail fast, allowing *this* `Deserialize` method to be declared as returning a non-null message, letting call sites omit the risky `!` assertion.

