### PR TITLE
String assertion messaging

### DIFF
--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -20,6 +20,26 @@ public class AssertException : Exception
                                     HasCompactRepresentation(actual);
     }
 
+    public static AssertException Create(string? expression, bool expected, bool actual)
+    {
+        return new AssertException(expression, Serialize(expected), Serialize(actual));
+    }
+
+    public static AssertException Create(string? expression, char expected, char actual)
+    {
+        return new AssertException(expression, Serialize(expected), Serialize(actual));
+    }
+    
+    public static AssertException Create(string? expression, Type expected, Type? actual)
+    {
+        return new AssertException(expression, Serialize(expected), actual == null ? null : Serialize(actual));
+    }
+
+    public static AssertException Create(string? expression, string? expected, string? actual)
+    {
+        return new AssertException(expression, expected == null ? null : Serialize(expected), actual == null ? null : Serialize(actual));
+    }
+
     public override string Message
     {
         get
@@ -68,4 +88,55 @@ public class AssertException : Exception
     {
         return input.Split(new[] {NewLine}, StringSplitOptions.None);
     }
+
+    static string Serialize(bool x) => x ? "true" : "false";
+
+    static string Serialize(char x) =>
+        $"'{Escape(x)}'";
+
+    static string Serialize(string x) =>
+        $"\"{string.Join("", x.Select(Escape))}\"";
+    
+    static string Escape(char x) =>
+        x switch
+        {
+            '\0' => @"\0",
+            '\a' => @"\a",
+            '\b' => @"\b",
+            '\t' => @"\t",
+            '\n' => @"\n",
+            '\v' => @"\v",
+            '\f' => @"\f",
+            '\r' => @"\r",
+            //'\e' => @"\e", TODO: Applicable in C# 13
+            ' ' => " ",
+            '"' => @"\""",
+            '\'' => @"\'",
+            '\\' => @"\\",
+            _ when (char.IsControl(x) || char.IsWhiteSpace(x)) => $"\\u{(int)x:X4}",
+            _ => x.ToString()
+        };
+
+    static string Serialize(Type x) =>
+        $"typeof({x switch
+        {
+            _ when x == typeof(bool) => "bool",
+            _ when x == typeof(sbyte) => "sbyte",
+            _ when x == typeof(byte) => "byte",
+            _ when x == typeof(short) => "short",
+            _ when x == typeof(ushort) => "ushort",
+            _ when x == typeof(int) => "int",
+            _ when x == typeof(uint) => "uint",
+            _ when x == typeof(long) => "long",
+            _ when x == typeof(ulong) => "ulong",
+            _ when x == typeof(nint) => "nint",
+            _ when x == typeof(nuint) => "nuint",
+            _ when x == typeof(decimal) => "decimal",
+            _ when x == typeof(double) => "double",
+            _ when x == typeof(float) => "float",
+            _ when x == typeof(char) => "char",
+            _ when x == typeof(string) => "string",
+            _ when x == typeof(object) => "object",
+            _ => x.ToString()
+        }})";
 }

--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -11,7 +11,7 @@ public class AssertException : Exception
     public string? Actual { get; }
     public bool HasCompactRepresentations { get; }
 
-    public AssertException(string? expression, string? expected, string? actual)
+    AssertException(string? expression, string? expected, string? actual)
     {
         Expression = expression;
         Expected = expected;
@@ -20,24 +20,46 @@ public class AssertException : Exception
                                     HasCompactRepresentation(actual);
     }
 
-    public static AssertException Create(string? expression, bool expected, bool actual)
+    public AssertException(string? expression, bool expected, bool actual)
     {
-        return new AssertException(expression, Serialize(expected), Serialize(actual));
+        Expression = expression;
+        Expected = Serialize(expected);
+        Actual = Serialize(actual);
+        HasCompactRepresentations = true;
     }
 
-    public static AssertException Create(string? expression, char expected, char actual)
+    public AssertException(string? expression, char expected, char actual)
     {
-        return new AssertException(expression, Serialize(expected), Serialize(actual));
-    }
-    
-    public static AssertException Create(string? expression, Type expected, Type? actual)
-    {
-        return new AssertException(expression, Serialize(expected), actual == null ? null : Serialize(actual));
+        Expression = expression;
+        Expected = Serialize(expected);
+        Actual = Serialize(actual);
+        HasCompactRepresentations = true;
     }
 
-    public static AssertException Create(string? expression, string? expected, string? actual)
+    public AssertException(string? expression, object? expected, object? actual)
+    {
+        Expression = expression;
+        Expected = expected?.ToString();
+        Actual = actual?.ToString();
+        HasCompactRepresentations = true;
+    }
+
+    public AssertException(string? expression, Type expected, Type? actual)
+    {
+        Expression = expression;
+        Expected = Serialize(expected);
+        Actual = actual == null ? null: Serialize(actual);
+        HasCompactRepresentations = true;
+    }
+
+    public static AssertException ForLiterals(string? expression, string? expected, string? actual)
     {
         return new AssertException(expression, expected == null ? null : Serialize(expected), actual == null ? null : Serialize(actual));
+    }
+
+    public static AssertException ForDescriptions(string? expression, string? expectationDescription, string? actualDescription)
+    {
+        return new AssertException(expression, expectationDescription, actualDescription);
     }
 
     public override string Message

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -22,21 +22,19 @@ public static class AssertionExtensions
     public static void ShouldBe(this string? actual, string? expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw new AssertException(expression,
-                expected == null ? "null" : Serialize(expected),
-                actual == null ? "null" : Serialize(actual));
+            throw AssertException.Create(expression, expected, actual);
     }
 
     public static void ShouldBe(this bool actual, bool expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw new AssertException(expression, Serialize(expected), Serialize(actual));
+            throw AssertException.Create(expression, expected, actual);
     }
     
     public static void ShouldBe(this char actual, char expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw new AssertException(expression, Serialize(expected), Serialize(actual));
+            throw AssertException.Create(expression, expected, actual);
     }
 
     public static void ShouldBe<T>(this IEquatable<T> actual, IEquatable<T> expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
@@ -48,7 +46,7 @@ public static class AssertionExtensions
     public static void ShouldBe(this Type actual, Type expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw new AssertException(expression, Serialize(expected), Serialize(actual));
+            throw AssertException.Create(expression, expected, actual);
     }
 
     public static void ShouldBe(this object? actual, object? expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
@@ -67,7 +65,7 @@ public static class AssertionExtensions
         if (actual is T typed)
             return typed;
 
-        throw new AssertException(expression, Serialize(typeof(T)), actual == null ? "null" : Serialize(actual.GetType()));
+        throw AssertException.Create(expression, typeof(T), actual?.GetType());
     }
 
     public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? expression = null) where TException : Exception
@@ -170,55 +168,4 @@ public static class AssertionExtensions
                 writer.WriteStringValue(value.ToString());
         }
     }
-
-    static string Serialize(char x) =>
-        $"'{Escape(x)}'";
-    
-    static string Escape(char x) =>
-        x switch
-        {
-            '\0' => @"\0",
-            '\a' => @"\a",
-            '\b' => @"\b",
-            '\t' => @"\t",
-            '\n' => @"\n",
-            '\v' => @"\v",
-            '\f' => @"\f",
-            '\r' => @"\r",
-            //'\e' => @"\e", TODO: Applicable in C# 13
-            ' ' => " ",
-            '"' => @"\""",
-            '\'' => @"\'",
-            '\\' => @"\\",
-            _ when (char.IsControl(x) || char.IsWhiteSpace(x)) => $"\\u{(int)x:X4}",
-            _ => x.ToString()
-        };
-
-    static string Serialize(string x) =>
-        $"\"{string.Join("", x.Select(Escape))}\"";
-
-    static string Serialize(bool x) => x ? "true" : "false";
-
-    static string Serialize(Type x) =>
-        $"typeof({x switch
-        {
-            _ when x == typeof(bool) => "bool",
-            _ when x == typeof(sbyte) => "sbyte",
-            _ when x == typeof(byte) => "byte",
-            _ when x == typeof(short) => "short",
-            _ when x == typeof(ushort) => "ushort",
-            _ when x == typeof(int) => "int",
-            _ when x == typeof(uint) => "uint",
-            _ when x == typeof(long) => "long",
-            _ when x == typeof(ulong) => "ulong",
-            _ when x == typeof(nint) => "nint",
-            _ when x == typeof(nuint) => "nuint",
-            _ when x == typeof(decimal) => "decimal",
-            _ when x == typeof(double) => "double",
-            _ when x == typeof(float) => "float",
-            _ when x == typeof(char) => "char",
-            _ when x == typeof(string) => "string",
-            _ when x == typeof(object) => "object",
-            _ => x.ToString()
-        }})";
 }

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -22,7 +22,9 @@ public static class AssertionExtensions
     public static void ShouldBe(this string? actual, string? expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw new AssertException(expression, expected, actual);
+            throw new AssertException(expression,
+                expected == null ? "null" : Serialize(expected),
+                actual == null ? "null" : Serialize(actual));
     }
 
     public static void ShouldBe(this bool actual, bool expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -22,37 +22,37 @@ public static class AssertionExtensions
     public static void ShouldBe(this string? actual, string? expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw AssertException.Create(expression, expected, actual);
+            throw AssertException.ForLiterals(expression, expected, actual);
     }
 
     public static void ShouldBe(this bool actual, bool expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw AssertException.Create(expression, expected, actual);
+            throw new AssertException(expression, expected, actual);
     }
     
     public static void ShouldBe(this char actual, char expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw AssertException.Create(expression, expected, actual);
+            throw new AssertException(expression, expected, actual);
     }
 
     public static void ShouldBe<T>(this IEquatable<T> actual, IEquatable<T> expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (!actual.Equals(expected))
-            throw new AssertException(expression, expected.ToString(), actual.ToString());
+            throw new AssertException(expression, expected, actual);
     }
 
     public static void ShouldBe(this Type actual, Type expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual != expected)
-            throw AssertException.Create(expression, expected, actual);
+            throw new AssertException(expression, expected, actual);
     }
 
     public static void ShouldBe(this object? actual, object? expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (!Equals(actual, expected))
-            throw new AssertException(expression, expected?.ToString(), actual?.ToString());
+            throw new AssertException(expression, expected, actual);
     }
 
     public static void ShouldBe<T>(this IEnumerable<T> actual, T[] expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
@@ -65,7 +65,7 @@ public static class AssertionExtensions
         if (actual is T typed)
             return typed;
 
-        throw AssertException.Create(expression, typeof(T), actual?.GetType());
+        throw new AssertException(expression, typeof(T), actual?.GetType());
     }
 
     public static TException ShouldThrow<TException>(this Action shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? expression = null) where TException : Exception
@@ -82,7 +82,7 @@ public static class AssertionExtensions
             return (TException)actual;
         }
 
-        throw new AssertException(expression, typeof(TException).FullName, "No exception was thrown.");
+        throw AssertException.ForDescriptions(expression, typeof(TException).FullName, "No exception was thrown.");
     }
 
     public static async Task<TException> ShouldThrowAsync<TException>(this Func<Task> shouldThrowAsync, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrowAsync))] string? expression = null) where TException : Exception
@@ -99,19 +99,19 @@ public static class AssertionExtensions
             return (TException)actual;
         }
 
-        throw new AssertException(expression, typeof(TException).FullName, "No exception was thrown.");
+        throw AssertException.ForDescriptions(expression, typeof(TException).FullName, "No exception was thrown.");
     }
 
     public static void ShouldBeGreaterThan<T>(this T actual, T minimum, [CallerArgumentExpression(nameof(actual))] string? expression = null) where T: IComparable<T>
     {
         if (actual.CompareTo(minimum) <= 0)
-            throw new AssertException(expression, $"> {minimum}", actual.ToString());
+            throw AssertException.ForDescriptions(expression, $"> {minimum}", actual.ToString());
     }
 
     public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T minimum, [CallerArgumentExpression(nameof(actual))] string? expression = null) where T: IComparable<T>
     {
         if (actual.CompareTo(minimum) < 0)
-            throw new AssertException(expression, $">= {minimum}", actual.ToString());
+            throw AssertException.ForDescriptions(expression, $">= {minimum}", actual.ToString());
     }
 
     public static void ShouldMatch<T>(this T actual, T expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
@@ -120,7 +120,7 @@ public static class AssertionExtensions
         var expectedJson = Json(expected);
             
         if (actualJson != expectedJson)
-            throw new AssertException(expression, expectedJson, actualJson);
+            throw AssertException.ForDescriptions(expression, expectedJson, actualJson);
     }
 
     public static void ShouldSatisfy<T>(this IEnumerable<T> actual, Action<T>[] itemExpectations, [CallerArgumentExpression(nameof(actual))] string? expression = null)
@@ -128,7 +128,7 @@ public static class AssertionExtensions
         var actualItems = actual.ToArray();
 
         if (actualItems.Length != itemExpectations.Length)
-            throw new AssertException(
+            throw AssertException.ForDescriptions(
                 expression,
                 $"{itemExpectations.Length} items",
                 $"{actualItems.Length} items");
@@ -147,7 +147,7 @@ public static class AssertionExtensions
     public static void ShouldNotBeNull([NotNull] this object? actual, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual == null)
-            throw new AssertException(expression, "not null", "null");
+            throw AssertException.ForDescriptions(expression, "not null", "null");
     }
 
     static string Json<T>(T @object)

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -170,24 +170,30 @@ public static class AssertionExtensions
     }
 
     static string Serialize(char x) =>
+        $"'{Escape(x)}'";
+    
+    static string Escape(char x) =>
         x switch
         {
-            '\0' => @"'\0'",
-            '\a' => @"'\a'",
-            '\b' => @"'\b'",
-            '\t' => @"'\t'",
-            '\n' => @"'\n'",
-            '\v' => @"'\v'",
-            '\f' => @"'\f'",
-            '\r' => @"'\r'",
-            //'\e' => @"'\e'", TODO: Applicable in C# 13
-            ' ' => "' '",
-            '"' => @"'\""'",
-            '\'' => @"'\''",
-            '\\' => @"'\\'",
-            _ when (char.IsControl(x) || char.IsWhiteSpace(x)) => $"'\\u{(int)x:X4}'",
-            _ => $"'{x}'"
+            '\0' => @"\0",
+            '\a' => @"\a",
+            '\b' => @"\b",
+            '\t' => @"\t",
+            '\n' => @"\n",
+            '\v' => @"\v",
+            '\f' => @"\f",
+            '\r' => @"\r",
+            //'\e' => @"\e", TODO: Applicable in C# 13
+            ' ' => " ",
+            '"' => @"\""",
+            '\'' => @"\'",
+            '\\' => @"\\",
+            _ when (char.IsControl(x) || char.IsWhiteSpace(x)) => $"\\u{(int)x:X4}",
+            _ => x.ToString()
         };
+
+    static string Serialize(string x) =>
+        $"\"{string.Join("", x.Select(Escape))}\"";
 
     static string Serialize(bool x) => x ? "true" : "false";
 

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -184,18 +184,18 @@ public class AssertionTests
             x should be "  " but was "abc"
             """);
 
-        "\u0000\0 \u0007\a \u0008\b \u0009\t \u000A\n \u000B\v".ShouldBe("\0\0 \a\a \b\b \t\t \n\n \v\v");
-        Contradiction("abc", x => x.ShouldBe("\0\a\b\t\n\v"),
+        "\u0000\0 \u0007\a \u0008\b \u0009\t \u000A\n \u000D\r".ShouldBe("\0\0 \a\a \b\b \t\t \n\n \r\r");
+        Contradiction("abc", x => x.ShouldBe("\0\a\b\t\n\r"),
             """
-            x should be "\0\a\b\t\n\v" but was "abc"
+            x should be "\0\a\b\t\n\r" but was "abc"
             """);
 
         // TODO: In C# 13, include \u001B\e becoming \e\e
-        "\u000C\f \u000D\r \u0022\" \u0027\' \u005C\\".ShouldBe("\f\f \r\r \"\" \'\' \\\\");
+        "\u000C\f \u000B\v \u0022\" \u0027\' \u005C\\".ShouldBe("\f\f \v\v \"\" \'\' \\\\");
         // TODO: In C# 13, include \e being preserved.
-        Contradiction("abc", x => x.ShouldBe("\f\r\"\'\\"),
+        Contradiction("abc", x => x.ShouldBe("\f\v\"\'\\"),
             """
-            x should be "\f\r\"\'\\" but was "abc"
+            x should be "\f\v\"\'\\" but was "abc"
             """);
 
         foreach (var c in UnicodeEscapedCharacters())

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -1,10 +1,12 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Text;
+using static System.Environment;
 
 namespace Fixie.Tests.Assertions;
 
 public class AssertionTests
 {
-    static readonly string Line = Environment.NewLine + Environment.NewLine;
+    static readonly string Line = NewLine + NewLine;
 
     public void ShouldAssertBools()
     {
@@ -208,6 +210,75 @@ public class AssertionTests
         }
     }
 
+    public void ShouldAssertMultilineStrings()
+    {
+        var original = new StringBuilder()
+            .AppendLine("Line 1")
+            .AppendLine("Line 2")
+            .AppendLine("Line 3")
+            .Append("Line 4")
+            .ToString();
+
+        var altered = new StringBuilder()
+            .AppendLine("Line 1")
+            .AppendLine("Line 2 Altered")
+            .AppendLine("Line 3")
+            .Append("Line 4")
+            .ToString();
+
+        var mixedLineEndings = "\r \n \r\n \n \r";
+
+        original.ShouldBe(original);
+        altered.ShouldBe(altered);
+
+        Contradiction(original, x => x.ShouldBe(altered),
+            new StringBuilder()
+                .AppendLine("x should be")
+                .AppendLine("\t\"\"\"")
+                .AppendLine("\tLine 1")
+                .AppendLine("\tLine 2 Altered")
+                .AppendLine("\tLine 3")
+                .AppendLine("\tLine 4")
+                .AppendLine("\t\"\"\"")
+                .AppendLine()
+                .AppendLine("but was")
+                .AppendLine("\t\"\"\"")
+                .AppendLine("\tLine 1")
+                .AppendLine("\tLine 2")
+                .AppendLine("\tLine 3")
+                .AppendLine("\tLine 4")
+                .Append("\t\"\"\"")
+                .ToString());
+
+        Contradiction(original, x => x.ShouldBe(mixedLineEndings),
+            new StringBuilder()
+                .AppendLine("x should be")
+                .AppendLine("\t\"\\r \\n \\r\\n \\n \\r\"")
+                .AppendLine()
+                .AppendLine("but was")
+                .AppendLine("\t\"\"\"")
+                .AppendLine("\tLine 1")
+                .AppendLine("\tLine 2")
+                .AppendLine("\tLine 3")
+                .AppendLine("\tLine 4")
+                .Append("\t\"\"\"")
+                .ToString());
+
+        Contradiction(mixedLineEndings, x => x.ShouldBe(original),
+            new StringBuilder()
+                .AppendLine("x should be")
+                .AppendLine("\t\"\"\"")
+                .AppendLine("\tLine 1")
+                .AppendLine("\tLine 2")
+                .AppendLine("\tLine 3")
+                .AppendLine("\tLine 4")
+                .AppendLine("\t\"\"\"")
+                .AppendLine()
+                .AppendLine("but was")
+                .Append("\t\"\\r \\n \\r\\n \\n \\r\"")
+                .ToString());
+    }
+
     public void ShouldAssertTypes()
     {
         typeof(int).ShouldBe(typeof(int));
@@ -292,8 +363,8 @@ public class AssertionTests
                 if (exception.Message != expectedMessage)
                     throw new Exception(
                         $"An example assertion failed as expected, but with the wrong message.{Line}" +
-                        $"Expected Message:{Line}\t{expectedMessage}{Line}" +
-                        $"Actual Message:{Line}\t{exception.Message}");
+                        $"Expected Message:{Line}{Indent(expectedMessage)}{Line}" +
+                        $"Actual Message:{Line}{Indent(exception.Message)}");
                 return;
             }
 
@@ -312,6 +383,9 @@ public class AssertionTests
             $"The actual value in question was:{Line}" +
             $"\t{actual}");
     }
+
+    static string Indent(string multiline) =>
+        string.Join(NewLine, multiline.Split(NewLine).Select(x => $"\t{x}"));
 
     static IEnumerable<char> UnicodeEscapedCharacters()
     {

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -158,6 +158,56 @@ public class AssertionTests
         }
     }
 
+    public void ShouldAssertStrings()
+    {
+        "a☺".ShouldBe("a☺");
+        Contradiction("a☺", x => x.ShouldBe("z☺"),
+            """
+            x should be "z☺" but was "a☺"
+            """);
+
+        ((string?)null).ShouldBe(null);
+        Contradiction("abc", x => x.ShouldBe(null),
+            """
+            x should be null but was "abc"
+            """);
+        Contradiction(((string?)null), x => x.ShouldBe("abc"),
+            """
+            x should be "abc" but was null
+            """);
+        
+        "\u0020 ".ShouldBe("  ");
+        Contradiction("abc", x => x.ShouldBe("\u0020 "),
+            """
+            x should be "  " but was "abc"
+            """);
+
+        "\u0000\0 \u0007\a \u0008\b \u0009\t \u000A\n \u000B\v".ShouldBe("\0\0 \a\a \b\b \t\t \n\n \v\v");
+        Contradiction("abc", x => x.ShouldBe("\0\a\b\t\n\v"),
+            """
+            x should be "\0\a\b\t\n\v" but was "abc"
+            """);
+
+        // TODO: In C# 13, include \u001B\e becoming \e\e
+        "\u000C\f \u000D\r \u0022\" \u0027\' \u005C\\".ShouldBe("\f\f \r\r \"\" \'\' \\\\");
+        // TODO: In C# 13, include \e being preserved.
+        Contradiction("abc", x => x.ShouldBe("\f\r\"\'\\"),
+            """
+            x should be "\f\r\"\'\\" but was "abc"
+            """);
+
+        foreach (var c in UnicodeEscapedCharacters())
+        {
+            var s = c.ToString();
+
+            s.ShouldBe(s);
+            Contradiction("a", x => x.ShouldBe(s),
+                $"""
+                 x should be "\u{(int)c:X4}" but was "a"
+                 """);
+        }
+    }
+
     public void ShouldAssertTypes()
     {
         typeof(int).ShouldBe(typeof(int));

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -257,6 +257,28 @@ public class AssertionTests
         Contradiction((AssertionTests?)null, x => x.ShouldBe<AssertionTests>(), "x should be typeof(Fixie.Tests.Assertions.AssertionTests) but was null");
     }
 
+    public void ShouldAssertObjects()
+    {
+        var objectA = new SampleA();
+        var objectB = new SampleB();
+
+        ((object?)null).ShouldBe(((object?)null));
+        objectA.ShouldBe(objectA);
+        objectB.ShouldBe(objectB);
+
+        Contradiction((object?)null, x => x.ShouldBe(objectA),
+            "x should be Fixie.Tests.Assertions.AssertionTests+SampleA but was null");
+        Contradiction(objectB, x => x.ShouldBe((object?)null),
+            "x should be null but was Fixie.Tests.Assertions.AssertionTests+SampleB");
+        Contradiction(objectB, x => x.ShouldBe(objectA),
+            "x should be Fixie.Tests.Assertions.AssertionTests+SampleA but was Fixie.Tests.Assertions.AssertionTests+SampleB");
+        Contradiction(objectA, x => x.ShouldBe(objectB),
+            "x should be Fixie.Tests.Assertions.AssertionTests+SampleB but was Fixie.Tests.Assertions.AssertionTests+SampleA");
+    }
+
+    class SampleA;
+    class SampleB;
+
     static void Contradiction<T>(T actual, Action<T> shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string? assertion = null)
     {
         try

--- a/src/Fixie.Tests/DiffToolReport.cs
+++ b/src/Fixie.Tests/DiffToolReport.cs
@@ -20,7 +20,7 @@ class DiffToolReport : IHandler<TestFailed>, IHandler<ExecutionCompleted>
     public async Task Handle(ExecutionCompleted message)
     {
         if (singleFailure is AssertException exception)
-            if (!exception.HasCompactRepresentations)
+            if (exception.HasMultilineRepresentation)
                 await LaunchDiffTool(exception);
     }
 


### PR DESCRIPTION
When asserting on string equality, failure messaging uses reliable C# string literal formatting for the values in question. For single line strings, "normal literals" are used. For multiline strings,
"""
raw literals
"""
are used. When the string in question includes a mix of line endings, "normal literals" are used so that individual line ending characters can still be easily compared by the developer.

Examples:

```
example should be "z☺" but was "a☺"
```

```
example should be
	"""
	Line 1
	Line 2
	Line 3
	Line 4
	"""

but was
	"""
	Line 1
	Line 2 OOPS
	Line 3
	Line 4
	"""
```

```
example should be "\r \n \r\n \r \r" but was "\r \n \r\n \n \r"
```