### PR TITLE
Assertion failure readability

### DIFF
--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -102,11 +102,36 @@ public class AssertException : Exception
             return "null";
 
         if (IsMultiline(x))
-            return $"\"\"\"{NewLine}{x}{NewLine}\"\"\"";
+        {
+            var terminal = RawStringTerminal(x);
+
+            return $"{terminal}{NewLine}{x}{NewLine}{terminal}";
+        }
         
         return $"\"{string.Join("", x.Select(Escape))}\"";
     }
-    
+
+    static string RawStringTerminal(string x)
+    {
+        var longestDoubleQuoteSequence = 0;
+        var currentDoubleQuoteSequence = 0;
+
+        foreach (var c in x)
+        {
+            if (c != '\"')
+            {
+                currentDoubleQuoteSequence = 0;
+                continue;
+            }
+
+            currentDoubleQuoteSequence++;
+            if (currentDoubleQuoteSequence > longestDoubleQuoteSequence)
+                longestDoubleQuoteSequence = currentDoubleQuoteSequence;
+        }
+
+        return new string('\"', longestDoubleQuoteSequence < 3 ? 3 : longestDoubleQuoteSequence + 1);
+    }
+
     static string Escape(char x) =>
         x switch
         {

--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -64,7 +64,7 @@ public class AssertException : Exception
     }
 
     static string Indent(string multiline) =>
-        string.Join(NewLine, multiline.Split(NewLine).Select(x => $"\t{x}"));
+        string.Join(NewLine, multiline.Split(NewLine).Select(x => $"    {x}"));
 
     public override string? StackTrace => FilterStackTrace(base.StackTrace);
 
@@ -162,7 +162,7 @@ public class AssertException : Exception
 
     static string SerializeList<T>(T[] items)
     {
-        var formattedItems = string.Join("," + NewLine, items.Select(arg => "  " + SerializeByType(arg)));
+        var formattedItems = string.Join("," + NewLine, items.Select(arg => "    " + SerializeByType(arg)));
 
         return $"[{NewLine}{formattedItems}{NewLine}]";
     }

--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -102,15 +102,7 @@ public class AssertException : Exception
             return "null";
 
         if (IsMultiline(x))
-        {
-            var unescapedLines = x.Split(NewLine);
-
-            var indentedEscapedLines = unescapedLines.Select(line => string.Join("", line.Select(Escape)));
-        
-            var rejoinedEscapedLines = string.Join(NewLine, indentedEscapedLines);
-
-            return $"\"\"\"{NewLine}{rejoinedEscapedLines}{NewLine}\"\"\"";
-        }
+            return $"\"\"\"{NewLine}{x}{NewLine}\"\"\"";
         
         return $"\"{string.Join("", x.Select(Escape))}\"";
     }

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -278,6 +278,31 @@ public class AssertionTests
              but was
                  "\r \n \r\n \n \r"
              """");
+
+        var apparentEscapeSequences =
+            """
+            \u0020
+            \u0000\0 \u0007\a \u0008\b \u0009\t \u000A\n \u000D\r
+            \u000C\f \u000B\v \u001B\e \u0022\" \u0027\' \u005C\\
+            """;
+
+        Contradiction(apparentEscapeSequences, x => x.ShouldBe(original),
+            """"
+            x should be
+                """
+                Line 1
+                Line 2
+                Line 3
+                Line 4
+                """
+
+            but was
+                """
+                \u0020
+                \u0000\0 \u0007\a \u0008\b \u0009\t \u000A\n \u000D\r
+                \u000C\f \u000B\v \u001B\e \u0022\" \u0027\' \u005C\\
+                """
+            """");
     }
 
     public void ShouldAssertTypes()

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -303,6 +303,85 @@ public class AssertionTests
                 \u000C\f \u000B\v \u001B\e \u0022\" \u0027\' \u005C\\
                 """
             """");
+
+        var containsApparentOneQuotedRawLiteral =
+            """
+            "
+            Value contains an apparent one-quotes bounded raw string literal.
+            "
+            """;
+
+        var containsApparentTwoQuotedRawLiteral =
+            """
+            ""
+            Value contains an apparent two-quotes bounded raw string literal.
+            ""
+            """;
+
+        var containsApparentThreeQuotedRawLiteral =
+            """"
+            """
+            Value contains an apparent three-quotes bounded raw string literal.
+            """
+            """";
+
+        var containsApparentFourQuotedRawLiteral =
+            """""
+            """"
+            Value contains an apparent four-quotes bounded raw string literal.
+            """"
+            """"";
+
+         Contradiction(containsApparentTwoQuotedRawLiteral, x => x.ShouldBe(containsApparentOneQuotedRawLiteral),
+             """"
+             x should be
+                 """
+                 "
+                 Value contains an apparent one-quotes bounded raw string literal.
+                 "
+                 """
+
+             but was
+                 """
+                 ""
+                 Value contains an apparent two-quotes bounded raw string literal.
+                 ""
+                 """
+             """");
+
+        Contradiction(containsApparentThreeQuotedRawLiteral, x => x.ShouldBe(containsApparentTwoQuotedRawLiteral),
+            """""
+            x should be
+                """
+                ""
+                Value contains an apparent two-quotes bounded raw string literal.
+                ""
+                """
+
+            but was
+                """"
+                """
+                Value contains an apparent three-quotes bounded raw string literal.
+                """
+                """"
+            """"");
+
+        Contradiction(containsApparentFourQuotedRawLiteral, x => x.ShouldBe(containsApparentThreeQuotedRawLiteral),
+            """"""
+            x should be
+                """"
+                """
+                Value contains an apparent three-quotes bounded raw string literal.
+                """
+                """"
+
+            but was
+                """""
+                """"
+                Value contains an apparent four-quotes bounded raw string literal.
+                """"
+                """""
+            """""");
     }
 
     public void ShouldAssertTypes()

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -232,53 +232,51 @@ public class AssertionTests
         original.ShouldBe(original);
         altered.ShouldBe(altered);
 
-        var indent = '\t';
-
         Contradiction(original, x => x.ShouldBe(altered),
-            $""""
+            """"
             x should be
-            {indent}"""
-            {indent}Line 1
-            {indent}Line 2 Altered
-            {indent}Line 3
-            {indent}Line 4
-            {indent}"""
+                """
+                Line 1
+                Line 2 Altered
+                Line 3
+                Line 4
+                """
 
             but was
-            {indent}"""
-            {indent}Line 1
-            {indent}Line 2
-            {indent}Line 3
-            {indent}Line 4
-            {indent}"""
+                """
+                Line 1
+                Line 2
+                Line 3
+                Line 4
+                """
             """");
 
         Contradiction(original, x => x.ShouldBe(mixedLineEndings),
-            $""""
+            """"
              x should be
-             {indent}"\r \n \r\n \n \r"
+                 "\r \n \r\n \n \r"
 
              but was
-             {indent}"""
-             {indent}Line 1
-             {indent}Line 2
-             {indent}Line 3
-             {indent}Line 4
-             {indent}"""
+                 """
+                 Line 1
+                 Line 2
+                 Line 3
+                 Line 4
+                 """
              """");
 
         Contradiction(mixedLineEndings, x => x.ShouldBe(original),
-            $""""
+            """"
              x should be
-             {indent}"""
-             {indent}Line 1
-             {indent}Line 2
-             {indent}Line 3
-             {indent}Line 4
-             {indent}"""
+                 """
+                 Line 1
+                 Line 2
+                 Line 3
+                 Line 4
+                 """
 
              but was
-             {indent}"\r \n \r\n \n \r"
+                 "\r \n \r\n \n \r"
              """");
     }
 
@@ -357,27 +355,27 @@ public class AssertionTests
         Contradiction(new[] { 0 }, x => x.ShouldBe([]),
             """
             x should be
-            	[
-            	
-            	]
+                [
+                
+                ]
 
             but was
-            	[
-            	  0
-            	]
+                [
+                    0
+                ]
             """);
 
         Contradiction(new int[] { }, x => x.ShouldBe([0]),
             """
             x should be
-            	[
-            	  0
-            	]
+                [
+                    0
+                ]
 
             but was
-            	[
-            	
-            	]
+                [
+                
+                ]
             """);
 
         new[] { false, true, false }.ShouldBe([false, true, false]);
@@ -385,17 +383,17 @@ public class AssertionTests
         Contradiction(new[] { false, true, false }, x => x.ShouldBe([false, true]),
             """
             x should be
-            	[
-            	  false,
-            	  true
-            	]
+                [
+                    false,
+                    true
+                ]
 
             but was
-            	[
-            	  false,
-            	  true,
-            	  false
-            	]
+                [
+                    false,
+                    true,
+                    false
+                ]
             """);
         
         new[] { 'A', 'B', 'C' }.ShouldBe(['A', 'B', 'C']);
@@ -403,17 +401,17 @@ public class AssertionTests
         Contradiction(new[] { 'A', 'B', 'C' }, x => x.ShouldBe(['A', 'C']),
             """
             x should be
-            	[
-            	  'A',
-            	  'C'
-            	]
+                [
+                    'A',
+                    'C'
+                ]
 
             but was
-            	[
-            	  'A',
-            	  'B',
-            	  'C'
-            	]
+                [
+                    'A',
+                    'B',
+                    'C'
+                ]
             """);
 
         new[] { "A", "B", "C" }.ShouldBe(["A", "B", "C"]);
@@ -421,17 +419,17 @@ public class AssertionTests
         Contradiction(new[] { "A", "B", "C" }, x => x.ShouldBe(["A", "C"]),
             """
             x should be
-            	[
-            	  "A",
-            	  "C"
-            	]
+                [
+                    "A",
+                    "C"
+                ]
 
             but was
-            	[
-            	  "A",
-            	  "B",
-            	  "C"
-            	]
+                [
+                    "A",
+                    "B",
+                    "C"
+                ]
             """);
 
         new[] { typeof(int), typeof(bool) }.ShouldBe([typeof(int), typeof(bool)]);
@@ -439,16 +437,16 @@ public class AssertionTests
         Contradiction(new[] { typeof(int), typeof(bool) }, x => x.ShouldBe([typeof(bool), typeof(int)]),
             """
             x should be
-            	[
-            	  typeof(bool),
-            	  typeof(int)
-            	]
+                [
+                    typeof(bool),
+                    typeof(int)
+                ]
             
             but was
-            	[
-            	  typeof(int),
-            	  typeof(bool)
-            	]
+                [
+                    typeof(int),
+                    typeof(bool)
+                ]
             """);
 
         var sampleA = new Sample("A");
@@ -459,16 +457,16 @@ public class AssertionTests
         Contradiction(new[] { sampleA, sampleB }, x => x.ShouldBe([sampleB, sampleA]),
             """
             x should be
-            	[
-            	  Sample B,
-            	  Sample A
-            	]
+                [
+                    Sample B,
+                    Sample A
+                ]
 
             but was
-            	[
-            	  Sample A,
-            	  Sample B
-            	]
+                [
+                    Sample A,
+                    Sample B
+                ]
             """);
     }
 

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Text;
 using static System.Environment;
 
 namespace Fixie.Tests.Assertions;
@@ -212,71 +211,75 @@ public class AssertionTests
 
     public void ShouldAssertMultilineStrings()
     {
-        var original = new StringBuilder()
-            .AppendLine("Line 1")
-            .AppendLine("Line 2")
-            .AppendLine("Line 3")
-            .Append("Line 4")
-            .ToString();
+        var original =
+            """
+            Line 1
+            Line 2
+            Line 3
+            Line 4
+            """;
 
-        var altered = new StringBuilder()
-            .AppendLine("Line 1")
-            .AppendLine("Line 2 Altered")
-            .AppendLine("Line 3")
-            .Append("Line 4")
-            .ToString();
+        var altered =
+            """
+            Line 1
+            Line 2 Altered
+            Line 3
+            Line 4
+            """;
 
         var mixedLineEndings = "\r \n \r\n \n \r";
 
         original.ShouldBe(original);
         altered.ShouldBe(altered);
 
+        var indent = '\t';
+
         Contradiction(original, x => x.ShouldBe(altered),
-            new StringBuilder()
-                .AppendLine("x should be")
-                .AppendLine("\t\"\"\"")
-                .AppendLine("\tLine 1")
-                .AppendLine("\tLine 2 Altered")
-                .AppendLine("\tLine 3")
-                .AppendLine("\tLine 4")
-                .AppendLine("\t\"\"\"")
-                .AppendLine()
-                .AppendLine("but was")
-                .AppendLine("\t\"\"\"")
-                .AppendLine("\tLine 1")
-                .AppendLine("\tLine 2")
-                .AppendLine("\tLine 3")
-                .AppendLine("\tLine 4")
-                .Append("\t\"\"\"")
-                .ToString());
+            $""""
+            x should be
+            {indent}"""
+            {indent}Line 1
+            {indent}Line 2 Altered
+            {indent}Line 3
+            {indent}Line 4
+            {indent}"""
+
+            but was
+            {indent}"""
+            {indent}Line 1
+            {indent}Line 2
+            {indent}Line 3
+            {indent}Line 4
+            {indent}"""
+            """");
 
         Contradiction(original, x => x.ShouldBe(mixedLineEndings),
-            new StringBuilder()
-                .AppendLine("x should be")
-                .AppendLine("\t\"\\r \\n \\r\\n \\n \\r\"")
-                .AppendLine()
-                .AppendLine("but was")
-                .AppendLine("\t\"\"\"")
-                .AppendLine("\tLine 1")
-                .AppendLine("\tLine 2")
-                .AppendLine("\tLine 3")
-                .AppendLine("\tLine 4")
-                .Append("\t\"\"\"")
-                .ToString());
+            $""""
+             x should be
+             {indent}"\r \n \r\n \n \r"
+
+             but was
+             {indent}"""
+             {indent}Line 1
+             {indent}Line 2
+             {indent}Line 3
+             {indent}Line 4
+             {indent}"""
+             """");
 
         Contradiction(mixedLineEndings, x => x.ShouldBe(original),
-            new StringBuilder()
-                .AppendLine("x should be")
-                .AppendLine("\t\"\"\"")
-                .AppendLine("\tLine 1")
-                .AppendLine("\tLine 2")
-                .AppendLine("\tLine 3")
-                .AppendLine("\tLine 4")
-                .AppendLine("\t\"\"\"")
-                .AppendLine()
-                .AppendLine("but was")
-                .Append("\t\"\\r \\n \\r\\n \\n \\r\"")
-                .ToString());
+            $""""
+             x should be
+             {indent}"""
+             {indent}Line 1
+             {indent}Line 2
+             {indent}Line 3
+             {indent}Line 4
+             {indent}"""
+
+             but was
+             {indent}"\r \n \r\n \n \r"
+             """");
     }
 
     public void ShouldAssertTypes()


### PR DESCRIPTION
This fixes the rendering of raw string literals as appears in assertion exception messages.

1. Indentation uses spaces instead of tabs. Before this, it was too easy to have a failing multiline string assertion where the stated "expected... but was..." string literals appeared to be identical as they only differed in superficial whitespace. This may have only affected the self-testing of assertion methods themselves, but was annoying enough to warrant fixing.
2. Properly surrounds raw string literals in an appropriate number of `"""` double quotes, respecting the longest sequence of double quote characters in the string content.
3. Avoids incorrectly handling escape sequences in the string content. Raw strings precisely aren't about escape sequences.