### PR TITLE
Phase out assertion params keyword

### DIFF
--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -109,7 +109,7 @@ public static class AssertionExtensions
             throw new AssertException(expectedJson, actualJson);
     }
 
-    public static void ShouldSatisfy<T>(this IEnumerable<T> actual, params Action<T>[] itemExpectations)
+    public static void ShouldSatisfy<T>(this IEnumerable<T> actual, Action<T>[] itemExpectations)
     {
         var actualItems = actual.ToArray();
 

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -36,7 +36,7 @@ public static class AssertionExtensions
             throw new AssertException(expected?.ToString(), actual?.ToString());
     }
 
-    public static void ShouldBe<T>(this IEnumerable<T> actual, params T[] expected)
+    public static void ShouldBe<T>(this IEnumerable<T> actual, T[] expected)
     {
         actual.ToArray().ShouldMatch(expected);
     }

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -23,13 +23,14 @@ public class BusTests
         await bus.Publish(new Event(3));
 
         console.ToString().Lines()
-            .ShouldBe(
+            .ShouldBe([
                 FullName<EventHandler>() + " handled Event 1",
                 FullName<CombinationEventHandler>() + " handled Event 1",
                 FullName<AnotherEventHandler>() + " handled AnotherEvent 2",
                 FullName<CombinationEventHandler>() + " handled AnotherEvent 2",
                 FullName<EventHandler>() + " handled Event 3",
-                FullName<CombinationEventHandler>() + " handled Event 3");
+                FullName<CombinationEventHandler>() + " handled Event 3"
+            ]);
     }
 
     public async Task ShouldCatchAndLogExceptionsThrowByProblematicReportsRatherThanInterruptExecution()
@@ -48,7 +49,7 @@ public class BusTests
         await bus.Publish(new Event(3));
 
         console.ToString().Lines()
-            .ShouldBe(
+            .ShouldBe([
                 FullName<EventHandler>() + " handled Event 1",
                 FullName<FailingEventHandler>() + $" threw an exception while attempting to handle a message of type {FullName<Event>()}:",
                 "",
@@ -59,7 +60,8 @@ public class BusTests
                 FullName<FailingEventHandler>() + $" threw an exception while attempting to handle a message of type {FullName<Event>()}:",
                 "",
                 FullName<StubException>() + ": Could not handle Event 3",
-                "<<Stack Trace>>");
+                "<<Stack Trace>>"
+            ]);
     }
 
     class Event : IMessage

--- a/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/ClassDiscovererTests.cs
@@ -66,8 +66,7 @@ public class ClassDiscovererTests
         var discovery = new DefaultDiscovery();
 
         DiscoveredTestClasses(discovery)
-            .ShouldBe(
-                typeof(NameEndsWithTests));
+            .ShouldBe([typeof(NameEndsWithTests)]);
     }
 
     public void ShouldSupportMaximalDiscoveryOfConcreteClasses()
@@ -75,14 +74,15 @@ public class ClassDiscovererTests
         var discovery = new MaximumDiscovery();
 
         DiscoveredTestClasses(discovery)
-            .ShouldBe(
+            .ShouldBe([
                 typeof(StaticClass),
                 typeof(DefaultConstructor),
                 typeof(NoDefaultConstructor),
                 typeof(NameEndsWithTests),
                 typeof(String),
                 typeof(InheritanceSampleBase),
-                typeof(InheritanceSample));
+                typeof(InheritanceSample)
+            ]);
     }
 
     public void ShouldNotConsiderCompilerGeneratedClosureClasses()
@@ -98,14 +98,15 @@ public class ClassDiscovererTests
         var discovery = new MaximumDiscovery();
 
         DiscoveredTestClasses(discovery, nested)
-            .ShouldBe(
+            .ShouldBe([
                 typeof(StaticClass),
                 typeof(DefaultConstructor),
                 typeof(NoDefaultConstructor),
                 typeof(NameEndsWithTests),
                 typeof(String),
                 typeof(InheritanceSampleBase),
-                typeof(InheritanceSample));
+                typeof(InheritanceSample)
+            ]);
     }
 
     public void ShouldDiscoverClassesSatisfyingAllSpecifiedConditions()
@@ -113,10 +114,11 @@ public class ClassDiscovererTests
         var discovery = new NarrowDiscovery();
 
         DiscoveredTestClasses(discovery)
-            .ShouldBe(
+            .ShouldBe([
                 typeof(NameEndsWithTests),
                 typeof(InheritanceSampleBase),
-                typeof(InheritanceSample));
+                typeof(InheritanceSample)
+            ]);
     }
 
     public void ShouldFailWithClearExplanationWhenDiscoveryThrows()

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -4,18 +4,16 @@ namespace Fixie.Tests.Internal;
 
 public class GenericArgumentResolverTests
 {
-    static readonly Type[] Empty = [];
-
     public void ShouldResolveNothingWhenThereAreNoInputParameters()
     {
         Resolve("NoParameters")
-            .ShouldBe(Empty);
+            .ShouldBe([]);
     }
 
     public void ShouldResolveNothingWhenThereAreNoGenericParameters()
     {
         Resolve("NoGenericArguments", 0, "")
-            .ShouldBe(Empty);
+            .ShouldBe([]);
     }
 
     public void ShouldNotResolveWhenGenericTypeHasNoMatchingParameters()
@@ -33,28 +31,28 @@ public class GenericArgumentResolverTests
     public void ShouldResolveToConcreteTypeOfValueWhenGenericTypeHasOneNonNullMatchingParameter()
     {
         Resolve("OneMatchingParameter", 1.2m)
-            .ShouldBe(typeof(decimal));
+            .ShouldBe([typeof(decimal)]);
 
         Resolve("OneMatchingParameter", "string")
-            .ShouldBe(typeof(string));
+            .ShouldBe([typeof(string)]);
     }
 
     public void ShouldResolveToFirstConcreteTypeWhenGenericTypeHasMultipleMatchingParametersOfInconsistentConcreteTypes()
     {
         Resolve("MultipleMatchingParameter", 1.2m, "string", 0)
-            .ShouldBe(typeof(decimal));
+            .ShouldBe([typeof(decimal)]);
         
         Resolve("MultipleMatchingParameter", 1.2m, "string a", "string b")
-            .ShouldBe(typeof(decimal));
+            .ShouldBe([typeof(decimal)]);
     }
 
     public void ShouldResolveToConcreteTypeOfValuesWhenGenericTypeHasMultipleMatchingParametersOfTheExactSameConcreteType()
     {
         Resolve("MultipleMatchingParameter", 1.2m, 2.3m, 3.4m)
-            .ShouldBe(typeof(decimal));
+            .ShouldBe([typeof(decimal)]);
 
         Resolve("MultipleMatchingParameter", "string a", "string b", "string c")
-            .ShouldBe(typeof(string));
+            .ShouldBe([typeof(string)]);
     }
 
     public void ShouldNotResolveWhenGenericTypeHasMultipleMatchingParametersButAllAreNull()
@@ -66,25 +64,25 @@ public class GenericArgumentResolverTests
     public void ShouldTreatNullsAsTypeCompatibleWithReferenceTypes()
     {
         Resolve("MultipleMatchingParameter", null, "string b", "string c")
-            .ShouldBe(typeof(string));
+            .ShouldBe([typeof(string)]);
 
         Resolve("MultipleMatchingParameter", "string a", null, "string c")
-            .ShouldBe(typeof(string));
+            .ShouldBe([typeof(string)]);
 
         Resolve("MultipleMatchingParameter", "string a", "string b", null)
-            .ShouldBe(typeof(string));
+            .ShouldBe([typeof(string)]);
     }
 
     public void ShouldIgnoreNullAsTypeIncompatibleWithValueTypes()
     {
         Resolve("MultipleMatchingParameter", null, 2.3m, 3.4m)
-            .ShouldBe(typeof(decimal));
+            .ShouldBe([typeof(decimal)]);
 
         Resolve("MultipleMatchingParameter", 1.2m, null, 3.4m)
-            .ShouldBe(typeof(decimal));
+            .ShouldBe([typeof(decimal)]);
 
         Resolve("MultipleMatchingParameter", 1.2m, 2.3m, null)
-            .ShouldBe(typeof(decimal));
+            .ShouldBe([typeof(decimal)]);
     }
 
     public void ShouldResolveGenericArgumentsIfAndOnlyIfTheyCanAllBeResolved()
@@ -143,16 +141,16 @@ public class GenericArgumentResolverTests
                 x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
 
         Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string", 0)
-            .ShouldBe(typeof(bool), typeof(decimal));
+            .ShouldBe([typeof(bool), typeof(decimal)]);
 
         Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string a", "string b")
-            .ShouldBe(typeof(bool), typeof(decimal));
+            .ShouldBe([typeof(bool), typeof(decimal)]);
 
         Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, 2.3m, 3.4m)
-            .ShouldBe(typeof(bool), typeof(decimal));
+            .ShouldBe([typeof(bool), typeof(decimal)]);
 
         Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", "string c")
-            .ShouldBe(typeof(bool), typeof(string));
+            .ShouldBe([typeof(bool), typeof(string)]);
 
         Resolve("MultipleSatisfiableGenericArguments", false, null, null, null)
             .ShouldSatisfy(
@@ -160,10 +158,10 @@ public class GenericArgumentResolverTests
                 x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
         
         Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", null)
-            .ShouldBe(typeof(bool), typeof(string));
+            .ShouldBe([typeof(bool), typeof(string)]);
 
         Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, 2.3m, null)
-            .ShouldBe(typeof(bool), typeof(decimal));
+            .ShouldBe([typeof(bool), typeof(decimal)]);
     }
 
     public void ShouldNotResolveWhenInputParameterCountIsLessThanDeclaredParameterCount()
@@ -175,48 +173,48 @@ public class GenericArgumentResolverTests
     public void ShouldAttemptReasonableResolutionByIgnoringExcessParametersWhenInputParameterCountIsGreaterThanDeclaredParameterCount()
     {
         Resolve("MultipleMatchingParameter", 1, 2, 3, 4)
-            .ShouldBe(typeof(int));
+            .ShouldBe([typeof(int)]);
     }
 
     public void ShouldResolveGenericArgumentsWhenGenericConstraintsAreSatisfied()
     {
         Resolve("ConstrainedGeneric", 1)
-            .ShouldBe(typeof(int));
+            .ShouldBe([typeof(int)]);
 
         Resolve("ConstrainedGeneric", true)
-            .ShouldBe(typeof(bool));
+            .ShouldBe([typeof(bool)]);
     }
 
     public void ShouldResolveGenericTypeParametersAppearingWithinComplexParameterTypes()
     {
         Resolve("CompoundGenericParameter", new KeyValuePair<int, string>(1, "A"))
-            .ShouldBe(typeof(int), typeof(string));
+            .ShouldBe([typeof(int), typeof(string)]);
 
         Resolve("CompoundGenericParameter", new KeyValuePair<string, int>("A", 1))
-            .ShouldBe(typeof(string), typeof(int));
+            .ShouldBe([typeof(string), typeof(int)]);
 
         Resolve("GenericFuncParameter", 5, new Func<int, int>(i => i * 2), 10)
-            .ShouldBe(typeof(int));
+            .ShouldBe([typeof(int)]);
 
         Resolve("GenericFuncParameter", 5, new Func<int, string>(i => i.ToString()), "5")
-            .ShouldBe(typeof(string));
+            .ShouldBe([typeof(string)]);
 
         //We select string as our T, though the char argument would fail to cast at runtime,
         //causing this test to fail.
         Resolve("GenericFuncParameter", 5, new Func<int, string>(i => i.ToString()), '5')
-            .ShouldBe(typeof(string));
+            .ShouldBe([typeof(string)]);
     }
 
     public void ShouldResolveGenericTypeParametersAppearingWithinArrays()
     {
         Resolve("GenericArrayResolution", new[] {1}, "A")
-            .ShouldBe(typeof(int), typeof(string));
+            .ShouldBe([typeof(int), typeof(string)]);
 
         Resolve("GenericArrayResolution", new[] {"B"}, 2)
-            .ShouldBe(typeof(string), typeof(int));
+            .ShouldBe([typeof(string), typeof(int)]);
 
         Resolve("GenericArrayResolution", new[] {"C"}, new[] {3})
-            .ShouldBe(typeof(string), typeof(int[]));
+            .ShouldBe([typeof(string), typeof(int[])]);
 
         Resolve("GenericArrayResolution", 0, 1)
             .ShouldSatisfy(
@@ -227,22 +225,22 @@ public class GenericArgumentResolverTests
     public void ShouldResolveNullableValueTypeParametersWithConcreteValueTypes()
     {
         Resolve("NullableValueTypeResolution", 1, 2, 3, 4)
-            .ShouldBe(typeof(int), typeof(int));
+            .ShouldBe([typeof(int), typeof(int)]);
 
         Resolve("NullableValueTypeResolution", 'a', 2.0d, 3.0d, 4)
-            .ShouldBe(typeof(char), typeof(double));
+            .ShouldBe([typeof(char), typeof(double)]);
         
         Resolve("NullableValueTypeResolution", 'a', 2.0d, 3, 4)
-            .ShouldBe(typeof(char), typeof(double));
+            .ShouldBe([typeof(char), typeof(double)]);
         
         Resolve("NullableValueTypeResolution", 'a', 2, 3.03, 4)
-            .ShouldBe(typeof(char), typeof(int));
+            .ShouldBe([typeof(char), typeof(int)]);
 
         Resolve("NullableValueTypeResolution", 'a', null, 3.03, 4)
-            .ShouldBe(typeof(char), typeof(double));
+            .ShouldBe([typeof(char), typeof(double)]);
 
         Resolve("NullableValueTypeResolution", 'a', 2, null, 4)
-            .ShouldBe(typeof(char), typeof(int));
+            .ShouldBe([typeof(char), typeof(int)]);
 
         Resolve("NullableValueTypeResolution", null, 2, 3, 4)
             .ShouldSatisfy(

--- a/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
+++ b/src/Fixie.Tests/Internal/GenericArgumentResolverTests.cs
@@ -19,13 +19,13 @@ public class GenericArgumentResolverTests
     public void ShouldNotResolveWhenGenericTypeHasNoMatchingParameters()
     {
         Resolve("NoMatchingParameters", 0, "")
-            .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
+            .ShouldSatisfy([x => x.ShouldBeGenericTypeParameter("T")]);
     }
 
     public void ShouldNotResolveWhenGenericTypeHasOneNullMatchingParameter()
     {
         Resolve("OneMatchingParameter", new object?[] {null})
-            .ShouldSatisfy(t => t.ShouldBeGenericTypeParameter("T"));
+            .ShouldSatisfy([t => t.ShouldBeGenericTypeParameter("T")]);
     }
         
     public void ShouldResolveToConcreteTypeOfValueWhenGenericTypeHasOneNonNullMatchingParameter()
@@ -58,7 +58,7 @@ public class GenericArgumentResolverTests
     public void ShouldNotResolveWhenGenericTypeHasMultipleMatchingParametersButAllAreNull()
     {
         Resolve("MultipleMatchingParameter", null, null, null)
-            .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
+            .ShouldSatisfy([x => x.ShouldBeGenericTypeParameter("T")]);
     }
 
     public void ShouldTreatNullsAsTypeCompatibleWithReferenceTypes()
@@ -88,57 +88,66 @@ public class GenericArgumentResolverTests
     public void ShouldResolveGenericArgumentsIfAndOnlyIfTheyCanAllBeResolved()
     {
         Resolve("MultipleUnsatisfiableGenericArguments", null, 1.2m, "string", 0)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TNoMatch"),
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
 
         Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, "string", 0)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TNoMatch"),
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
 
         Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, "string a", "string b")
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TNoMatch"),
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
 
         Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, 2.3m, 3.4m)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TNoMatch"),
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
 
         Resolve("MultipleUnsatisfiableGenericArguments", false, "string a", "string b", "string c")
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TNoMatch"),
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
 
         Resolve("MultipleUnsatisfiableGenericArguments", false, null, null, null)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TNoMatch"),
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
-        
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
+
         Resolve("MultipleUnsatisfiableGenericArguments", false, "string a", "string b", null)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TNoMatch"),
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
 
         Resolve("MultipleUnsatisfiableGenericArguments", false, 1.2m, 2.3m, null)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TNoMatch"),
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
 
         Resolve("MultipleSatisfiableGenericArguments", null, 1.2m, "string", 0)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
 
         Resolve("MultipleSatisfiableGenericArguments", false, 1.2m, "string", 0)
             .ShouldBe([typeof(bool), typeof(decimal)]);
@@ -153,9 +162,10 @@ public class GenericArgumentResolverTests
             .ShouldBe([typeof(bool), typeof(string)]);
 
         Resolve("MultipleSatisfiableGenericArguments", false, null, null, null)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("TOneMatch"),
-                x => x.ShouldBeGenericTypeParameter("TMultipleMatch"));
+                x => x.ShouldBeGenericTypeParameter("TMultipleMatch")
+            ]);
         
         Resolve("MultipleSatisfiableGenericArguments", false, "string a", "string b", null)
             .ShouldBe([typeof(bool), typeof(string)]);
@@ -167,7 +177,7 @@ public class GenericArgumentResolverTests
     public void ShouldNotResolveWhenInputParameterCountIsLessThanDeclaredParameterCount()
     {
         Resolve("MultipleMatchingParameter", 1, 2)
-            .ShouldSatisfy(x => x.ShouldBeGenericTypeParameter("T"));
+            .ShouldSatisfy([x => x.ShouldBeGenericTypeParameter("T")]);
     }
 
     public void ShouldAttemptReasonableResolutionByIgnoringExcessParametersWhenInputParameterCountIsGreaterThanDeclaredParameterCount()
@@ -217,9 +227,10 @@ public class GenericArgumentResolverTests
             .ShouldBe([typeof(string), typeof(int[])]);
 
         Resolve("GenericArrayResolution", 0, 1)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("T1"),
-                x => x.ShouldBeGenericTypeParameter("T2"));
+                x => x.ShouldBeGenericTypeParameter("T2")
+            ]);
     }
 
     public void ShouldResolveNullableValueTypeParametersWithConcreteValueTypes()
@@ -243,9 +254,10 @@ public class GenericArgumentResolverTests
             .ShouldBe([typeof(char), typeof(int)]);
 
         Resolve("NullableValueTypeResolution", null, 2, 3, 4)
-            .ShouldSatisfy(
+            .ShouldSatisfy([
                 x => x.ShouldBeGenericTypeParameter("T1"),
-                x => x.ShouldBeGenericTypeParameter("T2"));
+                x => x.ShouldBeGenericTypeParameter("T2")
+            ]);
     }
 
     public void ShouldLeaveGenericTypeParameterWhenGenericTypeParametersCannotBeResolved()

--- a/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
+++ b/src/Fixie.Tests/Internal/MethodDiscovererTests.cs
@@ -44,18 +44,20 @@ public class MethodDiscovererTests
         var discovery = new DefaultDiscovery();
 
         DiscoveredTestMethods<Sample>(discovery)
-            .ShouldBe(
+            .ShouldBe([
                 "PublicInstanceNoArgsVoid()",
                 "PublicInstanceNoArgsWithReturn()",
                 "PublicInstanceWithArgsVoid(x)",
-                "PublicInstanceWithArgsWithReturn(x)");
+                "PublicInstanceWithArgsWithReturn(x)"
+            ]);
 
         DiscoveredTestMethods<AsyncSample>(discovery)
-            .ShouldBe(
+            .ShouldBe([
                 "PublicInstanceNoArgsVoid()",
                 "PublicInstanceNoArgsWithReturn()",
                 "PublicInstanceWithArgsVoid(x)",
-                "PublicInstanceWithArgsWithReturn(x)");
+                "PublicInstanceWithArgsWithReturn(x)"
+            ]);
     }
 
     public void ShouldSupportMaximalDiscoveryOfAllPublicMethods()
@@ -63,7 +65,7 @@ public class MethodDiscovererTests
         var discovery = new MaximumDiscovery();
 
         DiscoveredTestMethods<Sample>(discovery)
-            .ShouldBe(
+            .ShouldBe([
                 "PublicInstanceNoArgsVoid()",
                 "PublicInstanceNoArgsWithReturn()",
                 "PublicInstanceWithArgsVoid(x)",
@@ -72,10 +74,11 @@ public class MethodDiscovererTests
                 "PublicStaticNoArgsVoid()",
                 "PublicStaticNoArgsWithReturn()",
                 "PublicStaticWithArgsVoid(x)",
-                "PublicStaticWithArgsWithReturn(x)");
+                "PublicStaticWithArgsWithReturn(x)"
+            ]);
 
         DiscoveredTestMethods<AsyncSample>(discovery)
-            .ShouldBe(
+            .ShouldBe([
                 "PublicInstanceNoArgsVoid()",
                 "PublicInstanceNoArgsWithReturn()",
                 "PublicInstanceWithArgsVoid(x)",
@@ -84,7 +87,8 @@ public class MethodDiscovererTests
                 "PublicStaticNoArgsVoid()",
                 "PublicStaticNoArgsWithReturn()",
                 "PublicStaticWithArgsVoid(x)",
-                "PublicStaticWithArgsWithReturn(x)");
+                "PublicStaticWithArgsWithReturn(x)"
+            ]);
     }
 
     public void ShouldDiscoverMethodsSatisfyingAllSpecifiedConditions()
@@ -92,7 +96,7 @@ public class MethodDiscovererTests
         var discovery = new NarrowDiscovery();
 
         DiscoveredTestMethods<Sample>(discovery)
-            .ShouldBe("PublicInstanceNoArgsVoid()");
+            .ShouldBe(["PublicInstanceNoArgsVoid()"]);
     }
 
     public void ShouldFailWithClearExplanationWhenDiscoveryThrows()

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -27,13 +27,14 @@ public class RunnerTests
 
         console.ToString().ShouldBeEmpty();
 
-        report.Entries.ShouldBe(
+        report.Entries.ShouldBe([
             Self + "+PassTestClass.PassA discovered",
             Self + "+PassTestClass.PassB discovered",
             Self + "+PassFailTestClass.Fail discovered",
             Self + "+PassFailTestClass.Pass discovered",
             Self + "+SkipTestClass.SkipA discovered",
-            Self + "+SkipTestClass.SkipB discovered");
+            Self + "+SkipTestClass.SkipB discovered"
+        ]);
     }
 
     public async Task ShouldPerformExecutionPhase()
@@ -59,13 +60,14 @@ public class RunnerTests
 
         console.ToString().ShouldBeEmpty();
 
-        report.Entries.ShouldBe(
+        report.Entries.ShouldBe([
             Self + "+PassTestClass.PassA passed",
             Self + "+PassTestClass.PassB passed",
             Self + "+PassFailTestClass.Fail failed: 'Fail' failed!",
             Self + "+PassFailTestClass.Pass passed",
             Self + "+SkipTestClass.SkipA skipped: This test did not run.",
-            Self + "+SkipTestClass.SkipB skipped: This test did not run.");
+            Self + "+SkipTestClass.SkipB skipped: This test did not run."
+        ]);
     }
 
     class CreateInstancePerCase : IExecution

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -45,19 +45,20 @@ public class AppVeyorReportTests : MessagingTests
         fail.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
+            .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
         fail.StdOut.ShouldBe("");
 
         failByAssertion.TestName.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.Outcome.ShouldBe("Failed");
         int.Parse(failByAssertion.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-        failByAssertion.ErrorMessage.Lines().ShouldBe(
+        failByAssertion.ErrorMessage.Lines().ShouldBe([
             "Expected: 2",
-            "Actual:   1");
+            "Actual:   1"
+        ]);
         failByAssertion.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
+            .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
         failByAssertion.StdOut.ShouldBe("");
 
         pass.TestName.ShouldBe(TestClass + ".Pass");
@@ -91,13 +92,17 @@ public class AppVeyorReportTests : MessagingTests
         shouldBeStringFail.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.Outcome.ShouldBe("Failed");
         int.Parse(shouldBeStringFail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-        shouldBeStringFail.ErrorMessage.Lines().ShouldBe(
+        shouldBeStringFail.ErrorMessage.Lines().ShouldBe([
             "Expected: System.String",
-            "Actual:   System.Int32");
+            "Actual:   System.Int32"
+        ]);
         shouldBeStringFail.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe("Fixie.Tests.Assertions.AssertException", At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
+            .ShouldBe([
+                "Fixie.Tests.Assertions.AssertException",
+                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
+            ]);
         shouldBeStringFail.StdOut.ShouldBe("");
     }
 }

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -106,19 +106,20 @@ public class AzureReportTests : MessagingTests
         fail.stackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
+            .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
 
         failByAssertion.automatedTestName.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.testCaseTitle.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.outcome.ShouldBe("Failed");
         failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-        failByAssertion.errorMessage.Lines().ShouldBe(
+        failByAssertion.errorMessage.Lines().ShouldBe([
             "Expected: 2",
-            "Actual:   1");
+            "Actual:   1"
+        ]);
         failByAssertion.stackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
+            .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
 
         pass.automatedTestName.ShouldBe(TestClass + ".Pass");
         pass.testCaseTitle.ShouldBe(TestClass + ".Pass");
@@ -152,15 +153,17 @@ public class AzureReportTests : MessagingTests
         shouldBeStringFail.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.outcome.ShouldBe("Failed");
         shouldBeStringFail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-        shouldBeStringFail.errorMessage.Lines().ShouldBe(
+        shouldBeStringFail.errorMessage.Lines().ShouldBe([
             "Expected: System.String",
-            "Actual:   System.Int32");
+            "Actual:   System.Int32"
+        ]);
         shouldBeStringFail.stackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe(
+            .ShouldBe([
                 "Fixie.Tests.Assertions.AssertException",
-                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
+                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
+            ]);
 
         var lastRequest = (Request<AzureReport.CompleteRun>)requests.Last();
         lastRequest.Method.ShouldBe(new HttpMethod("PATCH"));

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -13,7 +13,7 @@ public class ConsoleReportTests : MessagingTests
         output.Console
             .NormalizeStackTraceLines()
             .CleanDuration()
-            .ShouldBe(
+            .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
 
@@ -47,7 +47,8 @@ public class ConsoleReportTests : MessagingTests
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
                 "",
 
-                "3 passed, 3 failed, 1 skipped, took 1.23 seconds");
+                "3 passed, 3 failed, 1 skipped, took 1.23 seconds"
+            ]);
     }
 
     public async Task ShouldIncludePassingResultsWhenFilteringByPattern()
@@ -57,7 +58,7 @@ public class ConsoleReportTests : MessagingTests
         output.Console
             .NormalizeStackTraceLines()
             .CleanDuration()
-            .ShouldBe(
+            .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
 
@@ -98,7 +99,8 @@ public class ConsoleReportTests : MessagingTests
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
                 "",
 
-                "3 passed, 3 failed, 1 skipped, took 1.23 seconds");
+                "3 passed, 3 failed, 1 skipped, took 1.23 seconds"
+            ]);
     }
 
     class ZeroPassed : SelfTestDiscovery

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -45,7 +45,7 @@ public class LifecycleMessageTests : MessagingTests
         fail.Reason.StackTraceSummary()
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe(At("Fail()"));
+            .ShouldBe([At("Fail()")]);
         fail.Reason.Message.ShouldBe("'Fail' failed!");
 
         failByAssertionStarted.Test.ShouldBe(TestClass + ".FailByAssertion");
@@ -57,10 +57,11 @@ public class LifecycleMessageTests : MessagingTests
         failByAssertion.Reason.StackTraceSummary()
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe(At("FailByAssertion()"));
-        failByAssertion.Reason.Message.Lines().ShouldBe(
+            .ShouldBe([At("FailByAssertion()")]);
+        failByAssertion.Reason.Message.Lines().ShouldBe([
             "Expected: 2",
-            "Actual:   1");
+            "Actual:   1"
+        ]);
 
         skip.Test.ShouldBe(TestClass + ".Skip");
         skip.TestCase.ShouldBe(TestClass + ".Skip");
@@ -88,10 +89,11 @@ public class LifecycleMessageTests : MessagingTests
         shouldBeStringFail.Reason.StackTraceSummary()
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe(At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
-        shouldBeStringFail.Reason.Message.Lines().ShouldBe(
+            .ShouldBe([At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")]);
+        shouldBeStringFail.Reason.Message.Lines().ShouldBe([
             "Expected: System.String",
-            "Actual:   System.Int32");
+            "Actual:   System.Int32"
+        ]);
 
         executionCompleted.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         executionCompleted.Failed.ShouldBe(3);

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -14,7 +14,7 @@ public class TeamCityReportTests : MessagingTests
         output.Console
             .NormalizeStackTraceLines()
             .Select(x => Regex.Replace(x, @"duration='\d+'", "duration='#'"))
-            .ShouldBe(
+            .ShouldBe([
                 "##teamcity[testSuiteStarted name='Fixie.Tests']",
 
                 $"##teamcity[testStarted name='{TestClass}.Fail']",
@@ -27,14 +27,14 @@ public class TeamCityReportTests : MessagingTests
 
                 $"##teamcity[testStarted name='{TestClass}.Pass']",
                 $"##teamcity[testFinished name='{TestClass}.Pass' duration='#']",
-                
+
                 $"##teamcity[testStarted name='{TestClass}.Skip']",
                 $"##teamcity[testIgnored name='{TestClass}.Skip' message='|0x26a0 Skipped with attribute.']",
                 $"##teamcity[testFinished name='{TestClass}.Skip' duration='#']",
-                
+
                 $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>(\"A\")']",
                 $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"A\")' duration='#']",
-                
+
                 $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")']",
                 $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")' duration='#']",
 
@@ -42,6 +42,7 @@ public class TeamCityReportTests : MessagingTests
                 $"##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='Expected: System.String{eol}Actual:   System.Int32' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']",
                 $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' duration='#']",
 
-                "##teamcity[testSuiteFinished name='Fixie.Tests']");
+                "##teamcity[testSuiteFinished name='Fixie.Tests']"
+            ]);
     }
 }

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -9,7 +9,7 @@ public class StackTracePresentationTests
     public async Task ShouldProvideCleanStackTraceForImplicitTestClassConstructionFailures()
     {
         (await Run<ConstructionFailureTestClass, ImplicitExceptionHandling>())
-            .ShouldBe(
+            .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
@@ -20,13 +20,14 @@ public class StackTracePresentationTests
                 At<ConstructionFailureTestClass>(".ctor()"),
                 "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
                 "",
-                "1 failed, took 1.23 seconds");
+                "1 failed, took 1.23 seconds"
+            ]);
     }
         
     public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestClassConstructionFailures()
     {
         (await Run<ConstructionFailureTestClass, ExplicitExceptionHandling>())
-            .ShouldBe(
+            .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
@@ -37,16 +38,18 @@ public class StackTracePresentationTests
                 At<ConstructionFailureTestClass>(".ctor()"),
                 "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
                 "--- End of stack trace from previous location where exception was thrown ---",
-                At(typeof(TestClass), "Construct(Object[] parameters)", Path.Join("...", "src", "Fixie", "TestClass.cs")),
+                At(typeof(TestClass), "Construct(Object[] parameters)",
+                    Path.Join("...", "src", "Fixie", "TestClass.cs")),
                 At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
                 "",
-                "1 failed, took 1.23 seconds");
+                "1 failed, took 1.23 seconds"
+            ]);
     }
 
     public async Task ShouldProvideCleanStackTraceTestMethodFailures()
     {
         (await Run<FailureTestClass, ImplicitExceptionHandling>())
-            .ShouldBe(
+            .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
@@ -63,7 +66,8 @@ public class StackTracePresentationTests
                 "Fixie.Tests.FailureException",
                 At<FailureTestClass>("Synchronous()"),
                 "",
-                "2 failed, took 1.23 seconds");
+                "2 failed, took 1.23 seconds"
+            ]);
     }
 
     public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestMethodInvocationFailures()
@@ -74,7 +78,7 @@ public class StackTracePresentationTests
         const string initialInvoker = "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
 
         output
-            .ShouldBe(
+            .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
@@ -83,8 +87,11 @@ public class StackTracePresentationTests
                 "",
                 "Fixie.Tests.FailureException",
                 At<FailureTestClass>("Asynchronous()"),
-                At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
+                At(typeof(MethodInfoExtensions),
+                    "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)",
+                    Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
+                At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)",
+                    Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
                 At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
                 "",
                 "Test '" + FullName<FailureTestClass>() + ".Synchronous' failed:",
@@ -98,17 +105,21 @@ public class StackTracePresentationTests
                     : initialInvoker,
                 "   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)",
                 "--- End of stack trace from previous location where exception was thrown ---",
-                At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
+                At(typeof(MethodInfoExtensions),
+                    "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)",
+                    Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
+                At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)",
+                    Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
                 At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
                 "",
-                "2 failed, took 1.23 seconds");
+                "2 failed, took 1.23 seconds"
+            ]);
     }
 
     public async Task ShouldProvideLiterateStackTraceIncludingAllNestedExceptions()
     {
         (await Run<NestedFailureTestClass, ImplicitExceptionHandling>())
-            .ShouldBe(
+            .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
                 "Test '" + FullName<NestedFailureTestClass>() + ".Asynchronous' failed:",
@@ -143,7 +154,8 @@ public class StackTracePresentationTests
                 "Divide by Zero Exception!",
                 At<StackTracePresentationTests>("ThrowNestedException()"),
                 "",
-                "2 failed, took 1.23 seconds");
+                "2 failed, took 1.23 seconds"
+            ]);
     }
 
     static async Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : IExecution, new()

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -23,12 +23,13 @@ public class VsDiscoveryRecorderTests : MessagingTests
 
         log.Messages.ShouldBeEmpty();
 
-        discoverySink.TestCases.ShouldSatisfy(
+        discoverySink.TestCases.ShouldSatisfy([
             x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Fail", assemblyPath),
             x => x.ShouldBeDiscoveryTimeTest(TestClass + ".FailByAssertion", assemblyPath),
             x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", assemblyPath),
             x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Skip", assemblyPath),
-            x => x.ShouldBeDiscoveryTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath));
+            x => x.ShouldBeDiscoveryTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath)
+        ]);
     }
 
     public void ShouldDefaultSourceLocationPropertiesWhenSourceInspectionThrows()
@@ -45,19 +46,21 @@ public class VsDiscoveryRecorderTests : MessagingTests
         var expectedError =
             $"Error: {typeof(FileNotFoundException).FullName}: " +
             $"Could not find file '{Path.Combine(GetCurrentDirectory(), invalidAssemblyPath)}'.";
-        log.Messages.ShouldSatisfy(
+        log.Messages.ShouldSatisfy([
             x => x.Contains(expectedError).ShouldBe(true),
             x => x.Contains(expectedError).ShouldBe(true),
             x => x.Contains(expectedError).ShouldBe(true),
             x => x.Contains(expectedError).ShouldBe(true),
-            x => x.Contains(expectedError).ShouldBe(true));
+            x => x.Contains(expectedError).ShouldBe(true)
+        ]);
 
-        discoverySink.TestCases.ShouldSatisfy(
+        discoverySink.TestCases.ShouldSatisfy([
             x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Fail", invalidAssemblyPath),
             x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".FailByAssertion", invalidAssemblyPath),
             x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Pass", invalidAssemblyPath),
             x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Skip", invalidAssemblyPath),
-            x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(GenericTestClass + ".ShouldBeString", invalidAssemblyPath));
+            x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(GenericTestClass + ".ShouldBeString", invalidAssemblyPath)
+        ]);
     }
 
     void RecordAnticipatedPipeMessages(VsDiscoveryRecorder vsDiscoveryRecorder)

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -64,7 +64,7 @@ public class VsExecutionRecorderTests : MessagingTests
         fail.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe("Fixie.Tests.FailureException", At("Fail()"));
+            .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
         fail.DisplayName.ShouldBe(TestClass+".Fail");
         fail.Messages.ShouldBeEmpty();
         fail.Duration.ShouldBe(TimeSpan.FromMilliseconds(102));
@@ -74,13 +74,14 @@ public class VsExecutionRecorderTests : MessagingTests
         failByAssertion.TestCase.ShouldBeExecutionTimeTest(TestClass+".FailByAssertion", assemblyPath);
         failByAssertion.TestCase.DisplayName.ShouldBe(TestClass+".FailByAssertion");
         failByAssertion.Outcome.ShouldBe(TestOutcome.Failed);
-        failByAssertion.ErrorMessage.Lines().ShouldBe(
+        failByAssertion.ErrorMessage.Lines().ShouldBe([
             "Expected: 2",
-            "Actual:   1");
+            "Actual:   1"
+        ]);
         failByAssertion.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe("Fixie.Tests.Assertions.AssertException", At("FailByAssertion()"));
+            .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
         failByAssertion.DisplayName.ShouldBe(TestClass+".FailByAssertion");
         failByAssertion.Messages.ShouldBeEmpty();
         failByAssertion.Duration.ShouldBe(TimeSpan.FromMilliseconds(103));
@@ -133,15 +134,17 @@ public class VsExecutionRecorderTests : MessagingTests
         shouldBeStringFail.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
         shouldBeStringFail.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
         shouldBeStringFail.Outcome.ShouldBe(TestOutcome.Failed);
-        shouldBeStringFail.ErrorMessage.Lines().ShouldBe(
+        shouldBeStringFail.ErrorMessage.Lines().ShouldBe([
             "Expected: System.String",
-            "Actual:   System.Int32");
+            "Actual:   System.Int32"
+        ]);
         shouldBeStringFail.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
-            .ShouldBe(
+            .ShouldBe([
                 "Fixie.Tests.Assertions.AssertException",
-                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"));
+                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
+            ]);
         shouldBeStringFail.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.Messages.ShouldBeEmpty();
         shouldBeStringFail.Duration.ShouldBe(TimeSpan.FromMilliseconds(107));


### PR DESCRIPTION
Before we can upgrade assertions to use `[CallerArgumentExpression(...)]`, we first have to get our deprecated use of `params` arguments on those assertions out of the way. Use of `params` prevents use of subsequent default arguments like `[CallerArgumentExpression(...)]`, but thankfully the existence of collection expressions essentially invalidates `params` arguments as a concept. The tradeoff is easy, making each assertion's intention more clear while opening the door to `[CallerArgumentExpression(...)]` improvements in the next PR.