### PR TITLE
Descriptive assertions

### DIFF
--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -10,7 +10,7 @@ public class AssertException : Exception
     public string? Actual { get; }
     public bool HasCompactRepresentations { get; }
 
-    public AssertException(string? expected, string? actual)
+    public AssertException(string? expression, string? expected, string? actual)
     {
         Expected = expected;
         Actual = actual;

--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -6,12 +6,14 @@ public class AssertException : Exception
 {
     public static string FilterStackTraceAssemblyPrefix = typeof(AssertException).Namespace + ".";
 
+    public string? Expression { get; }
     public string? Expected { get; }
     public string? Actual { get; }
     public bool HasCompactRepresentations { get; }
 
     public AssertException(string? expression, string? expected, string? actual)
     {
+        Expression = expression;
         Expected = expected;
         Actual = actual;
         HasCompactRepresentations = HasCompactRepresentation(expected) &&
@@ -26,11 +28,10 @@ public class AssertException : Exception
             var actual = Actual ?? "null";
 
             if (HasCompactRepresentations)
-                return $"Expected: {expected}{NewLine}" +
-                       $"Actual:   {actual}";
+                return $"{Expression} should be {expected} but was {actual}";
 
-            return $"Expected:{NewLine}{expected}{NewLine}{NewLine}" +
-                   $"Actual:{NewLine}{actual}";
+            return $"{Expression} should be {NewLine}{expected}{NewLine}{NewLine}" +
+                   $"but was {NewLine}{actual}";
         }
     }
 

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -43,6 +43,12 @@ public static class AssertionExtensions
             throw new AssertException(expression, expected.ToString(), actual.ToString());
     }
 
+    public static void ShouldBe(this Type actual, Type expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
+    {
+        if (actual != expected)
+            throw new AssertException(expression, Serialize(expected), Serialize(actual));
+    }
+
     public static void ShouldBe(this object? actual, object? expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (!Equals(actual, expected))
@@ -59,7 +65,7 @@ public static class AssertionExtensions
         if (actual is T typed)
             return typed;
 
-        throw new AssertException(expression, typeof(T).ToString(), actual?.GetType().ToString());
+        throw new AssertException(expression, Serialize(typeof(T)), actual == null ? "null" : Serialize(actual.GetType()));
     }
 
     public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? expression = null) where TException : Exception
@@ -184,4 +190,27 @@ public static class AssertionExtensions
         };
 
     static string Serialize(bool x) => x ? "true" : "false";
+
+    static string Serialize(Type x) =>
+        $"typeof({x switch
+        {
+            _ when x == typeof(bool) => "bool",
+            _ when x == typeof(sbyte) => "sbyte",
+            _ when x == typeof(byte) => "byte",
+            _ when x == typeof(short) => "short",
+            _ when x == typeof(ushort) => "ushort",
+            _ when x == typeof(int) => "int",
+            _ when x == typeof(uint) => "uint",
+            _ when x == typeof(long) => "long",
+            _ when x == typeof(ulong) => "ulong",
+            _ when x == typeof(nint) => "nint",
+            _ when x == typeof(nuint) => "nuint",
+            _ when x == typeof(decimal) => "decimal",
+            _ when x == typeof(double) => "double",
+            _ when x == typeof(float) => "float",
+            _ when x == typeof(char) => "char",
+            _ when x == typeof(string) => "string",
+            _ when x == typeof(object) => "object",
+            _ => x.ToString()
+        }})";
 }

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -62,11 +62,6 @@ public static class AssertionExtensions
         throw new AssertException(expression, typeof(T).ToString(), actual?.GetType().ToString());
     }
 
-    public static void ShouldBeEmpty<T>(this IEnumerable<T> collection, [CallerArgumentExpression(nameof(collection))] string? expression = null)
-    {
-        collection.ShouldMatch([], expression);
-    }
-
     public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? expression = null) where TException : Exception
     {
         try

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -25,6 +25,12 @@ public static class AssertionExtensions
             throw new AssertException(expression, expected, actual);
     }
 
+    public static void ShouldBe(this bool actual, bool expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
+    {
+        if (actual != expected)
+            throw new AssertException(expression, Serialize(expected), Serialize(actual));
+    }
+
     public static void ShouldBe<T>(this IEquatable<T> actual, IEquatable<T> expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (!actual.Equals(expected))
@@ -155,4 +161,6 @@ public static class AssertionExtensions
                 writer.WriteStringValue(value.ToString());
         }
     }
+
+    static string Serialize(bool x) => x ? "true" : "false";
 }

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -30,6 +30,12 @@ public static class AssertionExtensions
         if (actual != expected)
             throw new AssertException(expression, Serialize(expected), Serialize(actual));
     }
+    
+    public static void ShouldBe(this char actual, char expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
+    {
+        if (actual != expected)
+            throw new AssertException(expression, Serialize(expected), Serialize(actual));
+    }
 
     public static void ShouldBe<T>(this IEquatable<T> actual, IEquatable<T> expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
@@ -161,6 +167,26 @@ public static class AssertionExtensions
                 writer.WriteStringValue(value.ToString());
         }
     }
+
+    static string Serialize(char x) =>
+        x switch
+        {
+            '\0' => @"'\0'",
+            '\a' => @"'\a'",
+            '\b' => @"'\b'",
+            '\t' => @"'\t'",
+            '\n' => @"'\n'",
+            '\v' => @"'\v'",
+            '\f' => @"'\f'",
+            '\r' => @"'\r'",
+            //'\e' => @"'\e'", TODO: Applicable in C# 13
+            ' ' => "' '",
+            '"' => @"'\""'",
+            '\'' => @"'\''",
+            '\\' => @"'\\'",
+            _ when (char.IsControl(x) || char.IsWhiteSpace(x)) => $"'\\u{(int)x:X4}'",
+            _ => $"'{x}'"
+        };
 
     static string Serialize(bool x) => x ? "true" : "false";
 }

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -18,43 +19,43 @@ public static class AssertionExtensions
         JsonSerializerOptions.Converters.Add(new StringRepresentation<Type>());
     }
 
-    public static void ShouldBe(this string? actual, string? expected)
+    public static void ShouldBe(this string? actual, string? expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw new AssertException(expected, actual);
+            throw new AssertException(expression, expected, actual);
     }
 
-    public static void ShouldBe<T>(this IEquatable<T> actual, IEquatable<T> expected)
+    public static void ShouldBe<T>(this IEquatable<T> actual, IEquatable<T> expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (!actual.Equals(expected))
-            throw new AssertException(expected.ToString(), actual.ToString());
+            throw new AssertException(expression, expected.ToString(), actual.ToString());
     }
 
-    public static void ShouldBe(this object? actual, object? expected)
+    public static void ShouldBe(this object? actual, object? expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (!Equals(actual, expected))
-            throw new AssertException(expected?.ToString(), actual?.ToString());
+            throw new AssertException(expression, expected?.ToString(), actual?.ToString());
     }
 
-    public static void ShouldBe<T>(this IEnumerable<T> actual, T[] expected)
+    public static void ShouldBe<T>(this IEnumerable<T> actual, T[] expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
-        actual.ToArray().ShouldMatch(expected);
+        actual.ToArray().ShouldMatch(expected, expression);
     }
 
-    public static T ShouldBe<T>(this object? actual)
+    public static T ShouldBe<T>(this object? actual, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual is T typed)
             return typed;
 
-        throw new AssertException(typeof(T).ToString(), actual?.GetType().ToString());
+        throw new AssertException(expression, typeof(T).ToString(), actual?.GetType().ToString());
     }
 
-    public static void ShouldBeEmpty<T>(this IEnumerable<T> collection)
+    public static void ShouldBeEmpty<T>(this IEnumerable<T> collection, [CallerArgumentExpression(nameof(collection))] string? expression = null)
     {
-        collection.ShouldMatch([]);
+        collection.ShouldMatch([], expression);
     }
 
-    public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage) where TException : Exception
+    public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? expression = null) where TException : Exception
     {
         try
         {
@@ -68,10 +69,10 @@ public static class AssertionExtensions
             return (TException)actual;
         }
 
-        throw new AssertException(typeof(TException).FullName, "No exception was thrown.");
+        throw new AssertException(expression, typeof(TException).FullName, "No exception was thrown.");
     }
 
-    public static async Task<TException> ShouldThrowAsync<TException>(this Func<Task> shouldThrowAsync, string expectedMessage) where TException : Exception
+    public static async Task<TException> ShouldThrowAsync<TException>(this Func<Task> shouldThrowAsync, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrowAsync))] string? expression = null) where TException : Exception
     {
         try
         {
@@ -85,36 +86,37 @@ public static class AssertionExtensions
             return (TException)actual;
         }
 
-        throw new AssertException(typeof(TException).FullName, "No exception was thrown.");
+        throw new AssertException(expression, typeof(TException).FullName, "No exception was thrown.");
     }
 
-    public static void ShouldBeGreaterThan<T>(this T actual, T minimum) where T: IComparable<T>
+    public static void ShouldBeGreaterThan<T>(this T actual, T minimum, [CallerArgumentExpression(nameof(actual))] string? expression = null) where T: IComparable<T>
     {
         if (actual.CompareTo(minimum) <= 0)
-            throw new AssertException($"value > {minimum}", actual.ToString());
+            throw new AssertException(expression, $"> {minimum}", actual.ToString());
     }
 
-    public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T minimum) where T: IComparable<T>
+    public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T minimum, [CallerArgumentExpression(nameof(actual))] string? expression = null) where T: IComparable<T>
     {
         if (actual.CompareTo(minimum) < 0)
-            throw new AssertException($"value >= {minimum}", actual.ToString());
+            throw new AssertException(expression, $">= {minimum}", actual.ToString());
     }
 
-    public static void ShouldMatch<T>(this T actual, T expected)
+    public static void ShouldMatch<T>(this T actual, T expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         var actualJson = Json(actual);
         var expectedJson = Json(expected);
             
         if (actualJson != expectedJson)
-            throw new AssertException(expectedJson, actualJson);
+            throw new AssertException(expression, expectedJson, actualJson);
     }
 
-    public static void ShouldSatisfy<T>(this IEnumerable<T> actual, Action<T>[] itemExpectations)
+    public static void ShouldSatisfy<T>(this IEnumerable<T> actual, Action<T>[] itemExpectations, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         var actualItems = actual.ToArray();
 
         if (actualItems.Length != itemExpectations.Length)
             throw new AssertException(
+                expression,
                 $"{itemExpectations.Length} items",
                 $"{actualItems.Length} items");
 
@@ -122,17 +124,17 @@ public static class AssertionExtensions
             itemExpectations[i](actualItems[i]);
     }
 
-    public static void ShouldBeGenericTypeParameter(this Type actual, string expectedName)
+    public static void ShouldBeGenericTypeParameter(this Type actual, string expectedName, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         actual.IsGenericParameter.ShouldBe(true);
         actual.FullName.ShouldBe(null);
         actual.Name.ShouldBe(expectedName);
     }
 
-    public static void ShouldNotBeNull([NotNull] this object? actual)
+    public static void ShouldNotBeNull([NotNull] this object? actual, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual == null)
-            throw new AssertException("not null", "null");
+            throw new AssertException(expression, "not null", "null");
     }
 
     static string Json<T>(T @object)

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -158,6 +158,55 @@ public class AssertionTests
         }
     }
 
+    public void ShouldAssertTypes()
+    {
+        typeof(int).ShouldBe(typeof(int));
+        typeof(char).ShouldBe(typeof(char));
+        Contradiction(typeof(Utility), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(Fixie.Tests.Utility)");
+        Contradiction(typeof(bool), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(bool)");
+        Contradiction(typeof(sbyte), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(sbyte)");
+        Contradiction(typeof(byte), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(byte)");
+        Contradiction(typeof(short), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(short)");
+        Contradiction(typeof(ushort), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(ushort)");
+        Contradiction(typeof(int), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(int)");
+        Contradiction(typeof(uint), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(uint)");
+        Contradiction(typeof(long), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(long)");
+        Contradiction(typeof(ulong), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(ulong)");
+        Contradiction(typeof(nint), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(nint)");
+        Contradiction(typeof(nuint), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(nuint)");
+        Contradiction(typeof(decimal), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(decimal)");
+        Contradiction(typeof(double), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(double)");
+        Contradiction(typeof(float), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(float)");
+        Contradiction(typeof(char), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(char)");
+        Contradiction(typeof(string), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(string)");
+        Contradiction(typeof(object), x => x.ShouldBe(typeof(AssertionTests)), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(object)");
+
+        1.ShouldBe<int>();
+        'A'.ShouldBe<char>();
+        Exception exception = new DivideByZeroException();
+        DivideByZeroException typedException = exception.ShouldBe<DivideByZeroException>();
+        Contradiction(new StubReport(), x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(Fixie.Tests.StubReport)");
+        Contradiction(true, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(bool)");
+        Contradiction((sbyte)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(sbyte)");
+        Contradiction((byte)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(byte)");
+        Contradiction((short)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(short)");
+        Contradiction((ushort)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(ushort)");
+        Contradiction((int)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(int)");
+        Contradiction((uint)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(uint)");
+        Contradiction((long)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(long)");
+        Contradiction((ulong)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(ulong)");
+        Contradiction((nint)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(nint)");
+        Contradiction((nuint)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(nuint)");
+        Contradiction((decimal)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(decimal)");
+        Contradiction((double)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(double)");
+        Contradiction((float)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(float)");
+        Contradiction((char)1, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(char)");
+        Contradiction("A", x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(string)");
+        Contradiction(new object(), x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was typeof(object)");
+        Contradiction((Exception?)null, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was null");
+        Contradiction((AssertionTests?)null, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was null");
+    }
+
     static void Contradiction<T>(T actual, Action<T> shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? assertion = null)
     {
         try

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -15,6 +15,109 @@ public class AssertionTests
         Contradiction(false, x => x.ShouldBe(true), "x should be true but was false");
     }
 
+    public void ShouldAssertChars()
+    {
+        'a'.ShouldBe('a');
+        '☺'.ShouldBe('☺');
+        Contradiction('a', x => x.ShouldBe('z'), "x should be 'z' but was 'a'");
+        
+        // Escape Sequence: Null
+        '\u0000'.ShouldBe('\0');
+        '\0'.ShouldBe('\0');
+        Contradiction('\n', x => x.ShouldBe('\0'), "x should be '\\0' but was '\\n'");
+
+        // Escape Sequence: Alert
+        '\u0007'.ShouldBe('\a');
+        '\a'.ShouldBe('\a');
+        Contradiction('\n', x => x.ShouldBe('\a'), "x should be '\\a' but was '\\n'");
+
+        // Escape Sequence: Backspace
+        '\u0008'.ShouldBe('\b');
+        '\b'.ShouldBe('\b');
+        Contradiction('\n', x => x.ShouldBe('\b'), "x should be '\\b' but was '\\n'");
+
+        // Escape Sequence: Horizontal tab
+        '\u0009'.ShouldBe('\t');
+        '\t'.ShouldBe('\t');
+        Contradiction('\n', x => x.ShouldBe('\t'), "x should be '\\t' but was '\\n'");
+
+        // Escape Sequence: New line
+        '\u000A'.ShouldBe('\n');
+        '\n'.ShouldBe('\n');
+        Contradiction('\r', x => x.ShouldBe('\n'), "x should be '\\n' but was '\\r'");
+
+        // Escape Sequence: Vertical tab
+        '\u000B'.ShouldBe('\v');
+        '\v'.ShouldBe('\v');
+        Contradiction('\n', x => x.ShouldBe('\v'), "x should be '\\v' but was '\\n'");
+
+        // Escape Sequence: Form feed
+        '\u000C'.ShouldBe('\f');
+        '\f'.ShouldBe('\f');
+        Contradiction('\n', x => x.ShouldBe('\f'), "x should be '\\f' but was '\\n'");
+
+        // Escape Sequence: Carriage return
+        '\u000D'.ShouldBe('\r');
+        '\r'.ShouldBe('\r');
+        Contradiction('\n', x => x.ShouldBe('\r'), "x should be '\\r' but was '\\n'");
+
+        // TODO: Applicable in C# 13
+        // Escape Sequence: Escape
+        // '\u001B'.ShouldBe('\e');
+        // '\e'.ShouldBe('\e');
+        // Contradiction('\n', x => x.ShouldBe('\e'), "x should be '\\e' but was '\\n'");
+
+        // Literal Space
+        ' '.ShouldBe(' ');
+        '\u0020'.ShouldBe(' ');
+        Contradiction('\n', x => x.ShouldBe(' '), "x should be ' ' but was '\\n'");
+
+        // Escape Sequence: Double quote
+        '\u0022'.ShouldBe('\"');
+        '\"'.ShouldBe('\"');
+        Contradiction('\n', x => x.ShouldBe('\"'), "x should be '\\\"' but was '\\n'");
+
+        // Escape Sequence: Single quote
+        '\u0027'.ShouldBe('\'');
+        '\''.ShouldBe('\'');
+        Contradiction('\n', x => x.ShouldBe('\''), "x should be '\\'' but was '\\n'");
+
+        // Escape Sequence: Backslash
+        '\u005C'.ShouldBe('\\');
+        '\\'.ShouldBe('\\');
+        Contradiction('\n', x => x.ShouldBe('\\'), "x should be '\\\\' but was '\\n'");
+
+        foreach (var c in UnicodeEscapedCharacters())
+        {
+            c.ShouldBe(c);
+            Contradiction('a', x => x.ShouldBe(c), $"x should be '\\u{(int)c:X4}' but was 'a'");
+        }
+    }
+
+    static IEnumerable<char> UnicodeEscapedCharacters()
+    {
+        // Code points from \u0000 to \u001F, \u007F, and from \u0080 to \u009F are
+        // "control characters". Some of these have single-character escape sequences
+        // like '\u000A' being equivalent to '\n'. When we omit code points better
+        // served by single-character escape sequences, we are left with those deserving
+        // '\uHHHH' hex escape sequences.
+
+        for (char c = '\u0001'; c <= '\u0006'; c++) yield return c;
+        for (char c = '\u000E'; c <= '\u001F'; c++) yield return c;
+        yield return '\u007F';
+        for (char c = '\u0080'; c <= '\u009F'; c++) yield return c;
+
+        // Several code points represent various kinds of whitespace. Some of these have
+        // single-character escape sequences like '\u0009' being equivalent to '\t', and
+        // the single space character ' ' is naturally represented with no need for any
+        // escape sequence. All other whitespace code points deserve '\uHHHH' hex escape
+        // sequences.
+
+        foreach (char c in (char[])['\u0085', '\u00A0', '\u1680']) yield return c;
+        for (char c = '\u2000'; c <= '\u2009'; c++) yield return c;
+        foreach (char c in (char[])['\u200A', '\u2028', '\u2029', '\u202F', '\u205F', '\u3000']) yield return c;
+    }
+
     static void Contradiction<T>(T actual, Action<T> shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? assertion = null)
     {
         try

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Fixie.Tests.Assertions;
+
+public class AssertionTests
+{
+    static readonly string Line = Environment.NewLine + Environment.NewLine;
+
+    public void ShouldAssertBools()
+    {
+        true.ShouldBe(true);
+        false.ShouldBe(false);
+
+        Contradiction(true, x => x.ShouldBe(false), "x should be false but was true");
+        Contradiction(false, x => x.ShouldBe(true), "x should be true but was false");
+    }
+
+    static void Contradiction<T>(T actual, Action<T> shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? assertion = null)
+    {
+        try
+        {
+            shouldThrow(actual);
+        }
+        catch (Exception exception)
+        {
+            if (exception is AssertException)
+            {
+                if (exception.Message != expectedMessage)
+                    throw new Exception(
+                        $"An example assertion failed as expected, but with the wrong message.{Line}" +
+                        $"Expected Message:{Line}\t{expectedMessage}{Line}" +
+                        $"Actual Message:{Line}\t{exception.Message}");
+                return;
+            }
+
+            throw new Exception(
+                $"An example assertion failed as expected, but with the wrong type.{Line}" +
+                $"\t{assertion}{Line}" +
+                $"The actual value in question was:{Line}" +
+                $"\t{actual}{Line}" +
+                $"The assertion threw {exception.GetType().FullName} with message:{Line}" +
+                $"\t{exception.Message}");
+        }
+
+        throw new Exception(
+            $"An example assertion was expected to fail, but did not:{Line}" +
+            $"\t{assertion}{Line}" +
+            $"The actual value in question was:{Line}" +
+            $"\t{actual}");
+    }
+}

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -15,6 +15,70 @@ public class AssertionTests
         Contradiction(false, x => x.ShouldBe(true), "x should be true but was false");
     }
 
+    public void ShouldAssertIntegralNumbers()
+    {
+        sbyte.MinValue.ShouldBe(sbyte.MinValue);
+        sbyte.MaxValue.ShouldBe(sbyte.MaxValue);
+        Contradiction((sbyte)1, x => x.ShouldBe((sbyte)2), "x should be 2 but was 1");
+        
+        byte.MinValue.ShouldBe(byte.MinValue);
+        byte.MaxValue.ShouldBe(byte.MaxValue);
+        Contradiction((byte)2, x => x.ShouldBe((byte)3), "x should be 3 but was 2");
+        
+        short.MinValue.ShouldBe(short.MinValue);
+        short.MaxValue.ShouldBe(short.MaxValue);
+        Contradiction((short)3, x => x.ShouldBe((short)4), "x should be 4 but was 3");
+        
+        ushort.MinValue.ShouldBe(ushort.MinValue);
+        ushort.MaxValue.ShouldBe(ushort.MaxValue);
+        Contradiction((ushort)4, x => x.ShouldBe((ushort)5), "x should be 5 but was 4");
+
+        int.MinValue.ShouldBe(int.MinValue);
+        int.MaxValue.ShouldBe(int.MaxValue);
+        Contradiction((int)5, x => x.ShouldBe((int)6), "x should be 6 but was 5");
+
+        uint.MinValue.ShouldBe(uint.MinValue);
+        uint.MaxValue.ShouldBe(uint.MaxValue);
+        Contradiction((uint)6, x => x.ShouldBe((uint)7), "x should be 7 but was 6");
+        
+        long.MinValue.ShouldBe(long.MinValue);
+        long.MaxValue.ShouldBe(long.MaxValue);
+        Contradiction((long)7, x => x.ShouldBe((long)8), "x should be 8 but was 7");
+
+        ulong.MinValue.ShouldBe(ulong.MinValue);
+        ulong.MaxValue.ShouldBe(ulong.MaxValue);
+        Contradiction((ulong)8, x => x.ShouldBe((ulong)9), "x should be 9 but was 8");
+
+        nint.MinValue.ShouldBe(nint.MinValue);
+        nint.MaxValue.ShouldBe(nint.MaxValue);
+        Contradiction((nint)9, x => x.ShouldBe((nint)10), "x should be 10 but was 9");
+
+        nuint.MinValue.ShouldBe(nuint.MinValue);
+        nuint.MaxValue.ShouldBe(nuint.MaxValue);
+        Contradiction((nuint)10, x => x.ShouldBe((nuint)11), "x should be 11 but was 10");
+    }
+
+    public void ShouldAssertFractionalNumbers()
+    {
+        decimal.MinValue.ShouldBe(decimal.MinValue);
+        decimal.MaxValue.ShouldBe(decimal.MaxValue);
+        Contradiction((decimal)1, x => x.ShouldBe((decimal)2), "x should be 2 but was 1");
+
+        double.MinValue.ShouldBe(double.MinValue);
+        double.MaxValue.ShouldBe(double.MaxValue);
+        Contradiction((double)2, x => x.ShouldBe((double)3), "x should be 3 but was 2");
+
+        float.MinValue.ShouldBe(float.MinValue);
+        float.MaxValue.ShouldBe(float.MaxValue);
+        Contradiction((float)3, x => x.ShouldBe((float)4), "x should be 4 but was 3");
+    }
+
+    public void ShouldAssertEquatables()
+    {
+        HttpMethod.Post.ShouldBe(HttpMethod.Post);
+        Contradiction(HttpMethod.Post, x => x.ShouldBe(HttpMethod.Get), "x should be GET but was POST");
+    }
+
     public void ShouldAssertChars()
     {
         'a'.ShouldBe('a');
@@ -94,30 +158,6 @@ public class AssertionTests
         }
     }
 
-    static IEnumerable<char> UnicodeEscapedCharacters()
-    {
-        // Code points from \u0000 to \u001F, \u007F, and from \u0080 to \u009F are
-        // "control characters". Some of these have single-character escape sequences
-        // like '\u000A' being equivalent to '\n'. When we omit code points better
-        // served by single-character escape sequences, we are left with those deserving
-        // '\uHHHH' hex escape sequences.
-
-        for (char c = '\u0001'; c <= '\u0006'; c++) yield return c;
-        for (char c = '\u000E'; c <= '\u001F'; c++) yield return c;
-        yield return '\u007F';
-        for (char c = '\u0080'; c <= '\u009F'; c++) yield return c;
-
-        // Several code points represent various kinds of whitespace. Some of these have
-        // single-character escape sequences like '\u0009' being equivalent to '\t', and
-        // the single space character ' ' is naturally represented with no need for any
-        // escape sequence. All other whitespace code points deserve '\uHHHH' hex escape
-        // sequences.
-
-        foreach (char c in (char[])['\u0085', '\u00A0', '\u1680']) yield return c;
-        for (char c = '\u2000'; c <= '\u2009'; c++) yield return c;
-        foreach (char c in (char[])['\u200A', '\u2028', '\u2029', '\u202F', '\u205F', '\u3000']) yield return c;
-    }
-
     static void Contradiction<T>(T actual, Action<T> shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? assertion = null)
     {
         try
@@ -150,5 +190,29 @@ public class AssertionTests
             $"\t{assertion}{Line}" +
             $"The actual value in question was:{Line}" +
             $"\t{actual}");
+    }
+
+    static IEnumerable<char> UnicodeEscapedCharacters()
+    {
+        // Code points from \u0000 to \u001F, \u007F, and from \u0080 to \u009F are
+        // "control characters". Some of these have single-character escape sequences
+        // like '\u000A' being equivalent to '\n'. When we omit code points better
+        // served by single-character escape sequences, we are left with those deserving
+        // '\uHHHH' hex escape sequences.
+
+        for (char c = '\u0001'; c <= '\u0006'; c++) yield return c;
+        for (char c = '\u000E'; c <= '\u001F'; c++) yield return c;
+        yield return '\u007F';
+        for (char c = '\u0080'; c <= '\u009F'; c++) yield return c;
+
+        // Several code points represent various kinds of whitespace. Some of these have
+        // single-character escape sequences like '\u0009' being equivalent to '\t', and
+        // the single space character ' ' is naturally represented with no need for any
+        // escape sequence. All other whitespace code points deserve '\uHHHH' hex escape
+        // sequences.
+
+        foreach (char c in (char[])['\u0085', '\u00A0', '\u1680']) yield return c;
+        for (char c = '\u2000'; c <= '\u2009'; c++) yield return c;
+        foreach (char c in (char[])['\u200A', '\u2028', '\u2029', '\u202F', '\u205F', '\u3000']) yield return c;
     }
 }

--- a/src/Fixie.Tests/Internal/RunnerTests.cs
+++ b/src/Fixie.Tests/Internal/RunnerTests.cs
@@ -25,7 +25,7 @@ public class RunnerTests
 
         await runner.Discover(candidateTypes, discovery);
 
-        console.ToString().ShouldBeEmpty();
+        console.ToString().ShouldBe("");
 
         report.Entries.ShouldBe([
             Self + "+PassTestClass.PassA discovered",
@@ -58,7 +58,7 @@ public class RunnerTests
 
         await runner.Run(candidateTypes, configuration, []);
 
-        console.ToString().ShouldBeEmpty();
+        console.ToString().ShouldBe("");
 
         report.Entries.ShouldBe([
             Self + "+PassTestClass.PassA passed",

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -78,7 +78,7 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
             "GenericTestClass.Args<System.Char, System.Double>('a', 3, System.Char, System.Double) passed",
 
             "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(1, 'a', System.Int32, System.Char) passed",
-            "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(2, 'b', System.Int32, System.Int32) failed: typeof(T2) should be System.Int32 but was System.Char",
+            "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(2, 'b', System.Int32, System.Int32) failed: typeof(T2) should be typeof(int) but was typeof(char)",
             "GenericTestClass.ConstrainedArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
             "GenericTestClass.ConstrainedArgs<T1, T2>(null, 2, System.Object, System.Int32) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
 

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -78,7 +78,7 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
             "GenericTestClass.Args<System.Char, System.Double>('a', 3, System.Char, System.Double) passed",
 
             "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(1, 'a', System.Int32, System.Char) passed",
-            "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(2, 'b', System.Int32, System.Int32) failed: Expected: System.Int32" + NewLine + "Actual:   System.Char",
+            "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(2, 'b', System.Int32, System.Int32) failed: typeof(T2) should be System.Int32 but was System.Char",
             "GenericTestClass.ConstrainedArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
             "GenericTestClass.ConstrainedArgs<T1, T2>(null, 2, System.Object, System.Int32) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
 
@@ -97,8 +97,8 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
             "AsyncTestClass.AwaitTaskThenPass passed",
             "AsyncTestClass.AwaitValueTaskThenPass passed",
             "AsyncTestClass.CompleteTaskThenPass passed",
-            "AsyncTestClass.FailAfterAwaitTask failed: Expected: 0" + NewLine + "Actual:   3",
-            "AsyncTestClass.FailAfterAwaitValueTask failed: Expected: 0" + NewLine + "Actual:   3",
+            "AsyncTestClass.FailAfterAwaitTask failed: result should be 0 but was 3",
+            "AsyncTestClass.FailAfterAwaitValueTask failed: result should be 0 but was 3",
             "AsyncTestClass.FailBeforeAwaitTask failed: 'FailBeforeAwaitTask' failed!",
             "AsyncTestClass.FailBeforeAwaitValueTask failed: 'FailBeforeAwaitValueTask' failed!",
             "AsyncTestClass.FailDuringAwaitTask failed: Attempted to divide by zero.",
@@ -141,7 +141,7 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
         output.ShouldHaveResults(
             "FSharpAsyncTestClass.AsyncPass passed",
             "FSharpAsyncTestClass.FailBeforeAsync failed: 'FailBeforeAsync' failed!",
-            "FSharpAsyncTestClass.FailFromAsync failed: Expected: 0" + NewLine + "Actual:   3",
+            "FSharpAsyncTestClass.FailFromAsync failed: result should be 0 but was 3",
             "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync returned null, " +
             "but a non-null awaitable object was expected.");
 

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -51,10 +51,7 @@ public class AppVeyorReportTests : MessagingTests
         failByAssertion.TestName.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.Outcome.ShouldBe("Failed");
         int.Parse(failByAssertion.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-        failByAssertion.ErrorMessage.Lines().ShouldBe([
-            "Expected: 2",
-            "Actual:   1"
-        ]);
+        failByAssertion.ErrorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
@@ -92,10 +89,8 @@ public class AppVeyorReportTests : MessagingTests
         shouldBeStringFail.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.Outcome.ShouldBe("Failed");
         int.Parse(shouldBeStringFail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
-        shouldBeStringFail.ErrorMessage.Lines().ShouldBe([
-            "Expected: System.String",
-            "Actual:   System.Int32"
-        ]);
+        shouldBeStringFail.ErrorMessage
+            .ShouldBe("genericArgument should be System.String but was System.Int32");
         shouldBeStringFail.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -20,7 +20,7 @@ public class AppVeyorReportTests : MessagingTests
 
         await Run(report);
 
-        console.ToString().ShouldBeEmpty();
+        console.ToString().ShouldBe("");
 
         results.Count.ShouldBe(7);
 

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -90,7 +90,7 @@ public class AppVeyorReportTests : MessagingTests
         shouldBeStringFail.Outcome.ShouldBe("Failed");
         int.Parse(shouldBeStringFail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
         shouldBeStringFail.ErrorMessage
-            .ShouldBe("genericArgument should be System.String but was System.Int32");
+            .ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -112,10 +112,7 @@ public class AzureReportTests : MessagingTests
         failByAssertion.testCaseTitle.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.outcome.ShouldBe("Failed");
         failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-        failByAssertion.errorMessage.Lines().ShouldBe([
-            "Expected: 2",
-            "Actual:   1"
-        ]);
+        failByAssertion.errorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.stackTrace
             .Lines()
             .NormalizeStackTraceLines()
@@ -153,10 +150,7 @@ public class AzureReportTests : MessagingTests
         shouldBeStringFail.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.outcome.ShouldBe("Failed");
         shouldBeStringFail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-        shouldBeStringFail.errorMessage.Lines().ShouldBe([
-            "Expected: System.String",
-            "Actual:   System.Int32"
-        ]);
+        shouldBeStringFail.errorMessage.ShouldBe("genericArgument should be System.String but was System.Int32");
         shouldBeStringFail.stackTrace
             .Lines()
             .NormalizeStackTraceLines()

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -150,7 +150,7 @@ public class AzureReportTests : MessagingTests
         shouldBeStringFail.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.outcome.ShouldBe("Failed");
         shouldBeStringFail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
-        shouldBeStringFail.errorMessage.ShouldBe("genericArgument should be System.String but was System.Int32");
+        shouldBeStringFail.errorMessage.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.stackTrace
             .Lines()
             .NormalizeStackTraceLines()

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -39,7 +39,7 @@ public class ConsoleReportTests : MessagingTests
 
                 "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
                 "",
-                "genericArgument should be System.String but was System.Int32",
+                "genericArgument should be typeof(string) but was typeof(int)",
                 "",
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
@@ -89,7 +89,7 @@ public class ConsoleReportTests : MessagingTests
 
                 "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
                 "",
-                "genericArgument should be System.String but was System.Int32",
+                "genericArgument should be typeof(string) but was typeof(int)",
                 "",
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -27,8 +27,7 @@ public class ConsoleReportTests : MessagingTests
 
                 "Test '" + TestClass + ".FailByAssertion' failed:",
                 "",
-                "Expected: 2",
-                "Actual:   1",
+                "x should be 2 but was 1",
                 "",
                 "Fixie.Tests.Assertions.AssertException",
                 At("FailByAssertion()"),
@@ -40,8 +39,7 @@ public class ConsoleReportTests : MessagingTests
 
                 "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
                 "",
-                "Expected: System.String",
-                "Actual:   System.Int32",
+                "genericArgument should be System.String but was System.Int32",
                 "",
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
@@ -72,8 +70,7 @@ public class ConsoleReportTests : MessagingTests
 
                 "Test '" + TestClass + ".FailByAssertion' failed:",
                 "",
-                "Expected: 2",
-                "Actual:   1",
+                "x should be 2 but was 1",
                 "",
                 "Fixie.Tests.Assertions.AssertException",
                 At("FailByAssertion()"),
@@ -92,8 +89,7 @@ public class ConsoleReportTests : MessagingTests
 
                 "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
                 "",
-                "Expected: System.String",
-                "Actual:   System.Int32",
+                "genericArgument should be System.String but was System.Int32",
                 "",
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -58,10 +58,7 @@ public class LifecycleMessageTests : MessagingTests
             .Lines()
             .NormalizeStackTraceLines()
             .ShouldBe([At("FailByAssertion()")]);
-        failByAssertion.Reason.Message.Lines().ShouldBe([
-            "Expected: 2",
-            "Actual:   1"
-        ]);
+        failByAssertion.Reason.Message.ShouldBe("x should be 2 but was 1");
 
         skip.Test.ShouldBe(TestClass + ".Skip");
         skip.TestCase.ShouldBe(TestClass + ".Skip");
@@ -90,10 +87,7 @@ public class LifecycleMessageTests : MessagingTests
             .Lines()
             .NormalizeStackTraceLines()
             .ShouldBe([At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")]);
-        shouldBeStringFail.Reason.Message.Lines().ShouldBe([
-            "Expected: System.String",
-            "Actual:   System.Int32"
-        ]);
+        shouldBeStringFail.Reason.Message.ShouldBe("genericArgument should be System.String but was System.Int32");
 
         executionCompleted.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         executionCompleted.Failed.ShouldBe(3);

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -87,7 +87,7 @@ public class LifecycleMessageTests : MessagingTests
             .Lines()
             .NormalizeStackTraceLines()
             .ShouldBe([At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")]);
-        shouldBeStringFail.Reason.Message.ShouldBe("genericArgument should be System.String but was System.Int32");
+        shouldBeStringFail.Reason.Message.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
 
         executionCompleted.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         executionCompleted.Failed.ShouldBe(3);

--- a/src/Fixie.Tests/Reports/MessagingTests.cs
+++ b/src/Fixie.Tests/Reports/MessagingTests.cs
@@ -90,7 +90,8 @@ public abstract class MessagingTests
 
         public void FailByAssertion()
         {
-            1.ShouldBe(2);
+            var x = 1;
+            x.ShouldBe(2);
         }
 
         const string alert = "\x26A0";

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -22,7 +22,7 @@ public class TeamCityReportTests : MessagingTests
                 $"##teamcity[testFinished name='{TestClass}.Fail' duration='#']",
 
                 $"##teamcity[testStarted name='{TestClass}.FailByAssertion']",
-                $"##teamcity[testFailed name='{TestClass}.FailByAssertion' message='Expected: 2{eol}Actual:   1' details='Fixie.Tests.Assertions.AssertException{eol}{At("FailByAssertion()")}']",
+                $"##teamcity[testFailed name='{TestClass}.FailByAssertion' message='x should be 2 but was 1' details='Fixie.Tests.Assertions.AssertException{eol}{At("FailByAssertion()")}']",
                 $"##teamcity[testFinished name='{TestClass}.FailByAssertion' duration='#']",
 
                 $"##teamcity[testStarted name='{TestClass}.Pass']",
@@ -39,7 +39,7 @@ public class TeamCityReportTests : MessagingTests
                 $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")' duration='#']",
 
                 $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.Int32>(123)']",
-                $"##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='Expected: System.String{eol}Actual:   System.Int32' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']",
+                $"##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='genericArgument should be System.String but was System.Int32' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']",
                 $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' duration='#']",
 
                 "##teamcity[testSuiteFinished name='Fixie.Tests']"

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -39,7 +39,7 @@ public class TeamCityReportTests : MessagingTests
                 $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")' duration='#']",
 
                 $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.Int32>(123)']",
-                $"##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='genericArgument should be System.String but was System.Int32' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']",
+                $"##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='genericArgument should be typeof(string) but was typeof(int)' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']",
                 $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' duration='#']",
 
                 "##teamcity[testSuiteFinished name='Fixie.Tests']"

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -18,7 +18,7 @@ public class XmlReportTests : MessagingTests
 
         await Run(report);
 
-        console.ToString().ShouldBeEmpty();
+        console.ToString().ShouldBe("");
         
         if (actual == null)
             throw new Exception("Expected non-null XML report.");

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -58,8 +58,7 @@ public class XmlReportTests : MessagingTests
     <test name=""{GenericTestClass}.ShouldBeString&lt;System.String&gt;(&quot;B&quot;)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Pass"" time=""1.234"" />
     <test name=""{GenericTestClass}.ShouldBeString&lt;System.Int32&gt;(123)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Fail"" time=""1.234"">
       <failure exception-type=""Fixie.Tests.Assertions.AssertException"">
-        <message><![CDATA[Expected: System.String
-Actual:   System.Int32]]></message>
+        <message><![CDATA[genericArgument should be System.String but was System.Int32]]></message>
         <stack-trace><![CDATA[{At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")}]]></stack-trace>
       </failure>
     </test>
@@ -73,8 +72,7 @@ Actual:   System.Int32]]></message>
     </test>
     <test name=""{TestClass}.FailByAssertion"" type=""{TestClass}"" method=""FailByAssertion"" result=""Fail"" time=""1.234"">
       <failure exception-type=""Fixie.Tests.Assertions.AssertException"">
-        <message><![CDATA[Expected: 2
-Actual:   1]]></message>
+        <message><![CDATA[x should be 2 but was 1]]></message>
         <stack-trace><![CDATA[{At("FailByAssertion()")}]]></stack-trace>
       </failure>
     </test>

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -58,7 +58,7 @@ public class XmlReportTests : MessagingTests
     <test name=""{GenericTestClass}.ShouldBeString&lt;System.String&gt;(&quot;B&quot;)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Pass"" time=""1.234"" />
     <test name=""{GenericTestClass}.ShouldBeString&lt;System.Int32&gt;(123)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Fail"" time=""1.234"">
       <failure exception-type=""Fixie.Tests.Assertions.AssertException"">
-        <message><![CDATA[genericArgument should be System.String but was System.Int32]]></message>
+        <message><![CDATA[genericArgument should be typeof(string) but was typeof(int)]]></message>
         <stack-trace><![CDATA[{At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")}]]></stack-trace>
       </failure>
     </test>

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -31,8 +31,8 @@ public class ReturnTypeTests : InstrumentedExecutionTests
             "AsyncTestClass.AwaitTaskThenPass passed",
             "AsyncTestClass.AwaitValueTaskThenPass passed",
             "AsyncTestClass.CompleteTaskThenPass passed",
-            "AsyncTestClass.FailAfterAwaitTask failed: Expected: 0" + NewLine + "Actual:   3",
-            "AsyncTestClass.FailAfterAwaitValueTask failed: Expected: 0" + NewLine + "Actual:   3",
+            "AsyncTestClass.FailAfterAwaitTask failed: result should be 0 but was 3",
+            "AsyncTestClass.FailAfterAwaitValueTask failed: result should be 0 but was 3",
             "AsyncTestClass.FailBeforeAwaitTask failed: 'FailBeforeAwaitTask' failed!",
             "AsyncTestClass.FailBeforeAwaitValueTask failed: 'FailBeforeAwaitValueTask' failed!",
             "AsyncTestClass.FailDuringAwaitTask failed: Attempted to divide by zero.",
@@ -72,7 +72,7 @@ public class ReturnTypeTests : InstrumentedExecutionTests
         output.ShouldHaveResults(
             "FSharpAsyncTestClass.AsyncPass passed",
             "FSharpAsyncTestClass.FailBeforeAsync failed: 'FailBeforeAsync' failed!",
-            "FSharpAsyncTestClass.FailFromAsync failed: Expected: 0" + NewLine + "Actual:   3",
+            "FSharpAsyncTestClass.FailFromAsync failed: result should be 0 but was 3",
             "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync returned null, " +
             "but a non-null awaitable object was expected.");
 

--- a/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
+++ b/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
@@ -41,7 +41,7 @@ public static class TestCaseMappingAssertions
 
     static void ShouldUseDefaultsForUnmappedProperties(TestCase test)
     {
-        test.Traits.ShouldBeEmpty();
+        test.Traits.ShouldBe([]);
         test.ExecutorUri.ToString().ShouldBe("executor://fixie.testadapter/");
     }
 

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -21,7 +21,7 @@ public class VsDiscoveryRecorderTests : MessagingTests
 
         RecordAnticipatedPipeMessages(vsDiscoveryRecorder);
 
-        log.Messages.ShouldBeEmpty();
+        log.Messages.ShouldBe([]);
 
         discoverySink.TestCases.ShouldSatisfy([
             x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Fail", assemblyPath),

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -74,10 +74,7 @@ public class VsExecutionRecorderTests : MessagingTests
         failByAssertion.TestCase.ShouldBeExecutionTimeTest(TestClass+".FailByAssertion", assemblyPath);
         failByAssertion.TestCase.DisplayName.ShouldBe(TestClass+".FailByAssertion");
         failByAssertion.Outcome.ShouldBe(TestOutcome.Failed);
-        failByAssertion.ErrorMessage.Lines().ShouldBe([
-            "Expected: 2",
-            "Actual:   1"
-        ]);
+        failByAssertion.ErrorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
@@ -128,16 +125,12 @@ public class VsExecutionRecorderTests : MessagingTests
         shouldBeStringPassB.Messages.ShouldBeEmpty();
         shouldBeStringPassB.Duration.ShouldBe(TimeSpan.FromMilliseconds(106));
 
-
         shouldBeStringFailStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
 
         shouldBeStringFail.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
         shouldBeStringFail.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
         shouldBeStringFail.Outcome.ShouldBe(TestOutcome.Failed);
-        shouldBeStringFail.ErrorMessage.Lines().ShouldBe([
-            "Expected: System.String",
-            "Actual:   System.Int32"
-        ]);
+        shouldBeStringFail.ErrorMessage.ShouldBe("genericArgument should be System.String but was System.Int32");
         shouldBeStringFail.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
@@ -183,7 +176,7 @@ public class VsExecutionRecorderTests : MessagingTests
             Reason = new PipeMessage.Exception
             {
                 Type = "Fixie.Tests.Assertions.AssertException",
-                Message = "Expected: 2" + NewLine + "Actual:   1",
+                Message = "x should be 2 but was 1",
                 StackTrace = At("FailByAssertion()")
             }
         }));
@@ -245,7 +238,7 @@ public class VsExecutionRecorderTests : MessagingTests
             Reason = new PipeMessage.Exception
             {
                 Type = "Fixie.Tests.Assertions.AssertException",
-                Message = "Expected: System.String" + NewLine + "Actual:   System.Int32",
+                Message = "genericArgument should be System.String but was System.Int32",
                 StackTrace = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
             }
         }));

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -29,8 +29,8 @@ public class VsExecutionRecorderTests : MessagingTests
         {
             if (message is TestResult result)
             {
-                result.Traits.ShouldBeEmpty();
-                result.Attachments.ShouldBeEmpty();
+                result.Traits.ShouldBe([]);
+                result.Attachments.ShouldBe([]);
                 result.ComputerName.ShouldBe(MachineName);
             }
         }
@@ -66,7 +66,7 @@ public class VsExecutionRecorderTests : MessagingTests
             .NormalizeStackTraceLines()
             .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
         fail.DisplayName.ShouldBe(TestClass+".Fail");
-        fail.Messages.ShouldBeEmpty();
+        fail.Messages.ShouldBe([]);
         fail.Duration.ShouldBe(TimeSpan.FromMilliseconds(102));
 
         failByAssertionStart.ShouldBeExecutionTimeTest(TestClass + ".FailByAssertion", assemblyPath);
@@ -80,7 +80,7 @@ public class VsExecutionRecorderTests : MessagingTests
             .NormalizeStackTraceLines()
             .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
         failByAssertion.DisplayName.ShouldBe(TestClass+".FailByAssertion");
-        failByAssertion.Messages.ShouldBeEmpty();
+        failByAssertion.Messages.ShouldBe([]);
         failByAssertion.Duration.ShouldBe(TimeSpan.FromMilliseconds(103));
 
         passStart.ShouldBeExecutionTimeTest(TestClass + ".Pass", assemblyPath);
@@ -91,7 +91,7 @@ public class VsExecutionRecorderTests : MessagingTests
         pass.ErrorMessage.ShouldBe(null);
         pass.ErrorStackTrace.ShouldBe(null);
         pass.DisplayName.ShouldBe(TestClass+".Pass");
-        pass.Messages.ShouldBeEmpty();
+        pass.Messages.ShouldBe([]);
         pass.Duration.ShouldBe(TimeSpan.FromMilliseconds(104));
 
         skip.TestCase.ShouldBeExecutionTimeTest(TestClass+".Skip", assemblyPath);
@@ -100,7 +100,7 @@ public class VsExecutionRecorderTests : MessagingTests
         skip.ErrorMessage.ShouldBe("⚠ Skipped with attribute.");
         skip.ErrorStackTrace.ShouldBe(null);
         skip.DisplayName.ShouldBe(TestClass+".Skip");
-        skip.Messages.ShouldBeEmpty();
+        skip.Messages.ShouldBe([]);
         skip.Duration.ShouldBe(TimeSpan.Zero);
 
         shouldBeStringPassAStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
@@ -111,7 +111,7 @@ public class VsExecutionRecorderTests : MessagingTests
         shouldBeStringPassA.ErrorMessage.ShouldBe(null);
         shouldBeStringPassA.ErrorStackTrace.ShouldBe(null);
         shouldBeStringPassA.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.String>(\"A\")");
-        shouldBeStringPassA.Messages.ShouldBeEmpty();
+        shouldBeStringPassA.Messages.ShouldBe([]);
         shouldBeStringPassA.Duration.ShouldBe(TimeSpan.FromMilliseconds(105));
 
         shouldBeStringPassBStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
@@ -122,7 +122,7 @@ public class VsExecutionRecorderTests : MessagingTests
         shouldBeStringPassB.ErrorMessage.ShouldBe(null);
         shouldBeStringPassB.ErrorStackTrace.ShouldBe(null);
         shouldBeStringPassB.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.String>(\"B\")");
-        shouldBeStringPassB.Messages.ShouldBeEmpty();
+        shouldBeStringPassB.Messages.ShouldBe([]);
         shouldBeStringPassB.Duration.ShouldBe(TimeSpan.FromMilliseconds(106));
 
         shouldBeStringFailStart.ShouldBeExecutionTimeTest(GenericTestClass + ".ShouldBeString", assemblyPath);
@@ -139,7 +139,7 @@ public class VsExecutionRecorderTests : MessagingTests
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
             ]);
         shouldBeStringFail.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString<System.Int32>(123)");
-        shouldBeStringFail.Messages.ShouldBeEmpty();
+        shouldBeStringFail.Messages.ShouldBe([]);
         shouldBeStringFail.Duration.ShouldBe(TimeSpan.FromMilliseconds(107));
     }
 

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -130,7 +130,7 @@ public class VsExecutionRecorderTests : MessagingTests
         shouldBeStringFail.TestCase.ShouldBeExecutionTimeTest(GenericTestClass+".ShouldBeString", assemblyPath);
         shouldBeStringFail.TestCase.DisplayName.ShouldBe(GenericTestClass+".ShouldBeString");
         shouldBeStringFail.Outcome.ShouldBe(TestOutcome.Failed);
-        shouldBeStringFail.ErrorMessage.ShouldBe("genericArgument should be System.String but was System.Int32");
+        shouldBeStringFail.ErrorMessage.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.ErrorStackTrace
             .Lines()
             .NormalizeStackTraceLines()
@@ -238,7 +238,7 @@ public class VsExecutionRecorderTests : MessagingTests
             Reason = new PipeMessage.Exception
             {
                 Type = "Fixie.Tests.Assertions.AssertException",
-                Message = "genericArgument should be System.String but was System.Int32",
+                Message = "genericArgument should be typeof(string) but was typeof(int)",
                 StackTrace = At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
             }
         }));


### PR DESCRIPTION
This dramatically improves the formatting of assertion messages, similar to that of Shouldly, but by letting the compiler do all of the work of obtaining a perfect "left of the dot" actual expression string via `[CallerArgumentExpression(...)]`. This is a step towards elevating these self-testing assertion helpers to a first class library of their own.