### PR TITLE
Improve target framework reporting

### DIFF
--- a/src/Fixie.Console/Foreground.cs
+++ b/src/Fixie.Console/Foreground.cs
@@ -9,6 +9,4 @@ class Foreground : IDisposable
     public static Foreground Red => new(ConsoleColor.Red);
 
     public static Foreground Yellow => new(ConsoleColor.Yellow);
-
-    public static Foreground Green => new(ConsoleColor.Green);
 }

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -33,10 +33,9 @@ try
             
         var targetFrameworks = GetTargetFrameworks(options, testProject);
             
-        bool runningForMultipleFrameworks = targetFrameworks.Length > 1;
         foreach (var targetFramework in targetFrameworks)
         {
-            int exitCode = RunTests(options, testProject, targetFramework, customArguments, runningForMultipleFrameworks);
+            int exitCode = RunTests(options, testProject, targetFramework, customArguments);
             
             if (exitCode != Success && exitCode != Failure)
                 Error("Unexpected exit code: " + exitCode);
@@ -115,7 +114,7 @@ static string[] GetTargetFrameworks(Options options, string testProject)
         $"The test project targets the following framework(s): {availableFrameworks}");
 }
 
-static int RunTests(Options options, string testProject, string targetFramework, string[] customArguments, bool runningForMultipleFrameworks)
+static int RunTests(Options options, string testProject, string targetFramework, string[] customArguments)
 {
     var assemblyMetadata = QueryTarget(testProject, "_Fixie_GetAssemblyMetadata", options.Configuration, targetFramework);
 
@@ -123,12 +122,7 @@ static int RunTests(Options options, string testProject, string targetFramework,
     var assemblyName = assemblyMetadata[1];
     var targetFileName = assemblyMetadata[2];
 
-    var context =
-        runningForMultipleFrameworks
-            ? $" ({targetFramework})"
-            : "";
-
-    Heading($"Running {assemblyName}{context}");
+    Heading($"Running {assemblyName} ({targetFramework})");
 
     var workingDirectory = Path.Combine(
         new FileInfo(testProject).Directory!.FullName,

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -133,6 +133,8 @@ static int RunTests(Options options, string testProject, string targetFramework,
     if (options.Tests != null)
         environmentVariables["FIXIE_TESTS_PATTERN"] = options.Tests;
 
+    environmentVariables["FIXIE_TARGET_FRAMEWORK"] = targetFramework;
+
     return Run("dotnet", workingDirectory, [targetFileName, ..customArguments], environmentVariables);
 }
 

--- a/src/Fixie.Console/Program.cs
+++ b/src/Fixie.Console/Program.cs
@@ -122,8 +122,6 @@ static int RunTests(Options options, string testProject, string targetFramework,
     var assemblyName = assemblyMetadata[1];
     var targetFileName = assemblyMetadata[2];
 
-    Heading($"Running {assemblyName} ({targetFramework})");
-
     var workingDirectory = Path.Combine(
         new FileInfo(testProject).Directory!.FullName,
         outputPath);
@@ -174,12 +172,6 @@ static void Help()
     WriteLine("    custom arguments");
     WriteLine("        Arbitrary arguments made available to custom discovery/execution classes.");
     WriteLine();
-}
-
-static void Heading(string message)
-{
-    using (Foreground.Green)
-        WriteLine(message);
 }
 
 static void Error(string message)

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -27,7 +27,7 @@ public class AppVeyorReportTests : MessagingTests
         foreach (var result in results)
         {
             result.TestFramework.ShouldBe("Fixie");
-            result.FileName.ShouldBe($"Fixie.Tests (.NETCoreApp,Version=v{TargetFrameworkVersion})");
+            result.FileName.ShouldBe($"Fixie.Tests (net{TargetFrameworkVersion})");
         }
 
         var fail = results[0];

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -66,7 +66,7 @@ public class AzureReportTests : MessagingTests
         firstRequest.Uri.ShouldBe($"http://localhost:4567/{project}/_apis/test/runs?api-version=5.0");
 
         var createRun = firstRequest.Content;
-        createRun.name.ShouldBe($"Fixie.Tests (.NETCoreApp,Version=v{TargetFrameworkVersion})");
+        createRun.name.ShouldBe($"Fixie.Tests (net{TargetFrameworkVersion})");
         createRun.build.id.ShouldBe(buildId);
         createRun.isAutomated.ShouldBe(true);
 

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Fixie.Reports;
+using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.Reports;
 
@@ -13,6 +14,7 @@ public class ConsoleReportTests : MessagingTests
             .NormalizeStackTraceLines()
             .CleanDuration()
             .ShouldBe(
+                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
 
                 "Test '" + TestClass + ".Fail' failed:",
@@ -56,6 +58,7 @@ public class ConsoleReportTests : MessagingTests
             .NormalizeStackTraceLines()
             .CleanDuration()
             .ShouldBe(
+                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
 
                 "Test '" + TestClass + ".Fail' failed:",

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -38,12 +38,6 @@ public class XmlReportTests : MessagingTests
         //Avoid brittle assertion introduced by system time.
         cleaned = Regex.Replace(cleaned, @"run-time=""\d\d:\d\d:\d\d""", @"run-time=""HH:MM:SS""");
 
-        //Avoid brittle assertion introduced by .NET version.
-        cleaned = cleaned.Replace($@"environment=""{IntPtr.Size * 8}-bit .NETCoreApp,Version=v{TargetFrameworkVersion}""", @"environment=""00-bit .NETCoreApp,Version=vX.Y""");
-
-        //Avoid brittle assertion introduced by fixie version.
-        cleaned = cleaned.Replace($@"test-framework=""{Fixie.Internal.Framework.Version}""", @"test-framework=""Fixie 1.2.3.4""");
-
         //Avoid brittle assertion introduced by test duration.
         cleaned = Regex.Replace(cleaned, @"time=""\d+\.\d\d\d""", @"time=""1.234""");
 
@@ -58,7 +52,7 @@ public class XmlReportTests : MessagingTests
 
             var expected = $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
 <assemblies>
-<assembly name=""{assemblyLocation}"" run-date=""YYYY-MM-DD"" run-time=""HH:MM:SS"" time=""1.234"" total=""7"" passed=""3"" failed=""3"" skipped=""1"" environment=""00-bit .NETCoreApp,Version=vX.Y"" test-framework=""Fixie 1.2.3.4"">
+<assembly name=""{assemblyLocation}"" run-date=""YYYY-MM-DD"" run-time=""HH:MM:SS"" time=""1.234"" total=""7"" passed=""3"" failed=""3"" skipped=""1"" environment=""64-bit net8.0"" test-framework=""{Fixie.Internal.Framework.Version}"">
   <collection time=""1.234"" name=""{GenericTestClass}"" total=""3"" passed=""2"" failed=""1"" skipped=""0"">
     <test name=""{GenericTestClass}.ShouldBeString&lt;System.String&gt;(&quot;A&quot;)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Pass"" time=""1.234"" />
     <test name=""{GenericTestClass}.ShouldBeString&lt;System.String&gt;(&quot;B&quot;)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Pass"" time=""1.234"" />

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -10,6 +10,7 @@ public class StackTracePresentationTests
     {
         (await Run<ConstructionFailureTestClass, ImplicitExceptionHandling>())
             .ShouldBe(
+                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
                 "",
@@ -26,6 +27,7 @@ public class StackTracePresentationTests
     {
         (await Run<ConstructionFailureTestClass, ExplicitExceptionHandling>())
             .ShouldBe(
+                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
                 "",
@@ -45,6 +47,7 @@ public class StackTracePresentationTests
     {
         (await Run<FailureTestClass, ImplicitExceptionHandling>())
             .ShouldBe(
+                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
                 "",
@@ -72,6 +75,7 @@ public class StackTracePresentationTests
 
         output
             .ShouldBe(
+                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
                 "",
@@ -105,6 +109,7 @@ public class StackTracePresentationTests
     {
         (await Run<NestedFailureTestClass, ImplicitExceptionHandling>())
             .ShouldBe(
+                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<NestedFailureTestClass>() + ".Asynchronous' failed:",
                 "",

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -11,11 +11,12 @@ public static class Utility
     {
         return new TestEnvironment(
             typeof(TestProject).Assembly,
+            null,
             console,
             Directory.GetCurrentDirectory());
     }
 
-    public static string TargetFrameworkVersion => "8.0";
+    public const string TargetFrameworkVersion = "8.0";
 
     public static string FullName<T>()
     {
@@ -62,7 +63,7 @@ public static class Utility
         if (candidateTypes.Length == 0)
             throw new InvalidOperationException("At least one type must be specified.");
 
-        var environment = new TestEnvironment(candidateTypes[0].Assembly, console, Directory.GetCurrentDirectory());
+        var environment = new TestEnvironment(candidateTypes[0].Assembly, null, console, Directory.GetCurrentDirectory());
         var runner = new Runner(environment, report);
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -19,7 +19,8 @@ public class EntryPoint
     {
         var console = Console.Out;
         var rootPath = Directory.GetCurrentDirectory();
-        var environment = new TestEnvironment(assembly, console, rootPath, customArguments);
+        var targetFramework = GetEnvironmentVariable("FIXIE_TARGET_FRAMEWORK");
+        var environment = new TestEnvironment(assembly, targetFramework, console, rootPath, customArguments);
 
         using var boundary = new ConsoleRedirectionBoundary();
 

--- a/src/Fixie/Internal/Foreground.cs
+++ b/src/Fixie/Internal/Foreground.cs
@@ -9,4 +9,6 @@ class Foreground : IDisposable
     public static Foreground Red => new(ConsoleColor.Red);
 
     public static Foreground Yellow => new(ConsoleColor.Yellow);
+
+    public static Foreground Green => new(ConsoleColor.Green);
 }

--- a/src/Fixie/Reports/ConsoleReport.cs
+++ b/src/Fixie/Reports/ConsoleReport.cs
@@ -4,11 +4,13 @@ using static System.Environment;
 namespace Fixie.Reports;
 
 class ConsoleReport :
+    IHandler<ExecutionStarted>,
     IHandler<TestSkipped>,
     IHandler<TestPassed>,
     IHandler<TestFailed>,
     IHandler<ExecutionCompleted>
 {
+    readonly TestEnvironment environment;
     readonly string? testPattern;
     readonly TextWriter console;
     readonly bool outputTestPassed;
@@ -20,9 +22,21 @@ class ConsoleReport :
     public ConsoleReport(TestEnvironment environment, string? testPattern = null)
     {
         console = environment.Console;
+        this.environment = environment;
         this.testPattern = testPattern;
         this.outputTestPassed = testPattern != null;
         paddingWouldRequireOpeningBlankLine = true;
+    }
+
+    public Task Handle(ExecutionStarted message)
+    {
+        var assemblyName = Path.GetFileNameWithoutExtension(environment.Assembly.Location);
+        var targetFramework = environment.TargetFramework;
+
+        using (Foreground.Green)
+            console.WriteLine($"Running {assemblyName} ({targetFramework})");
+
+        return Task.CompletedTask;
     }
 
     public Task Handle(TestSkipped message)


### PR DESCRIPTION
Reports wanting to output the target framework of the test assembly have historically accessed `TestEnvironment.TargetFramework` which has only approximated the value by looking up the insufficient `TargetFrameworkAttribute` in the assembly's metadata. This results in strings such as ".NETCoreApp,Version=v8.0" where users would expect and prefer "net8.0" as appears literally in the csproj. This assembly metadata is also "lossy" with respect to less common target framework monikers like "net8.0-windows", where the OS suffix information would be lost.

This PR improves the values of `TestEnvironment.TargetFramework` in two ways:

1. Since `dotnet fixie` has 100% accurate access to the values in the csproj, we use this value verbatim during console runs.
2. When we are not running through `dotnet fixie` (ie VS Test Explorer), we fall back to the `TargetFrameworkAttribute` but are willing to simplify that string to "netX.Y" format when the more verbose string has an obvious transformation available. If `TargetFrameworkAttribute` has some other format, it is allowed to pass through unaltered. This can be "lossy" with respect to things like the optional OS suffix, but is the best available value. Note that the target framework name that appears in VS Test Explorer's own tree of tests is exactly as lossy independent of test framework, and likely for the same reason.