### PR TITLE
Convert `dotnet fixie` to Top Level Statements

### DIFF
--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -2,19 +2,15 @@
 using static System.IO.Directory;
 using static Fixie.Console.Shell;
 
-namespace Fixie.Console;
+using Fixie.Console;
 
-class Program
-{
     const int Success = 0;
     const int Failure = 1;
     const int FatalError = 2;
 
-    static int Main(string[] arguments)
-    {
         try
         {
-            CommandLine.Partition(arguments, out var runnerArguments, out var customArguments);
+            CommandLine.Partition(args, out var runnerArguments, out var customArguments);
 
             var options = CommandLine.Parse<Options>(runnerArguments);
 
@@ -65,7 +61,6 @@ class Program
 
             return FatalError;
         }
-    }
 
     static IEnumerable<string> TestProjects(Options options)
     {
@@ -198,4 +193,3 @@ class Program
         using (Foreground.Red)
             WriteLine(message);
     }
-}


### PR DESCRIPTION
This trivially converts `dotnet fixie`'s `Program.cs` to Top Level Statements style. It is meant to be reviewed commit by commit. The first commit makes minimal touches to the file to technically convert to Top Level Statements, while avoiding whitespace changes that would complicate review. The second commit is a whitespace-only change where only excessive indentation is removed.