### PR TITLE
Parallel self testing

### DIFF
--- a/src/Fixie.Console/Foreground.cs
+++ b/src/Fixie.Console/Foreground.cs
@@ -2,15 +2,9 @@
 
 class Foreground : IDisposable
 {
-    readonly ConsoleColor before;
+    public Foreground(ConsoleColor color) => System.Console.ForegroundColor = color;
 
-    public Foreground(ConsoleColor color)
-    {
-        before = System.Console.ForegroundColor;
-        System.Console.ForegroundColor = color;
-    }
-
-    public void Dispose() => System.Console.ForegroundColor = before;
+    public void Dispose() => System.Console.ResetColor();
 
     public static Foreground Red => new(ConsoleColor.Red);
 

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -18,10 +18,14 @@ public class RunnerTests
         ];
         var discovery = new SelfTestDiscovery();
         
-        var environment = new TestEnvironment(GetType().Assembly, System.Console.Out, Directory.GetCurrentDirectory());
+        await using var console = new StringWriter();
+        
+        var environment = GetTestEnvironment(console);
         var runner = new Runner(environment, report);
 
         await runner.Discover(candidateTypes, discovery);
+
+        console.ToString().ShouldBeEmpty();
 
         report.Entries.ShouldBe(
             Self + "+PassTestClass.PassA discovered",
@@ -44,12 +48,16 @@ public class RunnerTests
         var discovery = new SelfTestDiscovery();
         var execution = new CreateInstancePerCase();
 
-        var environment = new TestEnvironment(GetType().Assembly, System.Console.Out, Directory.GetCurrentDirectory());
+        await using var console = new StringWriter();
+        
+        var environment = GetTestEnvironment(console);
         var runner = new Runner(environment, report);
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);
 
         await runner.Run(candidateTypes, configuration, []);
+
+        console.ToString().ShouldBeEmpty();
 
         report.Entries.ShouldBe(
             Self + "+PassTestClass.PassA passed",

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -25,11 +25,11 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
                             var result = await test.Method.Call(instance, parameters);
 
                             if (result != null)
-                                console.WriteLine($"{test.Method.Name} resulted in {result.GetType().FullName} with value {result}");
+                                ConsoleWriteLine($"{test.Method.Name} resulted in {result.GetType().FullName} with value {result}");
                             else if (test.Method.ReturnType != typeof(void) &&
                                      test.Method.ReturnType != typeof(Task) &&
                                      test.Method.ReturnType != typeof(ValueTask))
-                                console.WriteLine($"{test.Method.Name} resulted in null");
+                                ConsoleWriteLine($"{test.Method.Name} resulted in null");
 
                             await test.Pass(parameters, Stopwatch.GetElapsedTime(startTime));
                         }

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -9,7 +9,9 @@ public class AppVeyorReportTests : MessagingTests
     {
         List<AppVeyorReport.Result> results = [];
 
-        var report = new AppVeyorReport(GetTestEnvironment(), "http://localhost:4567", (uri, content) =>
+        await using var console = new StringWriter();
+        
+        var report = new AppVeyorReport(GetTestEnvironment(console), "http://localhost:4567", (uri, content) =>
         {
             uri.ShouldBe("http://localhost:4567/api/tests");
             results.Add(content);
@@ -17,6 +19,8 @@ public class AppVeyorReportTests : MessagingTests
         });
 
         await Run(report);
+
+        console.ToString().ShouldBeEmpty();
 
         results.Count.ShouldBe(7);
 

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -9,13 +9,17 @@ public class XmlReportTests : MessagingTests
 {
     public async Task ShouldProduceValidXmlDocument()
     {
-        var environment = GetTestEnvironment();
+        await using var console = new StringWriter();
+
+        var environment = GetTestEnvironment(console);
 
         XDocument? actual = null;
         var report = new XmlReport(environment, document => actual = document);
 
         await Run(report);
 
+        console.ToString().ShouldBeEmpty();
+        
         if (actual == null)
             throw new Exception("Expected non-null XML report.");
 

--- a/src/Fixie.Tests/TestProject.cs
+++ b/src/Fixie.Tests/TestProject.cs
@@ -4,12 +4,7 @@ class TestProject : ITestProject
 {
     public void Configure(TestConfiguration configuration, TestEnvironment environment)
     {
-        bool enableParallelism = true;
-
-        if (enableParallelism)
-            configuration.Conventions.Add<DefaultDiscovery, ParallelExecution>();
-        else
-            configuration.Conventions.Add<DefaultDiscovery, DefaultExecution>();
+        configuration.Conventions.Add<DefaultDiscovery, ParallelExecution>();
 
         if (environment.IsDevelopment())
             configuration.Reports.Add<DiffToolReport>();

--- a/src/Fixie.Tests/TestProject.cs
+++ b/src/Fixie.Tests/TestProject.cs
@@ -4,9 +4,28 @@ class TestProject : ITestProject
 {
     public void Configure(TestConfiguration configuration, TestEnvironment environment)
     {
+        bool enableParallelism = false;
+
+        if (enableParallelism)
+            configuration.Conventions.Add<DefaultDiscovery, ParallelExecution>();
+        else
+            configuration.Conventions.Add<DefaultDiscovery, DefaultExecution>();
+
         if (environment.IsDevelopment())
             configuration.Reports.Add<DiffToolReport>();
         else
             configuration.Reports.Add(new GitHubReport(environment));
+    }
+
+    class ParallelExecution : IExecution
+    {
+        public async Task Run(TestSuite testSuite)
+        {
+            await Parallel.ForEachAsync(testSuite.TestClasses, async (testClass, cancellationToken) =>
+            {
+                foreach (var test in testClass.Tests)
+                    await test.Run();
+            });
+        }
     }
 }

--- a/src/Fixie.Tests/TestProject.cs
+++ b/src/Fixie.Tests/TestProject.cs
@@ -4,7 +4,7 @@ class TestProject : ITestProject
 {
     public void Configure(TestConfiguration configuration, TestEnvironment environment)
     {
-        bool enableParallelism = false;
+        bool enableParallelism = true;
 
         if (enableParallelism)
             configuration.Conventions.Add<DefaultDiscovery, ParallelExecution>();

--- a/src/Fixie.Tests/TestProject.cs
+++ b/src/Fixie.Tests/TestProject.cs
@@ -21,11 +21,7 @@ class TestProject : ITestProject
     {
         public async Task Run(TestSuite testSuite)
         {
-            await Parallel.ForEachAsync(testSuite.TestClasses, async (testClass, cancellationToken) =>
-            {
-                foreach (var test in testClass.Tests)
-                    await test.Run();
-            });
+            await Parallel.ForEachAsync(testSuite.Tests, async (test, _) => await test.Run());
         }
     }
 }

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -14,14 +14,6 @@ public static class Utility
             console,
             Directory.GetCurrentDirectory());
     }
-    
-    public static TestEnvironment GetTestEnvironment()
-    {
-        return new TestEnvironment(
-            typeof(TestProject).Assembly,
-            System.Console.Out,
-            Directory.GetCurrentDirectory());
-    }
 
     public static string TargetFrameworkVersion => "8.0";
 

--- a/src/Fixie/Internal/Foreground.cs
+++ b/src/Fixie/Internal/Foreground.cs
@@ -2,15 +2,9 @@
 
 class Foreground : IDisposable
 {
-    readonly ConsoleColor before;
+    public Foreground(ConsoleColor color) => Console.ForegroundColor = color;
 
-    public Foreground(ConsoleColor color)
-    {
-        before = Console.ForegroundColor;
-        Console.ForegroundColor = color;
-    }
-
-    public void Dispose() => Console.ForegroundColor = before;
+    public void Dispose() => Console.ResetColor();
 
     public static Foreground Red => new(ConsoleColor.Red);
 

--- a/src/Fixie/Test.cs
+++ b/src/Fixie/Test.cs
@@ -112,7 +112,6 @@ public class Test
     /// <summary>
     /// Emits a pass result for this test.
     /// </summary>
-    /// <param name="duration"></param>
     public async Task Pass(TimeSpan? duration = null)
     {
         await Pass(EmptyParameters, duration);


### PR DESCRIPTION
This finalizes the ability to run Fixie's own self tests under a parallelizing custom `IExecution`.

The primary obstacle here was one test class base that relied heavily on a few static fields and temporal coupling so that hypothetical test suites could be run under instrumentation. The solution was to pivot from static fields to a containing object managed via `AsyncLocal<T>`, allowing each scenario to have an ephemeral global-feeling context of its own.