### PR TITLE
Improve string assertions

### DIFF
--- a/src/Fixie.Tests/InstrumentedExecutionTests.cs
+++ b/src/Fixie.Tests/InstrumentedExecutionTests.cs
@@ -35,10 +35,10 @@ public abstract class InstrumentedExecutionTests
     protected class Output
     {
         readonly string namespaceQualifiedTestClass;
-        readonly string[] lifecycle;
+        readonly string lifecycle;
         readonly string[] results;
 
-        public Output(string namespaceQualifiedTestClass, string[] lifecycle, string[] results)
+        public Output(string namespaceQualifiedTestClass, string lifecycle, string[] results)
         {
             this.namespaceQualifiedTestClass = namespaceQualifiedTestClass;
             this.lifecycle = lifecycle;
@@ -47,7 +47,7 @@ public abstract class InstrumentedExecutionTests
 
         public void ShouldHaveLifecycle(params string[] expected)
         {
-            lifecycle.ShouldBe(expected);
+            lifecycle.ShouldBe(string.Join("", expected.Select(x => x + Environment.NewLine)));
         }
 
         public void ShouldHaveResults(params string[] expected)
@@ -124,7 +124,7 @@ public abstract class InstrumentedExecutionTests
         {
             var results = await Utility.Run(testClass, execution, state.Console);
 
-            return new Output(GetType().FullName!, state.Console.ToString().Lines().ToArray(), results.ToArray());
+            return new Output(GetType().FullName!, state.Console.ToString() ?? "", results.ToArray());
         }
     }
 
@@ -137,7 +137,7 @@ public abstract class InstrumentedExecutionTests
         {
             var results = await Utility.Run(testClasses, execution, state.Console);
 
-            return new Output(GetType().FullName!, state.Console.ToString().Lines().ToArray(), results.ToArray());
+            return new Output(GetType().FullName!, state.Console.ToString() ?? "", results.ToArray());
         }
     }
 }

--- a/src/Fixie.Tests/Internal/BusTests.cs
+++ b/src/Fixie.Tests/Internal/BusTests.cs
@@ -22,15 +22,17 @@ public class BusTests
         await bus.Publish(new AnotherEvent(2));
         await bus.Publish(new Event(3));
 
-        console.ToString().Lines()
-            .ShouldBe([
-                FullName<EventHandler>() + " handled Event 1",
-                FullName<CombinationEventHandler>() + " handled Event 1",
-                FullName<AnotherEventHandler>() + " handled AnotherEvent 2",
-                FullName<CombinationEventHandler>() + " handled AnotherEvent 2",
-                FullName<EventHandler>() + " handled Event 3",
-                FullName<CombinationEventHandler>() + " handled Event 3"
-            ]);
+        console.ToString()
+            .ShouldBe(
+                $"""
+                 {FullName<EventHandler>()} handled Event 1
+                 {FullName<CombinationEventHandler>()} handled Event 1
+                 {FullName<AnotherEventHandler>()} handled AnotherEvent 2
+                 {FullName<CombinationEventHandler>()} handled AnotherEvent 2
+                 {FullName<EventHandler>()} handled Event 3
+                 {FullName<CombinationEventHandler>()} handled Event 3
+                 
+                 """);
     }
 
     public async Task ShouldCatchAndLogExceptionsThrowByProblematicReportsRatherThanInterruptExecution()
@@ -48,20 +50,24 @@ public class BusTests
         await bus.Publish(new AnotherEvent(2));
         await bus.Publish(new Event(3));
 
-        console.ToString().Lines()
-            .ShouldBe([
-                FullName<EventHandler>() + " handled Event 1",
-                FullName<FailingEventHandler>() + $" threw an exception while attempting to handle a message of type {FullName<Event>()}:",
-                "",
-                FullName<StubException>() + ": Could not handle Event 1",
-                "<<Stack Trace>>",
-                "",
-                FullName<EventHandler>() + " handled Event 3",
-                FullName<FailingEventHandler>() + $" threw an exception while attempting to handle a message of type {FullName<Event>()}:",
-                "",
-                FullName<StubException>() + ": Could not handle Event 3",
-                "<<Stack Trace>>"
-            ]);
+        console.ToString()
+            .ShouldBe(
+                $"""
+                {FullName<EventHandler>()} handled Event 1
+                {FullName<FailingEventHandler>()} threw an exception while attempting to handle a message of type {FullName<Event>()}:
+                
+                {FullName<StubException>()}: Could not handle Event 1
+                <<Stack Trace>>
+                
+                {FullName<EventHandler>()} handled Event 3
+                {FullName<FailingEventHandler>()} threw an exception while attempting to handle a message of type {FullName<Event>()}:
+                
+                {FullName<StubException>()}: Could not handle Event 3
+                <<Stack Trace>>
+                
+                
+                """
+            );
     }
 
     class Event : IMessage

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -43,8 +43,7 @@ public class AppVeyorReportTests : MessagingTests
         int.Parse(fail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
         fail.ErrorMessage.ShouldBe("'Fail' failed!");
         fail.ErrorStackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
         fail.StdOut.ShouldBe("");
 
@@ -53,8 +52,7 @@ public class AppVeyorReportTests : MessagingTests
         int.Parse(failByAssertion.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
         failByAssertion.ErrorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.ErrorStackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
         failByAssertion.StdOut.ShouldBe("");
 
@@ -92,8 +90,7 @@ public class AppVeyorReportTests : MessagingTests
         shouldBeStringFail.ErrorMessage
             .ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.ErrorStackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe([
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -43,8 +43,7 @@ public class AppVeyorReportTests : MessagingTests
         int.Parse(fail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
         fail.ErrorMessage.ShouldBe("'Fail' failed!");
         fail.ErrorStackTrace
-            .NormalizeStackTraces()
-            .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
+            .ShouldBeStackTrace(["Fixie.Tests.FailureException", At("Fail()")]);
         fail.StdOut.ShouldBe("");
 
         failByAssertion.TestName.ShouldBe(TestClass + ".FailByAssertion");
@@ -52,8 +51,7 @@ public class AppVeyorReportTests : MessagingTests
         int.Parse(failByAssertion.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
         failByAssertion.ErrorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.ErrorStackTrace
-            .NormalizeStackTraces()
-            .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
+            .ShouldBeStackTrace(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
         failByAssertion.StdOut.ShouldBe("");
 
         pass.TestName.ShouldBe(TestClass + ".Pass");
@@ -90,8 +88,7 @@ public class AppVeyorReportTests : MessagingTests
         shouldBeStringFail.ErrorMessage
             .ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.ErrorStackTrace
-            .NormalizeStackTraces()
-            .ShouldBe([
+            .ShouldBeStackTrace([
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
             ]);

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -104,8 +104,7 @@ public class AzureReportTests : MessagingTests
         fail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
         fail.errorMessage.ShouldBe("'Fail' failed!");
         fail.stackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
 
         failByAssertion.automatedTestName.ShouldBe(TestClass + ".FailByAssertion");
@@ -114,8 +113,7 @@ public class AzureReportTests : MessagingTests
         failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
         failByAssertion.errorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.stackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
 
         pass.automatedTestName.ShouldBe(TestClass + ".Pass");
@@ -152,8 +150,7 @@ public class AzureReportTests : MessagingTests
         shouldBeStringFail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
         shouldBeStringFail.errorMessage.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.stackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe([
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -104,8 +104,7 @@ public class AzureReportTests : MessagingTests
         fail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
         fail.errorMessage.ShouldBe("'Fail' failed!");
         fail.stackTrace
-            .NormalizeStackTraces()
-            .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
+            .ShouldBeStackTrace(["Fixie.Tests.FailureException", At("Fail()")]);
 
         failByAssertion.automatedTestName.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.testCaseTitle.ShouldBe(TestClass + ".FailByAssertion");
@@ -113,8 +112,7 @@ public class AzureReportTests : MessagingTests
         failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
         failByAssertion.errorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.stackTrace
-            .NormalizeStackTraces()
-            .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
+            .ShouldBeStackTrace(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
 
         pass.automatedTestName.ShouldBe(TestClass + ".Pass");
         pass.testCaseTitle.ShouldBe(TestClass + ".Pass");
@@ -150,8 +148,7 @@ public class AzureReportTests : MessagingTests
         shouldBeStringFail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
         shouldBeStringFail.errorMessage.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.stackTrace
-            .NormalizeStackTraces()
-            .ShouldBe([
+            .ShouldBeStackTrace([
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
             ]);

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -11,8 +11,7 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(environment => new ConsoleReport(environment));
 
         output.Console
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .CleanDuration()
             .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
@@ -55,8 +54,7 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console, testPattern: "*"));
 
         output.Console
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .CleanDuration()
             .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -10,9 +10,7 @@ public class ConsoleReportTests : MessagingTests
     {
         var output = await Run(environment => new ConsoleReport(environment));
 
-        output.Console
-            .NormalizeStackTraces()
-            .CleanDuration()
+        NormalizeOutput(output)
             .ShouldBe(
                 $"""
                  Running Fixie.Tests (net{TargetFrameworkVersion})
@@ -51,9 +49,7 @@ public class ConsoleReportTests : MessagingTests
     {
         var output = await Run(console => new ConsoleReport(console, testPattern: "*"));
 
-        output.Console
-            .NormalizeStackTraces()
-            .CleanDuration()
+        NormalizeOutput(output)
             .ShouldBe(
                 $"""
                  Running Fixie.Tests (net{TargetFrameworkVersion})
@@ -105,10 +101,7 @@ public class ConsoleReportTests : MessagingTests
 
         var output = await Run(console => new ConsoleReport(console), discovery);
 
-        output.Console
-            .CleanDuration()
-            .Lines()
-            .Last()
+        LastNonemptyLine(NormalizeOutput(output))
             .ShouldBe("2 failed, 1 skipped, took 1.23 seconds");
     }
 
@@ -124,10 +117,7 @@ public class ConsoleReportTests : MessagingTests
 
         var output = await Run(console => new ConsoleReport(console), discovery);
 
-        output.Console
-            .CleanDuration()
-            .Lines()
-            .Last()
+        LastNonemptyLine(NormalizeOutput(output))
             .ShouldBe("1 passed, 1 skipped, took 1.23 seconds");
     }
 
@@ -143,10 +133,7 @@ public class ConsoleReportTests : MessagingTests
 
         var output = await Run(console => new ConsoleReport(console), discovery);
 
-        output.Console
-            .CleanDuration()
-            .Lines()
-            .Last()
+        LastNonemptyLine(NormalizeOutput(output))
             .ShouldBe("1 passed, 2 failed, took 1.23 seconds");
     }
 
@@ -162,16 +149,20 @@ public class ConsoleReportTests : MessagingTests
 
         var output = await Run(console => new ConsoleReport(console), discovery);
 
-        output.Console
-            .Lines()
-            .Last()
+        LastNonemptyLine(NormalizeOutput(output))
             .ShouldBe("No tests found.");
 
         output = await Run(console => new ConsoleReport(console, testPattern: "Ineffective*Pattern"), discovery);
 
-        output.Console
-            .Lines()
-            .Last()
+        LastNonemptyLine(NormalizeOutput(output))
             .ShouldBe("No tests match the specified pattern: Ineffective*Pattern");
     }
+
+    static string NormalizeOutput(Output output) =>
+        output.Console
+            .NormalizeStackTraces()
+            .CleanDuration();
+
+    static string LastNonemptyLine(string multiline) =>
+        multiline.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Last();
 }

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -13,41 +13,38 @@ public class ConsoleReportTests : MessagingTests
         output.Console
             .NormalizeStackTraces()
             .CleanDuration()
-            .Lines()
-            .ShouldBe([
-                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
-                "",
+            .ShouldBe(
+                $"""
+                 Running Fixie.Tests (net{TargetFrameworkVersion})
 
-                "Test '" + TestClass + ".Fail' failed:",
-                "",
-                "'Fail' failed!",
-                "",
-                "Fixie.Tests.FailureException",
-                At("Fail()"),
-                "",
+                 Test '{TestClass}.Fail' failed:
 
-                "Test '" + TestClass + ".FailByAssertion' failed:",
-                "",
-                "x should be 2 but was 1",
-                "",
-                "Fixie.Tests.Assertions.AssertException",
-                At("FailByAssertion()"),
-                "",
+                 'Fail' failed!
 
-                "Test '" + TestClass + ".Skip' skipped:",
-                "⚠ Skipped with attribute.",
-                "",
+                 Fixie.Tests.FailureException
+                 {At("Fail()")}
 
-                "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
-                "",
-                "genericArgument should be typeof(string) but was typeof(int)",
-                "",
-                "Fixie.Tests.Assertions.AssertException",
-                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
-                "",
+                 Test '{TestClass}.FailByAssertion' failed:
 
-                "3 passed, 3 failed, 1 skipped, took 1.23 seconds"
-            ]);
+                 x should be 2 but was 1
+
+                 Fixie.Tests.Assertions.AssertException
+                 {At("FailByAssertion()")}
+
+                 Test '{TestClass}.Skip' skipped:
+                 ⚠ Skipped with attribute.
+
+                 Test '{GenericTestClass}.ShouldBeString<System.Int32>(123)' failed:
+
+                 genericArgument should be typeof(string) but was typeof(int)
+
+                 Fixie.Tests.Assertions.AssertException
+                 {At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")}
+
+                 3 passed, 3 failed, 1 skipped, took 1.23 seconds
+
+
+                 """);
     }
 
     public async Task ShouldIncludePassingResultsWhenFilteringByPattern()
@@ -57,48 +54,43 @@ public class ConsoleReportTests : MessagingTests
         output.Console
             .NormalizeStackTraces()
             .CleanDuration()
-            .Lines()
-            .ShouldBe([
-                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
-                "",
+            .ShouldBe(
+                $"""
+                 Running Fixie.Tests (net{TargetFrameworkVersion})
 
-                "Test '" + TestClass + ".Fail' failed:",
-                "",
-                "'Fail' failed!",
-                "",
-                "Fixie.Tests.FailureException",
-                At("Fail()"),
-                "",
+                 Test '{TestClass}.Fail' failed:
 
-                "Test '" + TestClass + ".FailByAssertion' failed:",
-                "",
-                "x should be 2 but was 1",
-                "",
-                "Fixie.Tests.Assertions.AssertException",
-                At("FailByAssertion()"),
-                "",
+                 'Fail' failed!
 
-                "Test '" + TestClass + ".Pass' passed",
-                "",
+                 Fixie.Tests.FailureException
+                 {At("Fail()")}
 
-                "Test '" + TestClass + ".Skip' skipped:",
-                "⚠ Skipped with attribute.",
-                "",
+                 Test '{TestClass}.FailByAssertion' failed:
 
-                "Test '" + GenericTestClass + ".ShouldBeString<System.String>(\"A\")' passed",
-                "Test '" + GenericTestClass + ".ShouldBeString<System.String>(\"B\")' passed",
-                "",
+                 x should be 2 but was 1
 
-                "Test '" + GenericTestClass + ".ShouldBeString<System.Int32>(123)' failed:",
-                "",
-                "genericArgument should be typeof(string) but was typeof(int)",
-                "",
-                "Fixie.Tests.Assertions.AssertException",
-                At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)"),
-                "",
+                 Fixie.Tests.Assertions.AssertException
+                 {At("FailByAssertion()")}
 
-                "3 passed, 3 failed, 1 skipped, took 1.23 seconds"
-            ]);
+                 Test '{TestClass}.Pass' passed
+
+                 Test '{TestClass}.Skip' skipped:
+                 ⚠ Skipped with attribute.
+
+                 Test '{GenericTestClass}.ShouldBeString<System.String>("A")' passed
+                 Test '{GenericTestClass}.ShouldBeString<System.String>("B")' passed
+
+                 Test '{GenericTestClass}.ShouldBeString<System.Int32>(123)' failed:
+
+                 genericArgument should be typeof(string) but was typeof(int)
+
+                 Fixie.Tests.Assertions.AssertException
+                 {At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")}
+
+                 3 passed, 3 failed, 1 skipped, took 1.23 seconds
+
+
+                 """);
     }
 
     class ZeroPassed : SelfTestDiscovery

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -11,6 +11,7 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(environment => new ConsoleReport(environment));
 
         output.Console
+            .Lines()
             .NormalizeStackTraceLines()
             .CleanDuration()
             .ShouldBe([
@@ -54,6 +55,7 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console, testPattern: "*"));
 
         output.Console
+            .Lines()
             .NormalizeStackTraceLines()
             .CleanDuration()
             .ShouldBe([
@@ -112,6 +114,7 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console), discovery);
 
         output.Console
+            .Lines()
             .CleanDuration()
             .Last()
             .ShouldBe("2 failed, 1 skipped, took 1.23 seconds");
@@ -130,6 +133,7 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console), discovery);
 
         output.Console
+            .Lines()
             .CleanDuration()
             .Last()
             .ShouldBe("1 passed, 1 skipped, took 1.23 seconds");
@@ -148,6 +152,7 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console), discovery);
 
         output.Console
+            .Lines()
             .CleanDuration()
             .Last()
             .ShouldBe("1 passed, 2 failed, took 1.23 seconds");
@@ -166,12 +171,14 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console), discovery);
 
         output.Console
+            .Lines()
             .Last()
             .ShouldBe("No tests found.");
 
         output = await Run(console => new ConsoleReport(console, testPattern: "Ineffective*Pattern"), discovery);
 
         output.Console
+            .Lines()
             .Last()
             .ShouldBe("No tests match the specified pattern: Ineffective*Pattern");
     }

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -12,6 +12,7 @@ public class ConsoleReportTests : MessagingTests
 
         output.Console
             .NormalizeStackTraces()
+            .Lines()
             .CleanDuration()
             .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
@@ -55,6 +56,7 @@ public class ConsoleReportTests : MessagingTests
 
         output.Console
             .NormalizeStackTraces()
+            .Lines()
             .CleanDuration()
             .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",

--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -12,8 +12,8 @@ public class ConsoleReportTests : MessagingTests
 
         output.Console
             .NormalizeStackTraces()
-            .Lines()
             .CleanDuration()
+            .Lines()
             .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
@@ -56,8 +56,8 @@ public class ConsoleReportTests : MessagingTests
 
         output.Console
             .NormalizeStackTraces()
-            .Lines()
             .CleanDuration()
+            .Lines()
             .ShouldBe([
                 $"Running Fixie.Tests (net{TargetFrameworkVersion})",
                 "",
@@ -114,8 +114,8 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console), discovery);
 
         output.Console
-            .Lines()
             .CleanDuration()
+            .Lines()
             .Last()
             .ShouldBe("2 failed, 1 skipped, took 1.23 seconds");
     }
@@ -133,8 +133,8 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console), discovery);
 
         output.Console
-            .Lines()
             .CleanDuration()
+            .Lines()
             .Last()
             .ShouldBe("1 passed, 1 skipped, took 1.23 seconds");
     }
@@ -152,8 +152,8 @@ public class ConsoleReportTests : MessagingTests
         var output = await Run(console => new ConsoleReport(console), discovery);
 
         output.Console
-            .Lines()
             .CleanDuration()
+            .Lines()
             .Last()
             .ShouldBe("1 passed, 2 failed, took 1.23 seconds");
     }

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -43,8 +43,7 @@ public class LifecycleMessageTests : MessagingTests
         fail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         fail.Reason.ShouldBe<FailureException>();
         fail.Reason.StackTraceSummary()
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe([At("Fail()")]);
         fail.Reason.Message.ShouldBe("'Fail' failed!");
 
@@ -55,8 +54,7 @@ public class LifecycleMessageTests : MessagingTests
         failByAssertion.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         failByAssertion.Reason.ShouldBe<AssertException>();
         failByAssertion.Reason.StackTraceSummary()
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe([At("FailByAssertion()")]);
         failByAssertion.Reason.Message.ShouldBe("x should be 2 but was 1");
 
@@ -84,8 +82,7 @@ public class LifecycleMessageTests : MessagingTests
         shouldBeStringFail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         shouldBeStringFail.Reason.ShouldBe<AssertException>();
         shouldBeStringFail.Reason.StackTraceSummary()
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe([At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")]);
         shouldBeStringFail.Reason.Message.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
 

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -43,8 +43,7 @@ public class LifecycleMessageTests : MessagingTests
         fail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         fail.Reason.ShouldBe<FailureException>();
         fail.Reason.StackTraceSummary()
-            .NormalizeStackTraces()
-            .ShouldBe([At("Fail()")]);
+            .ShouldBeStackTrace([At("Fail()")]);
         fail.Reason.Message.ShouldBe("'Fail' failed!");
 
         failByAssertionStarted.Test.ShouldBe(TestClass + ".FailByAssertion");
@@ -54,8 +53,7 @@ public class LifecycleMessageTests : MessagingTests
         failByAssertion.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         failByAssertion.Reason.ShouldBe<AssertException>();
         failByAssertion.Reason.StackTraceSummary()
-            .NormalizeStackTraces()
-            .ShouldBe([At("FailByAssertion()")]);
+            .ShouldBeStackTrace([At("FailByAssertion()")]);
         failByAssertion.Reason.Message.ShouldBe("x should be 2 but was 1");
 
         skip.Test.ShouldBe(TestClass + ".Skip");
@@ -82,8 +80,7 @@ public class LifecycleMessageTests : MessagingTests
         shouldBeStringFail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
         shouldBeStringFail.Reason.ShouldBe<AssertException>();
         shouldBeStringFail.Reason.StackTraceSummary()
-            .NormalizeStackTraces()
-            .ShouldBe([At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")]);
+            .ShouldBeStackTrace([At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")]);
         shouldBeStringFail.Reason.Message.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
 
         executionCompleted.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);

--- a/src/Fixie.Tests/Reports/MessagingTests.cs
+++ b/src/Fixie.Tests/Reports/MessagingTests.cs
@@ -24,10 +24,10 @@ public abstract class MessagingTests
 
     protected class Output
     {
-        public Output(string[] console)
+        public Output(string console)
             => Console = console;
 
-        public string[] Console { get; }
+        public string Console { get; }
     }
 
     protected Task<Output> Run(IReport report)
@@ -53,7 +53,7 @@ public abstract class MessagingTests
 
         await Utility.Run(getReport(GetTestEnvironment(console)), discovery, execution, console, candidateTypes);
 
-        return new Output(console.ToString().Lines().ToArray());
+        return new Output(console.ToString());
     }
 
     class MessagingTestsExecution : IExecution

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -12,6 +12,7 @@ public class TeamCityReportTests : MessagingTests
         var output = await Run(environment => new TeamCityReport(environment));
 
         output.Console
+            .Lines()
             .NormalizeStackTraceLines()
             .Select(x => Regex.Replace(x, @"duration='\d+'", "duration='#'"))
             .ShouldBe([

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -13,6 +13,7 @@ public class TeamCityReportTests : MessagingTests
 
         output.Console
             .NormalizeStackTraces()
+            .Lines()
             .Select(x => Regex.Replace(x, @"duration='\d+'", "duration='#'"))
             .ShouldBe([
                 "##teamcity[testSuiteStarted name='Fixie.Tests']",

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -12,8 +12,7 @@ public class TeamCityReportTests : MessagingTests
         var output = await Run(environment => new TeamCityReport(environment));
 
         output.Console
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .Select(x => Regex.Replace(x, @"duration='\d+'", "duration='#'"))
             .ShouldBe([
                 "##teamcity[testSuiteStarted name='Fixie.Tests']",

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -11,39 +11,30 @@ public class TeamCityReportTests : MessagingTests
 
         var output = await Run(environment => new TeamCityReport(environment));
 
-        output.Console
-            .NormalizeStackTraces()
-            .Lines()
-            .Select(x => Regex.Replace(x, @"duration='\d+'", "duration='#'"))
-            .ShouldBe([
-                "##teamcity[testSuiteStarted name='Fixie.Tests']",
-
-                $"##teamcity[testStarted name='{TestClass}.Fail']",
-                $"##teamcity[testFailed name='{TestClass}.Fail' message='|'Fail|' failed!' details='Fixie.Tests.FailureException{eol}{At("Fail()")}']",
-                $"##teamcity[testFinished name='{TestClass}.Fail' duration='#']",
-
-                $"##teamcity[testStarted name='{TestClass}.FailByAssertion']",
-                $"##teamcity[testFailed name='{TestClass}.FailByAssertion' message='x should be 2 but was 1' details='Fixie.Tests.Assertions.AssertException{eol}{At("FailByAssertion()")}']",
-                $"##teamcity[testFinished name='{TestClass}.FailByAssertion' duration='#']",
-
-                $"##teamcity[testStarted name='{TestClass}.Pass']",
-                $"##teamcity[testFinished name='{TestClass}.Pass' duration='#']",
-
-                $"##teamcity[testStarted name='{TestClass}.Skip']",
-                $"##teamcity[testIgnored name='{TestClass}.Skip' message='|0x26a0 Skipped with attribute.']",
-                $"##teamcity[testFinished name='{TestClass}.Skip' duration='#']",
-
-                $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>(\"A\")']",
-                $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"A\")' duration='#']",
-
-                $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")']",
-                $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>(\"B\")' duration='#']",
-
-                $"##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.Int32>(123)']",
-                $"##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='genericArgument should be typeof(string) but was typeof(int)' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']",
-                $"##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' duration='#']",
-
-                "##teamcity[testSuiteFinished name='Fixie.Tests']"
-            ]);
+        Regex.Replace(output.Console.NormalizeStackTraces(), @"duration='\d+'", "duration='#'")
+            .ShouldBe(
+                $"""
+                 ##teamcity[testSuiteStarted name='Fixie.Tests']
+                 ##teamcity[testStarted name='{TestClass}.Fail']
+                 ##teamcity[testFailed name='{TestClass}.Fail' message='|'Fail|' failed!' details='Fixie.Tests.FailureException{eol}{At("Fail()")}']
+                 ##teamcity[testFinished name='{TestClass}.Fail' duration='#']
+                 ##teamcity[testStarted name='{TestClass}.FailByAssertion']
+                 ##teamcity[testFailed name='{TestClass}.FailByAssertion' message='x should be 2 but was 1' details='Fixie.Tests.Assertions.AssertException{eol}{At("FailByAssertion()")}']
+                 ##teamcity[testFinished name='{TestClass}.FailByAssertion' duration='#']
+                 ##teamcity[testStarted name='{TestClass}.Pass']
+                 ##teamcity[testFinished name='{TestClass}.Pass' duration='#']
+                 ##teamcity[testStarted name='{TestClass}.Skip']
+                 ##teamcity[testIgnored name='{TestClass}.Skip' message='|0x26a0 Skipped with attribute.']
+                 ##teamcity[testFinished name='{TestClass}.Skip' duration='#']
+                 ##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>("A")']
+                 ##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>("A")' duration='#']
+                 ##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.String>("B")']
+                 ##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.String>("B")' duration='#']
+                 ##teamcity[testStarted name='{GenericTestClass}.ShouldBeString<System.Int32>(123)']
+                 ##teamcity[testFailed name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' message='genericArgument should be typeof(string) but was typeof(int)' details='Fixie.Tests.Assertions.AssertException{eol}{At<SampleGenericTestClass>("ShouldBeString|[T|](T genericArgument)")}']
+                 ##teamcity[testFinished name='{GenericTestClass}.ShouldBeString<System.Int32>(123)' duration='#']
+                 ##teamcity[testSuiteFinished name='Fixie.Tests']
+                 
+                 """);
     }
 }

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -24,8 +24,7 @@ public class XmlReportTests : MessagingTests
             throw new Exception("Expected non-null XML report.");
 
         CleanBrittleValues(actual.ToString())
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ToArray()
             .ShouldBe(ExpectedReport.Lines().ToArray());
     }

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -25,7 +25,7 @@ public class XmlReportTests : MessagingTests
 
         CleanBrittleValues(actual.ToString())
             .NormalizeStackTraces()
-            .ToArray()
+            .Lines()
             .ShouldBe(ExpectedReport.Lines().ToArray());
     }
 

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -25,8 +25,7 @@ public class XmlReportTests : MessagingTests
 
         CleanBrittleValues(actual.ToString())
             .NormalizeStackTraces()
-            .Lines()
-            .ShouldBe(ExpectedReport.Lines().ToArray());
+            .ShouldBe(ExpectedReport);
     }
 
     static string CleanBrittleValues(string actualRawContent)
@@ -49,39 +48,41 @@ public class XmlReportTests : MessagingTests
         {
             var assemblyLocation = GetType().Assembly.Location;
 
-            var expected = $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
-<assemblies>
-<assembly name=""{assemblyLocation}"" run-date=""YYYY-MM-DD"" run-time=""HH:MM:SS"" time=""1.234"" total=""7"" passed=""3"" failed=""3"" skipped=""1"" environment=""64-bit net8.0"" test-framework=""{Fixie.Internal.Framework.Version}"">
-  <collection time=""1.234"" name=""{GenericTestClass}"" total=""3"" passed=""2"" failed=""1"" skipped=""0"">
-    <test name=""{GenericTestClass}.ShouldBeString&lt;System.String&gt;(&quot;A&quot;)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Pass"" time=""1.234"" />
-    <test name=""{GenericTestClass}.ShouldBeString&lt;System.String&gt;(&quot;B&quot;)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Pass"" time=""1.234"" />
-    <test name=""{GenericTestClass}.ShouldBeString&lt;System.Int32&gt;(123)"" type=""{GenericTestClass}"" method=""ShouldBeString"" result=""Fail"" time=""1.234"">
-      <failure exception-type=""Fixie.Tests.Assertions.AssertException"">
-        <message><![CDATA[genericArgument should be typeof(string) but was typeof(int)]]></message>
-        <stack-trace><![CDATA[{At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")}]]></stack-trace>
-      </failure>
-    </test>
-  </collection>
-  <collection time=""1.234"" name=""{TestClass}"" total=""4"" passed=""1"" failed=""2"" skipped=""1"">
-    <test name=""{TestClass}.Fail"" type=""{TestClass}"" method=""Fail"" result=""Fail"" time=""1.234"">
-      <failure exception-type=""Fixie.Tests.FailureException"">
-        <message><![CDATA['Fail' failed!]]></message>
-        <stack-trace><![CDATA[{At("Fail()")}]]></stack-trace>
-      </failure>
-    </test>
-    <test name=""{TestClass}.FailByAssertion"" type=""{TestClass}"" method=""FailByAssertion"" result=""Fail"" time=""1.234"">
-      <failure exception-type=""Fixie.Tests.Assertions.AssertException"">
-        <message><![CDATA[x should be 2 but was 1]]></message>
-        <stack-trace><![CDATA[{At("FailByAssertion()")}]]></stack-trace>
-      </failure>
-    </test>
-    <test name=""{TestClass}.Pass"" type=""{TestClass}"" method=""Pass"" result=""Pass"" time=""1.234"" />
-    <test name=""{TestClass}.Skip"" type=""{TestClass}"" method=""Skip"" result=""Skip"" time=""1.234"">
-      <reason><![CDATA[⚠ Skipped with attribute.]]></reason>
-    </test>
-  </collection>
-</assembly>
-</assemblies>";
+            var expected = $"""
+                            <?xml version="1.0" encoding="utf-8" ?>
+                            <assemblies>
+                            <assembly name="{assemblyLocation}" run-date="YYYY-MM-DD" run-time="HH:MM:SS" time="1.234" total="7" passed="3" failed="3" skipped="1" environment="64-bit net8.0" test-framework="{Fixie.Internal.Framework.Version}">
+                              <collection time="1.234" name="{GenericTestClass}" total="3" passed="2" failed="1" skipped="0">
+                                <test name="{GenericTestClass}.ShouldBeString&lt;System.String&gt;(&quot;A&quot;)" type="{GenericTestClass}" method="ShouldBeString" result="Pass" time="1.234" />
+                                <test name="{GenericTestClass}.ShouldBeString&lt;System.String&gt;(&quot;B&quot;)" type="{GenericTestClass}" method="ShouldBeString" result="Pass" time="1.234" />
+                                <test name="{GenericTestClass}.ShouldBeString&lt;System.Int32&gt;(123)" type="{GenericTestClass}" method="ShouldBeString" result="Fail" time="1.234">
+                                  <failure exception-type="Fixie.Tests.Assertions.AssertException">
+                                    <message><![CDATA[genericArgument should be typeof(string) but was typeof(int)]]></message>
+                                    <stack-trace><![CDATA[{At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")}]]></stack-trace>
+                                  </failure>
+                                </test>
+                              </collection>
+                              <collection time="1.234" name="{TestClass}" total="4" passed="1" failed="2" skipped="1">
+                                <test name="{TestClass}.Fail" type="{TestClass}" method="Fail" result="Fail" time="1.234">
+                                  <failure exception-type="Fixie.Tests.FailureException">
+                                    <message><![CDATA['Fail' failed!]]></message>
+                                    <stack-trace><![CDATA[{At("Fail()")}]]></stack-trace>
+                                  </failure>
+                                </test>
+                                <test name="{TestClass}.FailByAssertion" type="{TestClass}" method="FailByAssertion" result="Fail" time="1.234">
+                                  <failure exception-type="Fixie.Tests.Assertions.AssertException">
+                                    <message><![CDATA[x should be 2 but was 1]]></message>
+                                    <stack-trace><![CDATA[{At("FailByAssertion()")}]]></stack-trace>
+                                  </failure>
+                                </test>
+                                <test name="{TestClass}.Pass" type="{TestClass}" method="Pass" result="Pass" time="1.234" />
+                                <test name="{TestClass}.Skip" type="{TestClass}" method="Skip" result="Skip" time="1.234">
+                                  <reason><![CDATA[⚠ Skipped with attribute.]]></reason>
+                                </test>
+                              </collection>
+                            </assembly>
+                            </assemblies>
+                            """;
 
             return XDocument.Parse(expected).ToString();
         }

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -9,156 +9,163 @@ public class StackTracePresentationTests
     public async Task ShouldProvideCleanStackTraceForImplicitTestClassConstructionFailures()
     {
         (await Run<ConstructionFailureTestClass, ImplicitExceptionHandling>())
-            .ShouldBe([
-                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
-                "",
-                "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
-                "",
-                "'.ctor' failed!",
-                "",
-                "Fixie.Tests.FailureException",
-                At<ConstructionFailureTestClass>(".ctor()"),
-                "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
-                "",
-                "1 failed, took 1.23 seconds"
-            ]);
+            .ShouldBe(
+               $"""
+                Running Fixie.Tests (net{TargetFrameworkVersion})
+                
+                Test '{FullName<ConstructionFailureTestClass>()}.UnreachableTest' failed:
+                
+                '.ctor' failed!
+                
+                Fixie.Tests.FailureException
+                {At<ConstructionFailureTestClass>(".ctor()")}
+                   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
+                
+                1 failed, took 1.23 seconds
+                
+                
+                """);
     }
         
     public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestClassConstructionFailures()
     {
         (await Run<ConstructionFailureTestClass, ExplicitExceptionHandling>())
-            .ShouldBe([
-                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
-                "",
-                "Test '" + FullName<ConstructionFailureTestClass>() + ".UnreachableTest' failed:",
-                "",
-                "'.ctor' failed!",
-                "",
-                "Fixie.Tests.FailureException",
-                At<ConstructionFailureTestClass>(".ctor()"),
-                "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
-                "--- End of stack trace from previous location ---",
-                At(typeof(TestClass), "Construct(Object[] parameters)",
-                    Path.Join("...", "src", "Fixie", "TestClass.cs")),
-                At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
-                "",
-                "1 failed, took 1.23 seconds"
-            ]);
+            .ShouldBe(
+               $"""
+                Running Fixie.Tests (net{TargetFrameworkVersion})
+                
+                Test '{FullName<ConstructionFailureTestClass>()}.UnreachableTest' failed:
+                
+                '.ctor' failed!
+                
+                Fixie.Tests.FailureException
+                {At<ConstructionFailureTestClass>(".ctor()")}
+                   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
+                --- End of stack trace from previous location ---
+                {At(typeof(TestClass), "Construct(Object[] parameters)",
+                    Path.Join("...", "src", "Fixie", "TestClass.cs"))}
+                {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
+                
+                1 failed, took 1.23 seconds
+                
+                
+                """);
     }
 
     public async Task ShouldProvideCleanStackTraceTestMethodFailures()
     {
         (await Run<FailureTestClass, ImplicitExceptionHandling>())
-            .ShouldBe([
-                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
-                "",
-                "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
-                "",
-                "'Asynchronous' failed!",
-                "",
-                "Fixie.Tests.FailureException",
-                At<FailureTestClass>("Asynchronous()"),
-                "",
-                "Test '" + FullName<FailureTestClass>() + ".Synchronous' failed:",
-                "",
-                "'Synchronous' failed!",
-                "",
-                "Fixie.Tests.FailureException",
-                At<FailureTestClass>("Synchronous()"),
-                "",
-                "2 failed, took 1.23 seconds"
-            ]);
+            .ShouldBe(
+               $"""
+                Running Fixie.Tests (net{TargetFrameworkVersion})
+                
+                Test '{FullName<FailureTestClass>()}.Asynchronous' failed:
+                
+                'Asynchronous' failed!
+                
+                Fixie.Tests.FailureException
+                {At<FailureTestClass>("Asynchronous()")}
+                
+                Test '{FullName<FailureTestClass>()}.Synchronous' failed:
+                
+                'Synchronous' failed!
+                
+                Fixie.Tests.FailureException
+                {At<FailureTestClass>("Synchronous()")}
+                
+                2 failed, took 1.23 seconds
+                
+                
+                """);
     }
 
     public async Task ShouldNotAlterTheMeaningfulStackTraceOfExplicitTestMethodInvocationFailures()
     {
-        var output = (await Run<FailureTestClass, ExplicitExceptionHandling>()).ToArray();
+        var output = await Run<FailureTestClass, ExplicitExceptionHandling>();
 
         const string optimizedInvoker = "   at InvokeStub_FailureTestClass.Synchronous(Object, Object, IntPtr*)";
         const string initialInvoker = "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
 
         output
-            .ShouldBe([
-                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
-                "",
-                "Test '" + FullName<FailureTestClass>() + ".Asynchronous' failed:",
-                "",
-                "'Asynchronous' failed!",
-                "",
-                "Fixie.Tests.FailureException",
-                At<FailureTestClass>("Asynchronous()"),
-                At(typeof(MethodInfoExtensions),
-                    "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)",
-                    Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)",
-                    Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
-                "",
-                "Test '" + FullName<FailureTestClass>() + ".Synchronous' failed:",
-                "",
-                "'Synchronous' failed!",
-                "",
-                "Fixie.Tests.FailureException",
-                At<FailureTestClass>("Synchronous()"),
-                output.Contains(optimizedInvoker)
-                    ? optimizedInvoker
-                    : initialInvoker,
-                "   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)",
-                "--- End of stack trace from previous location ---",
-                At(typeof(MethodInfoExtensions),
-                    "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)",
-                    Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)",
-                    Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),
-                At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
-                "",
-                "2 failed, took 1.23 seconds"
-            ]);
+            .ShouldBe(
+               $"""
+                Running Fixie.Tests (net{TargetFrameworkVersion})
+                
+                Test '{FullName<FailureTestClass>()}.Asynchronous' failed:
+                
+                'Asynchronous' failed!
+                
+                Fixie.Tests.FailureException
+                {At<FailureTestClass>("Asynchronous()")}
+                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs"))}
+                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs"))}
+                {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
+                
+                Test '{FullName<FailureTestClass>()}.Synchronous' failed:
+                
+                'Synchronous' failed!
+                
+                Fixie.Tests.FailureException
+                {At<FailureTestClass>("Synchronous()")}
+                {(output.Contains(optimizedInvoker) ? optimizedInvoker : initialInvoker)}
+                   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+                --- End of stack trace from previous location ---
+                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs"))}
+                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs"))}
+                {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
+                
+                2 failed, took 1.23 seconds
+                
+                
+                """);
     }
 
     public async Task ShouldProvideLiterateStackTraceIncludingAllNestedExceptions()
     {
         (await Run<NestedFailureTestClass, ImplicitExceptionHandling>())
-            .ShouldBe([
-                $"Running Fixie.Tests (net{TargetFrameworkVersion})",
-                "",
-                "Test '" + FullName<NestedFailureTestClass>() + ".Asynchronous' failed:",
-                "",
-                "Primary Exception!",
-                "",
-                FullName<PrimaryException>(),
-                At<StackTracePresentationTests>("ThrowNestedException()"),
-                At<NestedFailureTestClass>("Asynchronous()"),
-                "",
-                "------- Inner Exception: System.AggregateException -------",
-                "One or more errors occurred. (Divide by Zero Exception!)",
-                At<StackTracePresentationTests>("ThrowNestedException()"),
-                "",
-                "------- Inner Exception: System.DivideByZeroException -------",
-                "Divide by Zero Exception!",
-                At<StackTracePresentationTests>("ThrowNestedException()"),
-                "",
-                "Test '" + FullName<NestedFailureTestClass>() + ".Synchronous' failed:",
-                "",
-                "Primary Exception!",
-                "",
-                FullName<PrimaryException>(),
-                At<StackTracePresentationTests>("ThrowNestedException()"),
-                At<NestedFailureTestClass>("Synchronous()"),
-                "",
-                "------- Inner Exception: System.AggregateException -------",
-                "One or more errors occurred. (Divide by Zero Exception!)",
-                At<StackTracePresentationTests>("ThrowNestedException()"),
-                "",
-                "------- Inner Exception: System.DivideByZeroException -------",
-                "Divide by Zero Exception!",
-                At<StackTracePresentationTests>("ThrowNestedException()"),
-                "",
-                "2 failed, took 1.23 seconds"
-            ]);
+            .ShouldBe(
+               $"""
+                Running Fixie.Tests (net{TargetFrameworkVersion})
+                
+                Test '{FullName<NestedFailureTestClass>()}.Asynchronous' failed:
+                
+                Primary Exception!
+                
+                {FullName<PrimaryException>()}
+                {At<StackTracePresentationTests>("ThrowNestedException()")}
+                {At<NestedFailureTestClass>("Asynchronous()")}
+                
+                ------- Inner Exception: System.AggregateException -------
+                One or more errors occurred. (Divide by Zero Exception!)
+                {At<StackTracePresentationTests>("ThrowNestedException()")}
+                
+                ------- Inner Exception: System.DivideByZeroException -------
+                Divide by Zero Exception!
+                {At<StackTracePresentationTests>("ThrowNestedException()")}
+                
+                Test '{FullName<NestedFailureTestClass>()}.Synchronous' failed:
+                
+                Primary Exception!
+                
+                {FullName<PrimaryException>()}
+                {At<StackTracePresentationTests>("ThrowNestedException()")}
+                {At<NestedFailureTestClass>("Synchronous()")}
+                
+                ------- Inner Exception: System.AggregateException -------
+                One or more errors occurred. (Divide by Zero Exception!)
+                {At<StackTracePresentationTests>("ThrowNestedException()")}
+                
+                ------- Inner Exception: System.DivideByZeroException -------
+                Divide by Zero Exception!
+                {At<StackTracePresentationTests>("ThrowNestedException()")}
+                
+                2 failed, took 1.23 seconds
+                
+                
+                """);
     }
 
-    static async Task<IEnumerable<string>> Run<TSampleTestClass, TExecution>() where TExecution : IExecution, new()
+    static async Task<string> Run<TSampleTestClass, TExecution>() where TExecution : IExecution, new()
     {
         var discovery = new SelfTestDiscovery();
         var execution = new TExecution();
@@ -171,8 +178,7 @@ public class StackTracePresentationTests
 
         return console.ToString()
             .NormalizeStackTraces()
-            .CleanDuration()
-            .Lines();
+            .CleanDuration();
     }
 
     class ImplicitExceptionHandling : IExecution

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -169,8 +169,8 @@ public class StackTracePresentationTests
         
         await Utility.Run(report, discovery, execution, console, typeof(TSampleTestClass));
 
-        return console.ToString().Lines()
-            .NormalizeStackTraceLines()
+        return console.ToString()
+            .NormalizeStackTraces()
             .CleanDuration();
     }
 

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -171,8 +171,8 @@ public class StackTracePresentationTests
 
         return console.ToString()
             .NormalizeStackTraces()
-            .Lines()
-            .CleanDuration();
+            .CleanDuration()
+            .Lines();
     }
 
     class ImplicitExceptionHandling : IExecution

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -171,6 +171,7 @@ public class StackTracePresentationTests
 
         return console.ToString()
             .NormalizeStackTraces()
+            .Lines()
             .CleanDuration();
     }
 

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -37,7 +37,7 @@ public class StackTracePresentationTests
                 "Fixie.Tests.FailureException",
                 At<ConstructionFailureTestClass>(".ctor()"),
                 "   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)",
-                "--- End of stack trace from previous location where exception was thrown ---",
+                "--- End of stack trace from previous location ---",
                 At(typeof(TestClass), "Construct(Object[] parameters)",
                     Path.Join("...", "src", "Fixie", "TestClass.cs")),
                 At<ExplicitExceptionHandling>("Run(TestSuite testSuite)"),
@@ -104,7 +104,7 @@ public class StackTracePresentationTests
                     ? optimizedInvoker
                     : initialInvoker,
                 "   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)",
-                "--- End of stack trace from previous location where exception was thrown ---",
+                "--- End of stack trace from previous location ---",
                 At(typeof(MethodInfoExtensions),
                     "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)",
                     Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs")),

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -62,8 +62,7 @@ public class VsExecutionRecorderTests : MessagingTests
         fail.Outcome.ShouldBe(TestOutcome.Failed);
         fail.ErrorMessage.ShouldBe("'Fail' failed!");
         fail.ErrorStackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
         fail.DisplayName.ShouldBe(TestClass+".Fail");
         fail.Messages.ShouldBe([]);
@@ -76,8 +75,7 @@ public class VsExecutionRecorderTests : MessagingTests
         failByAssertion.Outcome.ShouldBe(TestOutcome.Failed);
         failByAssertion.ErrorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.ErrorStackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
         failByAssertion.DisplayName.ShouldBe(TestClass+".FailByAssertion");
         failByAssertion.Messages.ShouldBe([]);
@@ -132,8 +130,7 @@ public class VsExecutionRecorderTests : MessagingTests
         shouldBeStringFail.Outcome.ShouldBe(TestOutcome.Failed);
         shouldBeStringFail.ErrorMessage.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.ErrorStackTrace
-            .Lines()
-            .NormalizeStackTraceLines()
+            .NormalizeStackTraces()
             .ShouldBe([
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")

--- a/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsExecutionRecorderTests.cs
@@ -62,8 +62,7 @@ public class VsExecutionRecorderTests : MessagingTests
         fail.Outcome.ShouldBe(TestOutcome.Failed);
         fail.ErrorMessage.ShouldBe("'Fail' failed!");
         fail.ErrorStackTrace
-            .NormalizeStackTraces()
-            .ShouldBe(["Fixie.Tests.FailureException", At("Fail()")]);
+            .ShouldBeStackTrace(["Fixie.Tests.FailureException", At("Fail()")]);
         fail.DisplayName.ShouldBe(TestClass+".Fail");
         fail.Messages.ShouldBe([]);
         fail.Duration.ShouldBe(TimeSpan.FromMilliseconds(102));
@@ -75,8 +74,7 @@ public class VsExecutionRecorderTests : MessagingTests
         failByAssertion.Outcome.ShouldBe(TestOutcome.Failed);
         failByAssertion.ErrorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.ErrorStackTrace
-            .NormalizeStackTraces()
-            .ShouldBe(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
+            .ShouldBeStackTrace(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
         failByAssertion.DisplayName.ShouldBe(TestClass+".FailByAssertion");
         failByAssertion.Messages.ShouldBe([]);
         failByAssertion.Duration.ShouldBe(TimeSpan.FromMilliseconds(103));
@@ -130,8 +128,7 @@ public class VsExecutionRecorderTests : MessagingTests
         shouldBeStringFail.Outcome.ShouldBe(TestOutcome.Failed);
         shouldBeStringFail.ErrorMessage.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.ErrorStackTrace
-            .NormalizeStackTraces()
-            .ShouldBe([
+            .ShouldBeStackTrace([
                 "Fixie.Tests.Assertions.AssertException",
                 At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")
             ]);

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace Fixie.Tests;
@@ -49,6 +50,13 @@ static class TestExtensions
                 @"\) in .+([\\/])src([\\/])Fixie(.+)\.cs:line \d+",
                 ") in ...$1src$2Fixie$3.cs:line #");
         });
+    }
+
+    public static void ShouldBeStackTrace(this string? actual, string[] expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
+    {
+        actual
+            .NormalizeStackTraces()
+            .ShouldBe(expected, expression);
     }
 
     public static IEnumerable<string> CleanDuration(this IEnumerable<string> lines)

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -37,25 +37,23 @@ static class TestExtensions
         return lines;
     }
 
-    public static IEnumerable<string> NormalizeStackTraces(this string? multiline)
+    public static string NormalizeStackTraces(this string? multiline)
     {
         //Avoid brittle assertion introduced by stack trace absolute paths and line numbers.
 
         if (multiline == null)
             throw new Exception("Expected a non-null string.");
 
-        return multiline.Lines().Select(line =>
-        {
-            return Regex.Replace(line,
-                @"\) in .+([\\/])src([\\/])Fixie(.+)\.cs:line \d+",
-                ") in ...$1src$2Fixie$3.cs:line #");
-        });
+        return Regex.Replace(multiline,
+            @"\) in .+([\\/])src([\\/])Fixie(.+)\.cs:line \d+",
+            ") in ...$1src$2Fixie$3.cs:line #");
     }
 
     public static void ShouldBeStackTrace(this string? actual, string[] expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         actual
             .NormalizeStackTraces()
+            .Lines()
             .ShouldBe(expected, expression);
     }
 

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -53,8 +53,7 @@ static class TestExtensions
     {
         actual
             .NormalizeStackTraces()
-            .Lines()
-            .ShouldBe(expected, expression);
+            .ShouldBe(string.Join(Environment.NewLine, expected), expression);
     }
 
     public static IEnumerable<string> CleanDuration(this IEnumerable<string> lines)

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -24,19 +24,6 @@ static class TestExtensions
         return type.GetMethods(InstanceMethods);
     }
 
-    public static IEnumerable<string> Lines(this string? multiline)
-    {
-        if (multiline == null)
-            throw new Exception("Expected a non-null string.");
-
-        var lines = multiline.Split(new[] { Environment.NewLine }, StringSplitOptions.None).ToList();
-
-        while (lines.Count > 0 && lines[lines.Count-1] == "")
-            lines.RemoveAt(lines.Count-1);
-
-        return lines;
-    }
-
     public static string NormalizeStackTraces(this string? multiline)
     {
         //Avoid brittle assertion introduced by stack trace absolute paths and line numbers.

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -43,9 +43,6 @@ static class TestExtensions
 
         return lines.Select(line =>
         {
-            if (line == "--- End of stack trace from previous location ---")
-                line = "--- End of stack trace from previous location where exception was thrown ---";
-
             return Regex.Replace(line,
                 @"\) in .+([\\/])src([\\/])Fixie(.+)\.cs:line \d+",
                 ") in ...$1src$2Fixie$3.cs:line #");

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -36,12 +36,14 @@ static class TestExtensions
         return lines;
     }
 
-    public static IEnumerable<string> NormalizeStackTraceLines(this IEnumerable<string> lines)
+    public static IEnumerable<string> NormalizeStackTraces(this string? multiline)
     {
-        //Avoid brittle assertion introduced by stack trace absolute paths, line numbers,
-        //and platform dependent variations in the rethrow marker.
+        //Avoid brittle assertion introduced by stack trace absolute paths and line numbers.
 
-        return lines.Select(line =>
+        if (multiline == null)
+            throw new Exception("Expected a non-null string.");
+
+        return multiline.Lines().Select(line =>
         {
             return Regex.Replace(line,
                 @"\) in .+([\\/])src([\\/])Fixie(.+)\.cs:line \d+",

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -56,12 +56,12 @@ static class TestExtensions
             .ShouldBe(string.Join(Environment.NewLine, expected), expression);
     }
 
-    public static IEnumerable<string> CleanDuration(this IEnumerable<string> lines)
+    public static string CleanDuration(this string multiline)
     {
         //Avoid brittle assertion introduced by test duration.
 
         var decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
-        return lines.Select(line => Regex.Replace(line, @"took [\d" + Regex.Escape(decimalSeparator) + @"]+ seconds", @"took 1.23 seconds"));
+        return Regex.Replace(multiline, @"took [\d" + Regex.Escape(decimalSeparator) + "]+ seconds", "took 1.23 seconds");
     }
 }


### PR DESCRIPTION
This phases out the obfuscation of what are really multiline string assertions, using the 'raw string literals' syntax.