### PR TITLE
Dedicated reporting thread

### DIFF
--- a/src/Fixie/Internal/ExecutionRecorder.cs
+++ b/src/Fixie/Internal/ExecutionRecorder.cs
@@ -6,15 +6,15 @@ namespace Fixie.Internal;
 
 class ExecutionRecorder
 {
-    readonly Channel<IMessage> channel;
+    readonly ChannelWriter<IMessage> channelWriter;
 
     readonly ExecutionSummary assemblySummary;
     readonly Stopwatch assemblyStopwatch;
     readonly Stopwatch caseStopwatch;
 
-    public ExecutionRecorder(Channel<IMessage> channel)
+    public ExecutionRecorder(ChannelWriter<IMessage> channelWriter)
     {
-        this.channel = channel;
+        this.channelWriter = channelWriter;
 
         assemblySummary = new ExecutionSummary();
 
@@ -25,7 +25,7 @@ class ExecutionRecorder
     public async Task StartExecution()
     {
         var message = new ExecutionStarted();
-        await channel.Writer.WriteAsync(message);
+        await channelWriter.WriteAsync(message);
         assemblyStopwatch.Restart();
         caseStopwatch.Restart();
     }
@@ -33,7 +33,7 @@ class ExecutionRecorder
     public async Task Start(Test test)
     {
         var message = new TestStarted(test);
-        await channel.Writer.WriteAsync(message);
+        await channelWriter.WriteAsync(message);
     }
 
     public async Task Skip(Test test, string name, string reason)
@@ -42,7 +42,7 @@ class ExecutionRecorder
 
         var message = new TestSkipped(test.Name, name, duration, reason);
         assemblySummary.Add(message);
-        await channel.Writer.WriteAsync(message);
+        await channelWriter.WriteAsync(message);
 
         caseStopwatch.Restart();
     }
@@ -53,7 +53,7 @@ class ExecutionRecorder
 
         var message = new TestPassed(test.Name, name, duration);
         assemblySummary.Add(message);
-        await channel.Writer.WriteAsync(message);
+        await channelWriter.WriteAsync(message);
 
         caseStopwatch.Restart();
     }
@@ -64,7 +64,7 @@ class ExecutionRecorder
 
         var message = new TestFailed(test.Name, name, duration, reason);
         assemblySummary.Add(message);
-        await channel.Writer.WriteAsync(message);
+        await channelWriter.WriteAsync(message);
 
         caseStopwatch.Restart();
     }
@@ -76,7 +76,7 @@ class ExecutionRecorder
         assemblyStopwatch.Stop();
 
         var message = new ExecutionCompleted(assemblySummary, duration);
-        await channel.Writer.WriteAsync(message);
+        await channelWriter.WriteAsync(message);
 
         return assemblySummary;
     }

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Threading.Channels;
 using Fixie.Reports;
 
 namespace Fixie.Internal;
@@ -66,10 +67,28 @@ class Runner
         var conventions = configuration.Conventions.Items;
         var bus = new Bus(console, defaultReports.Concat(configuration.Reports.Items).ToArray());
 
-        var recorder = new ExecutionRecorder(bus);
-            
         using (new ConsoleRedirectionBoundary())
         {
+            var channel = Channel.CreateUnbounded<IMessage>();
+
+            var recorder = new ExecutionRecorder(channel);
+
+            var consumer = Task.Run(async () =>
+            {
+                await foreach (var message in channel.Reader.ReadAllAsync())
+                {
+                    switch (message)
+                    {
+                        case ExecutionStarted x: await bus.Publish(x); break;
+                        case TestStarted x: await bus.Publish(x); break;
+                        case TestSkipped x: await bus.Publish(x); break;
+                        case TestPassed x: await bus.Publish(x); break;
+                        case TestFailed x: await bus.Publish(x); break;
+                        case ExecutionCompleted x: await bus.Publish(x); break;
+                    }
+                }
+            });
+
             await recorder.StartExecution();
 
             foreach (var convention in conventions)
@@ -78,7 +97,13 @@ class Runner
                 await Run(testSuite, convention.Execution);
             }
 
-            return await recorder.CompleteExecution();
+            var assemblySummary = await recorder.CompleteExecution();
+
+            channel.Writer.Complete();
+
+            await consumer;
+
+            return assemblySummary;
         }
     }
 

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -69,7 +69,14 @@ class Runner
 
         using (new ConsoleRedirectionBoundary())
         {
-            var channel = Channel.CreateUnbounded<IMessage>();
+            var channel = Channel.CreateUnbounded<IMessage>(
+                new UnboundedChannelOptions
+                {
+                    AllowSynchronousContinuations = false,
+                    SingleReader = true,
+                    SingleWriter = false
+                }
+            );
 
             var recorder = new ExecutionRecorder(channel);
 

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -78,11 +78,13 @@ class Runner
                 }
             );
 
-            var recorder = new ExecutionRecorder(channel);
+            var channelReader = channel.Reader;
+
+            var recorder = new ExecutionRecorder(channel.Writer);
 
             var consumer = Task.Run(async () =>
             {
-                await foreach (var message in channel.Reader.ReadAllAsync())
+                await foreach (var message in channelReader.ReadAllAsync())
                 {
                     switch (message)
                     {


### PR DESCRIPTION
This moves all `IReport` execution to a dedicated background thread. Partly, this is to improve test run performance even when tests are run in a single-threaded `IExecution`. Additionally, this is a step towards enabling test runner stability in the presence of a hypothetical parallel `IExecution`, though this PR does not finalize that stability. The `IReport` event processing itself becomes stable, with each message processed in safe sequence, but all mutable state in `ExecutionRecorder` (test counts and durations) would still pose issues in parallel runs.