### PR TITLE
Update actions/setup-dotnet to the latest version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: 0
         filter: tree:0
     - name: .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         fetch-depth: 0
         filter: tree:0
     - name: .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           8.0


### PR DESCRIPTION
We've been getting the following warning on our use of slightly out of date github actions dependencies:

> Annotations
> 1 warning
> ci
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/setup-dotnet@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
