### PR TITLE
Simplify test comparison fakery

### DIFF
--- a/src/Fixie.Tests/Reports/ConsoleReportTests.cs
+++ b/src/Fixie.Tests/Reports/ConsoleReportTests.cs
@@ -160,8 +160,8 @@ public class ConsoleReportTests : MessagingTests
 
     static string NormalizeOutput(Output output) =>
         output.Console
-            .NormalizeStackTraces()
-            .CleanDuration();
+            .NormalizeLineNumbers()
+            .NormalizeDuration();
 
     static string LastNonemptyLine(string multiline) =>
         multiline.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Last();

--- a/src/Fixie.Tests/Reports/TeamCityReportTests.cs
+++ b/src/Fixie.Tests/Reports/TeamCityReportTests.cs
@@ -11,7 +11,7 @@ public class TeamCityReportTests : MessagingTests
 
         var output = await Run(environment => new TeamCityReport(environment));
 
-        Regex.Replace(output.Console.NormalizeStackTraces(), @"duration='\d+'", "duration='#'")
+        Regex.Replace(output.Console.NormalizeLineNumbers(), @"duration='\d+'", "duration='#'")
             .ShouldBe(
                 $"""
                  ##teamcity[testSuiteStarted name='Fixie.Tests']

--- a/src/Fixie.Tests/Reports/XmlReportTests.cs
+++ b/src/Fixie.Tests/Reports/XmlReportTests.cs
@@ -24,7 +24,7 @@ public class XmlReportTests : MessagingTests
             throw new Exception("Expected non-null XML report.");
 
         CleanBrittleValues(actual.ToString())
-            .NormalizeStackTraces()
+            .NormalizeLineNumbers()
             .ShouldBe(ExpectedReport);
     }
 

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 
@@ -43,7 +44,7 @@ public class StackTracePresentationTests
                    at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
                 --- End of stack trace from previous location ---
                 {At(typeof(TestClass), "Construct(Object[] parameters)",
-                    Path.Join("...", "src", "Fixie", "TestClass.cs"))}
+                    AbsolutePath(["..", "Fixie", "TestClass.cs"]))}
                 {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
                 
                 1 failed, took 1.23 seconds
@@ -86,6 +87,8 @@ public class StackTracePresentationTests
         const string optimizedInvoker = "   at InvokeStub_FailureTestClass.Synchronous(Object, Object, IntPtr*)";
         const string initialInvoker = "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
 
+        var pathToMethodInfoExtensions = AbsolutePath(["..", "Fixie", "MethodInfoExtensions.cs"]);
+
         output
             .ShouldBe(
                $"""
@@ -97,8 +100,8 @@ public class StackTracePresentationTests
                 
                 Fixie.Tests.FailureException
                 {At<FailureTestClass>("Asynchronous()")}
-                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs"))}
-                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs"))}
+                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", pathToMethodInfoExtensions)}
+                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", pathToMethodInfoExtensions)}
                 {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
                 
                 Test '{FullName<FailureTestClass>()}.Synchronous' failed:
@@ -110,8 +113,8 @@ public class StackTracePresentationTests
                 {(output.Contains(optimizedInvoker) ? optimizedInvoker : initialInvoker)}
                    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
                 --- End of stack trace from previous location ---
-                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs"))}
-                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", Path.Join("...", "src", "Fixie", "MethodInfoExtensions.cs"))}
+                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", pathToMethodInfoExtensions)}
+                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", pathToMethodInfoExtensions)}
                 {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
                 
                 2 failed, took 1.23 seconds
@@ -275,4 +278,9 @@ public class StackTracePresentationTests
         public PrimaryException(Exception innerException)
             : base("Primary Exception!", innerException) { }
     }
+
+    static string AbsolutePath(string[] relativePathFromThisCodeFile, [CallerFilePath] string path = default!) =>
+        Path.GetFullPath(
+            path: Path.Join(relativePathFromThisCodeFile),
+            basePath: Path.GetDirectoryName(path)!);
 }

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -180,8 +180,8 @@ public class StackTracePresentationTests
         await Utility.Run(report, discovery, execution, console, typeof(TSampleTestClass));
 
         return console.ToString()
-            .NormalizeStackTraces()
-            .CleanDuration();
+            .NormalizeLineNumbers()
+            .NormalizeDuration();
     }
 
     class ImplicitExceptionHandling : IExecution

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Fixie.Reports;
 using static Fixie.Tests.Utility;
 

--- a/src/Fixie.Tests/StackTracePresentationTests.cs
+++ b/src/Fixie.Tests/StackTracePresentationTests.cs
@@ -43,8 +43,7 @@ public class StackTracePresentationTests
                 {At<ConstructionFailureTestClass>(".ctor()")}
                    at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
                 --- End of stack trace from previous location ---
-                {At(typeof(TestClass), "Construct(Object[] parameters)",
-                    AbsolutePath(["..", "Fixie", "TestClass.cs"]))}
+                {At(typeof(TestClass), "Construct(Object[] parameters)", ["..", "Fixie", "TestClass.cs"])}
                 {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
                 
                 1 failed, took 1.23 seconds
@@ -87,8 +86,6 @@ public class StackTracePresentationTests
         const string optimizedInvoker = "   at InvokeStub_FailureTestClass.Synchronous(Object, Object, IntPtr*)";
         const string initialInvoker = "   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)";
 
-        var pathToMethodInfoExtensions = AbsolutePath(["..", "Fixie", "MethodInfoExtensions.cs"]);
-
         output
             .ShouldBe(
                $"""
@@ -100,8 +97,8 @@ public class StackTracePresentationTests
                 
                 Fixie.Tests.FailureException
                 {At<FailureTestClass>("Asynchronous()")}
-                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", pathToMethodInfoExtensions)}
-                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", pathToMethodInfoExtensions)}
+                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", ["..", "Fixie", "MethodInfoExtensions.cs"])}
+                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", ["..", "Fixie", "MethodInfoExtensions.cs"])}
                 {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
                 
                 Test '{FullName<FailureTestClass>()}.Synchronous' failed:
@@ -113,8 +110,8 @@ public class StackTracePresentationTests
                 {(output.Contains(optimizedInvoker) ? optimizedInvoker : initialInvoker)}
                    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
                 --- End of stack trace from previous location ---
-                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", pathToMethodInfoExtensions)}
-                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", pathToMethodInfoExtensions)}
+                {At(typeof(MethodInfoExtensions), "CallResolvedMethod(MethodInfo resolvedMethod, Object instance, Object[] parameters)", ["..", "Fixie", "MethodInfoExtensions.cs"])}
+                {At(typeof(MethodInfoExtensions), "Call(MethodInfo method, Object instance, Object[] parameters)", ["..", "Fixie", "MethodInfoExtensions.cs"])}
                 {At<ExplicitExceptionHandling>("Run(TestSuite testSuite)")}
                 
                 2 failed, took 1.23 seconds
@@ -278,9 +275,4 @@ public class StackTracePresentationTests
         public PrimaryException(Exception innerException)
             : base("Primary Exception!", innerException) { }
     }
-
-    static string AbsolutePath(string[] relativePathFromThisCodeFile, [CallerFilePath] string path = default!) =>
-        Path.GetFullPath(
-            path: Path.Join(relativePathFromThisCodeFile),
-            basePath: Path.GetDirectoryName(path)!);
 }

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -24,7 +24,7 @@ static class TestExtensions
         return type.GetMethods(InstanceMethods);
     }
 
-    public static string NormalizeStackTraces(this string? multiline)
+    public static string NormalizeLineNumbers(this string? multiline)
     {
         if (multiline == null)
             throw new Exception("Expected a non-null string.");
@@ -35,11 +35,11 @@ static class TestExtensions
     public static void ShouldBeStackTrace(this string? actual, string[] expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         actual
-            .NormalizeStackTraces()
+            .NormalizeLineNumbers()
             .ShouldBe(string.Join(Environment.NewLine, expected), expression);
     }
 
-    public static string CleanDuration(this string multiline)
+    public static string NormalizeDuration(this string multiline)
     {
         //Avoid brittle assertion introduced by test duration.
 

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -26,14 +26,10 @@ static class TestExtensions
 
     public static string NormalizeStackTraces(this string? multiline)
     {
-        //Avoid brittle assertion introduced by stack trace absolute paths and line numbers.
-
         if (multiline == null)
             throw new Exception("Expected a non-null string.");
 
-        return Regex.Replace(multiline,
-            @"\) in .+([\\/])src([\\/])Fixie(.+)\.cs:line \d+",
-            ") in ...$1src$2Fixie$3.cs:line #");
+        return Regex.Replace(multiline, @"\.cs:line \d+", ".cs:line #");
     }
 
     public static void ShouldBeStackTrace(this string? actual, string[] expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)

--- a/src/Fixie.Tests/TestExtensions.cs
+++ b/src/Fixie.Tests/TestExtensions.cs
@@ -24,16 +24,14 @@ static class TestExtensions
         return type.GetMethods(InstanceMethods);
     }
 
-    public static string NormalizeLineNumbers(this string? multiline)
+    public static string NormalizeLineNumbers(this string multiline)
     {
-        if (multiline == null)
-            throw new Exception("Expected a non-null string.");
-
         return Regex.Replace(multiline, @"\.cs:line \d+", ".cs:line #");
     }
 
     public static void ShouldBeStackTrace(this string? actual, string[] expected, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
+        actual.ShouldNotBeNull();
         actual
             .NormalizeLineNumbers()
             .ShouldBe(string.Join(Environment.NewLine, expected), expression);

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using Fixie.Internal;
 using Fixie.Reports;
 

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -25,20 +25,15 @@ public static class Utility
     }
 
     public static string At<T>(string method, [CallerFilePath] string path = default!)
-        => At(typeof(T), method, NormalizedPath(path));
+        => At(typeof(T), method, path);
 
-    public static string At(Type type, string method, string normalizedPath)
+    public static string At(Type type, string method, string path)
     {
         var typeFullName = type.FullName ??
                            throw new Exception($"Expected type {type.Name} to have a non-null FullName.");
 
-        return $"   at {typeFullName.Replace("+", ".")}.{method} in {normalizedPath}:line #";
+        return $"   at {typeFullName.Replace("+", ".")}.{method} in {path}:line #";
     }
-
-    static string NormalizedPath(string path)
-        => Regex.Replace(path,
-            @".+([\\/])src([\\/])Fixie(.+)\.cs",
-            "...$1src$2Fixie$3.cs");
 
     public static async Task<IEnumerable<string>> Run(Type testClass, IExecution execution, TextWriter console)
     {

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -27,6 +27,15 @@ public static class Utility
     public static string At<T>(string method, [CallerFilePath] string path = default!)
         => At(typeof(T), method, path);
 
+    public static string At(Type type, string method, string[] relativePathFromCallingCodeFile, [CallerFilePath] string path = default!)
+    {
+        var absolutePath = Path.GetFullPath(
+            path: Path.Join(relativePathFromCallingCodeFile),
+            basePath: Path.GetDirectoryName(path)!);
+
+        return At(type, method, absolutePath);
+    }
+
     public static string At(Type type, string method, string path)
     {
         var typeFullName = type.FullName ??


### PR DESCRIPTION
This simplifies needless complexity from tests, where absolute paths that appear in stack traces would be normalized, and then again when asserting on those values so that normalized values would be compared to normalized values. This was all originally in service of unpredictable absolute paths based on where the developer clones the repo to, as well as variations cross platform. The solution instead is to avoid interfering in the first place, and to simply calculate expectations in a platform agnostic way.