### PR TITLE
Flexible assertions

### DIFF
--- a/src/Fixie.Tests/Assertions/AssertException.cs
+++ b/src/Fixie.Tests/Assertions/AssertException.cs
@@ -12,7 +12,7 @@ public class AssertException : Exception
     public bool HasMultilineRepresentation { get; }
     readonly string message;
 
-    AssertException(string? expression, string expected, string actual)
+    AssertException(string? expression, string expected, string actual, string? message = null)
     {
         HasMultilineRepresentation = IsMultiline(expected) || IsMultiline(actual);
 
@@ -20,9 +20,16 @@ public class AssertException : Exception
         Expected = expected;
         Actual = actual;
 
-        message = HasMultilineRepresentation
-            ? MultilineMessage(Expression, Expected, Actual)
-            : ScalarMessage(Expression, Expected, Actual);
+        if (message == null)
+        {
+            this.message = HasMultilineRepresentation
+                ? MultilineMessage(Expression, Expected, Actual)
+                : ScalarMessage(Expression, Expected, Actual);
+        }
+        else
+        {
+            this.message = message;
+        }
     }
 
     public static AssertException ForValues<T>(string? expression, T expected, T actual)
@@ -38,6 +45,11 @@ public class AssertException : Exception
     public static AssertException ForLists<T>(string? expression, T[] expected, T[] actual)
     {
         return new AssertException(expression, SerializeList(expected), SerializeList(actual));
+    }
+    
+    public static AssertException ForMessage(string? expression, string expected, string actual, string message)
+    {
+        return new AssertException(expression, expected, actual, message);
     }
 
     public override string Message => message;

--- a/src/Fixie.Tests/Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Tests/Assertions/AssertionExtensions.cs
@@ -169,7 +169,7 @@ public static class AssertionExtensions
     public static void ShouldNotBeNull([NotNull] this object? actual, [CallerArgumentExpression(nameof(actual))] string? expression = null)
     {
         if (actual == null)
-            throw AssertException.ForDescriptions(expression, "not null", "null");
+            throw AssertException.ForMessage(expression, "not null", "null", $"{expression} should not be null but was null");
     }
 
     static string Json<T>(T @object)

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using static System.Environment;
+using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.Assertions;
 
@@ -438,18 +439,31 @@ public class AssertionTests
         var objectA = new SampleA();
         var objectB = new SampleB();
 
-        ((object?)null).ShouldBe(((object?)null));
         objectA.ShouldBe(objectA);
         objectB.ShouldBe(objectB);
 
-        Contradiction((object?)null, x => x.ShouldBe(objectA),
-            "x should be Fixie.Tests.Assertions.AssertionTests+SampleA but was null");
         Contradiction(objectB, x => x.ShouldBe((object?)null),
-            "x should be null but was Fixie.Tests.Assertions.AssertionTests+SampleB");
+            $"x should be null but was {FullName<SampleB>()}");
         Contradiction(objectB, x => x.ShouldBe(objectA),
-            "x should be Fixie.Tests.Assertions.AssertionTests+SampleA but was Fixie.Tests.Assertions.AssertionTests+SampleB");
+            $"x should be {FullName<SampleA>()} but was {FullName<SampleB>()}");
         Contradiction(objectA, x => x.ShouldBe(objectB),
-            "x should be Fixie.Tests.Assertions.AssertionTests+SampleB but was Fixie.Tests.Assertions.AssertionTests+SampleA");
+            $"x should be {FullName<SampleB>()} but was {FullName<SampleA>()}");
+    }
+
+    public void ShouldAssertNulls()
+    {
+        object? nullObject = null;
+        object nonNullObject = new SampleA();
+
+        nullObject.ShouldBe(null);
+        nonNullObject.ShouldNotBeNull();
+
+        Contradiction((object?)null, x => x.ShouldBe(nonNullObject),
+            $"x should be {FullName<SampleA>()} but was null");
+        Contradiction(nonNullObject, x => x.ShouldBe(null),
+            $"x should be null but was {FullName<SampleA>()}");
+        Contradiction((object?)null, x => x.ShouldNotBeNull(),
+            "x should be not null but was null");
     }
 
     public void ShouldAssertLists()

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -588,15 +588,24 @@ public class AssertionTests
             """);
     }
 
-    public void ShouldAssertComparisons()
+    public void ShouldAssertExpressions()
     {
-        Contradiction(3, x => x.ShouldBeGreaterThan(4), "x should be > 4 but was 3");
-        Contradiction(4, x => x.ShouldBeGreaterThan(4), "x should be > 4 but was 4");
-        5.ShouldBeGreaterThan(4);
+        Contradiction(3, value => value.Should(x => x > 4), "value should be > 4 but was 3");
+        Contradiction(4, value => value.Should(y => y > 4), "value should be > 4 but was 4");
+        5.Should(x => x > 4);
 
-        Contradiction(3, x => x.ShouldBeGreaterThanOrEqualTo(4), "x should be >= 4 but was 3");
-        4.ShouldBeGreaterThanOrEqualTo(4);
-        5.ShouldBeGreaterThanOrEqualTo(4);
+        Contradiction(3, value => value.Should(abc => abc >= 4), "value should be >= 4 but was 3");
+        4.Should(x => x >= 4);
+        5.Should(x => x >= 4);
+
+        Func<int, bool> someExpression = x => x >= 4;
+        Contradiction(3, value => value.Should(someExpression), "value should be someExpression but was 3");
+
+        var a1 = new SampleA();
+        var a2 = new SampleA();
+
+        a1.Should(x => x == a1);
+        Contradiction(a1, value => value.Should(x => x == a2), "value should be == a2 but was Fixie.Tests.Assertions.AssertionTests+SampleA");
     }
 
     class SampleA;

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -463,7 +463,7 @@ public class AssertionTests
         Contradiction(nonNullObject, x => x.ShouldBe(null),
             $"x should be null but was {FullName<SampleA>()}");
         Contradiction((object?)null, x => x.ShouldNotBeNull(),
-            "x should be not null but was null");
+            "x should not be null but was null");
     }
 
     public void ShouldAssertLists()

--- a/src/Fixie.Tests/Assertions/AssertionTests.cs
+++ b/src/Fixie.Tests/Assertions/AssertionTests.cs
@@ -588,6 +588,17 @@ public class AssertionTests
             """);
     }
 
+    public void ShouldAssertComparisons()
+    {
+        Contradiction(3, x => x.ShouldBeGreaterThan(4), "x should be > 4 but was 3");
+        Contradiction(4, x => x.ShouldBeGreaterThan(4), "x should be > 4 but was 4");
+        5.ShouldBeGreaterThan(4);
+
+        Contradiction(3, x => x.ShouldBeGreaterThanOrEqualTo(4), "x should be >= 4 but was 3");
+        4.ShouldBeGreaterThanOrEqualTo(4);
+        5.ShouldBeGreaterThanOrEqualTo(4);
+    }
+
     class SampleA;
     class SampleB;
 

--- a/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
+++ b/src/Fixie.Tests/Reports/AppVeyorReportTests.cs
@@ -40,7 +40,7 @@ public class AppVeyorReportTests : MessagingTests
 
         fail.TestName.ShouldBe(TestClass + ".Fail");
         fail.Outcome.ShouldBe("Failed");
-        int.Parse(fail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        int.Parse(fail.DurationMilliseconds).Should(x => x >= 0);
         fail.ErrorMessage.ShouldBe("'Fail' failed!");
         fail.ErrorStackTrace
             .ShouldBeStackTrace(["Fixie.Tests.FailureException", At("Fail()")]);
@@ -48,7 +48,7 @@ public class AppVeyorReportTests : MessagingTests
 
         failByAssertion.TestName.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.Outcome.ShouldBe("Failed");
-        int.Parse(failByAssertion.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        int.Parse(failByAssertion.DurationMilliseconds).Should(x => x >= 0);
         failByAssertion.ErrorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.ErrorStackTrace
             .ShouldBeStackTrace(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
@@ -56,35 +56,35 @@ public class AppVeyorReportTests : MessagingTests
 
         pass.TestName.ShouldBe(TestClass + ".Pass");
         pass.Outcome.ShouldBe("Passed");
-        int.Parse(pass.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        int.Parse(pass.DurationMilliseconds).Should(x => x >= 0);
         pass.ErrorMessage.ShouldBe(null);
         pass.ErrorStackTrace.ShouldBe(null);
         pass.StdOut.ShouldBe("");
 
         skip.TestName.ShouldBe(TestClass + ".Skip");
         skip.Outcome.ShouldBe("Skipped");
-        int.Parse(skip.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        int.Parse(skip.DurationMilliseconds).Should(x => x >= 0);
         skip.ErrorMessage.ShouldBe("⚠ Skipped with attribute.");
         skip.ErrorStackTrace.ShouldBe(null);
         skip.StdOut.ShouldBe("");
 
         shouldBeStringPassA.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
         shouldBeStringPassA.Outcome.ShouldBe("Passed");
-        int.Parse(shouldBeStringPassA.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        int.Parse(shouldBeStringPassA.DurationMilliseconds).Should(x => x >= 0);
         shouldBeStringPassA.ErrorMessage.ShouldBe(null);
         shouldBeStringPassA.ErrorStackTrace.ShouldBe(null);
         shouldBeStringPassA.StdOut.ShouldBe("");
 
         shouldBeStringPassB.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
         shouldBeStringPassB.Outcome.ShouldBe("Passed");
-        int.Parse(shouldBeStringPassB.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        int.Parse(shouldBeStringPassB.DurationMilliseconds).Should(x => x >= 0);
         shouldBeStringPassB.ErrorMessage.ShouldBe(null);
         shouldBeStringPassB.ErrorStackTrace.ShouldBe(null);
         shouldBeStringPassB.StdOut.ShouldBe("");
 
         shouldBeStringFail.TestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.Outcome.ShouldBe("Failed");
-        int.Parse(shouldBeStringFail.DurationMilliseconds).ShouldBeGreaterThanOrEqualTo(0);
+        int.Parse(shouldBeStringFail.DurationMilliseconds).Should(x => x >= 0);
         shouldBeStringFail.ErrorMessage
             .ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.ErrorStackTrace

--- a/src/Fixie.Tests/Reports/AzureReportTests.cs
+++ b/src/Fixie.Tests/Reports/AzureReportTests.cs
@@ -101,7 +101,7 @@ public class AzureReportTests : MessagingTests
         fail.automatedTestName.ShouldBe(TestClass + ".Fail");
         fail.testCaseTitle.ShouldBe(TestClass + ".Fail");
         fail.outcome.ShouldBe("Failed");
-        fail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        fail.durationInMs.Should(x => x >= 0);
         fail.errorMessage.ShouldBe("'Fail' failed!");
         fail.stackTrace
             .ShouldBeStackTrace(["Fixie.Tests.FailureException", At("Fail()")]);
@@ -109,7 +109,7 @@ public class AzureReportTests : MessagingTests
         failByAssertion.automatedTestName.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.testCaseTitle.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.outcome.ShouldBe("Failed");
-        failByAssertion.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        failByAssertion.durationInMs.Should(x => x >= 0);
         failByAssertion.errorMessage.ShouldBe("x should be 2 but was 1");
         failByAssertion.stackTrace
             .ShouldBeStackTrace(["Fixie.Tests.Assertions.AssertException", At("FailByAssertion()")]);
@@ -117,35 +117,35 @@ public class AzureReportTests : MessagingTests
         pass.automatedTestName.ShouldBe(TestClass + ".Pass");
         pass.testCaseTitle.ShouldBe(TestClass + ".Pass");
         pass.outcome.ShouldBe("Passed");
-        pass.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        pass.durationInMs.Should(x => x >= 0);
         pass.errorMessage.ShouldBe(null);
         pass.stackTrace.ShouldBe(null);
 
         skip.automatedTestName.ShouldBe(TestClass + ".Skip");
         skip.testCaseTitle.ShouldBe(TestClass + ".Skip");
         skip.outcome.ShouldBe("Warning");
-        skip.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        skip.durationInMs.Should(x => x >= 0);
         skip.errorMessage.ShouldBe("⚠ Skipped with attribute.");
         skip.stackTrace.ShouldBe(null);
 
         shouldBeStringPassA.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
         shouldBeStringPassA.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
         shouldBeStringPassA.outcome.ShouldBe("Passed");
-        shouldBeStringPassA.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringPassA.durationInMs.Should(x => x >= 0);
         shouldBeStringPassA.errorMessage.ShouldBe(null);
         shouldBeStringPassA.stackTrace.ShouldBe(null);
 
         shouldBeStringPassB.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
         shouldBeStringPassB.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
         shouldBeStringPassB.outcome.ShouldBe("Passed");
-        shouldBeStringPassB.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringPassB.durationInMs.Should(x => x >= 0);
         shouldBeStringPassB.errorMessage.ShouldBe(null);
         shouldBeStringPassB.stackTrace.ShouldBe(null);
 
         shouldBeStringFail.automatedTestName.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.testCaseTitle.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
         shouldBeStringFail.outcome.ShouldBe("Failed");
-        shouldBeStringFail.durationInMs.ShouldBeGreaterThanOrEqualTo(0);
+        shouldBeStringFail.durationInMs.Should(x => x >= 0);
         shouldBeStringFail.errorMessage.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
         shouldBeStringFail.stackTrace
             .ShouldBeStackTrace([

--- a/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
+++ b/src/Fixie.Tests/Reports/LifecycleMessageTests.cs
@@ -34,13 +34,13 @@ public class LifecycleMessageTests : MessagingTests
 
         pass.Test.ShouldBe(TestClass + ".Pass");
         pass.TestCase.ShouldBe(TestClass + ".Pass");
-        pass.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        pass.Duration.Should(x => x >= TimeSpan.Zero);
 
         failStarted.Test.ShouldBe(TestClass + ".Fail");
 
         fail.Test.ShouldBe(TestClass + ".Fail");
         fail.TestCase.ShouldBe(TestClass + ".Fail");
-        fail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        fail.Duration.Should(x => x >= TimeSpan.Zero);
         fail.Reason.ShouldBe<FailureException>();
         fail.Reason.StackTraceSummary()
             .ShouldBeStackTrace([At("Fail()")]);
@@ -50,7 +50,7 @@ public class LifecycleMessageTests : MessagingTests
 
         failByAssertion.Test.ShouldBe(TestClass + ".FailByAssertion");
         failByAssertion.TestCase.ShouldBe(TestClass + ".FailByAssertion");
-        failByAssertion.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        failByAssertion.Duration.Should(x => x >= TimeSpan.Zero);
         failByAssertion.Reason.ShouldBe<AssertException>();
         failByAssertion.Reason.StackTraceSummary()
             .ShouldBeStackTrace([At("FailByAssertion()")]);
@@ -58,32 +58,32 @@ public class LifecycleMessageTests : MessagingTests
 
         skip.Test.ShouldBe(TestClass + ".Skip");
         skip.TestCase.ShouldBe(TestClass + ".Skip");
-        skip.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        skip.Duration.Should(x => x >= TimeSpan.Zero);
         skip.Reason.ShouldBe("⚠ Skipped with attribute.");
 
         shouldBeStringPassAStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
 
         shouldBeStringPassA.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
         shouldBeStringPassA.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"A\")");
-        shouldBeStringPassA.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        shouldBeStringPassA.Duration.Should(x => x >= TimeSpan.Zero);
 
         shouldBeStringPassBStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
 
         shouldBeStringPassB.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
         shouldBeStringPassB.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.String>(\"B\")");
-        shouldBeStringPassB.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        shouldBeStringPassB.Duration.Should(x => x >= TimeSpan.Zero);
 
         shouldBeStringFailStarted.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
 
         shouldBeStringFail.Test.ShouldBe(GenericTestClass + ".ShouldBeString");
         shouldBeStringFail.TestCase.ShouldBe(GenericTestClass + ".ShouldBeString<System.Int32>(123)");
-        shouldBeStringFail.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        shouldBeStringFail.Duration.Should(x => x >= TimeSpan.Zero);
         shouldBeStringFail.Reason.ShouldBe<AssertException>();
         shouldBeStringFail.Reason.StackTraceSummary()
             .ShouldBeStackTrace([At<SampleGenericTestClass>("ShouldBeString[T](T genericArgument)")]);
         shouldBeStringFail.Reason.Message.ShouldBe("genericArgument should be typeof(string) but was typeof(int)");
 
-        executionCompleted.Duration.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
+        executionCompleted.Duration.Should(x => x >= TimeSpan.Zero);
         executionCompleted.Failed.ShouldBe(3);
         executionCompleted.Skipped.ShouldBe(1);
         executionCompleted.Passed.ShouldBe(3);

--- a/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
+++ b/src/Fixie.Tests/TestAdapter/TestCaseMappingAssertions.cs
@@ -49,7 +49,7 @@ public static class TestCaseMappingAssertions
     {
         test.CodeFilePath.ShouldNotBeNull();
         test.CodeFilePath.EndsWith("MessagingTests.cs").ShouldBe(true);
-        test.LineNumber.ShouldBeGreaterThan(0);
+        test.LineNumber.Should(x => x > 0);
     }
 
     static void ShouldNotHaveSourceLocation(TestCase test)


### PR DESCRIPTION
1. Test coverage and improved error message grammar for `ShouldNotBeNull()`.
2. Phase out the need for silly assertion explosion (`ShouldBeGreaterThan`, `ShouldBeGreaterThanOrEqualTo`, ...) in favor of a flexible lambda assertion:

An assertion like:

```cs
int.Parse(fail.DurationMilliseconds).Should(x => x >= 0);
```

Results in messages like:

```
int.Parse(fail.DurationMilliseconds) should be >= 0 but was -1000
```