### PR TITLE
Modernize TeamCity Report

### DIFF
--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -28,8 +28,8 @@ class TeamCityReport :
     public Task Handle(ExecutionStarted message)
     {
         var assembly = Encode(environment.Assembly.GetName().Name);
-        
-        Message("##teamcity[testSuiteStarted name='{0}']", assembly);
+
+        environment.Console.WriteLine($"##teamcity[testSuiteStarted name='{assembly}']");
         
         return Task.CompletedTask;
     }
@@ -39,10 +39,10 @@ class TeamCityReport :
         var testCase = Encode(message.TestCase);
         var reason = Encode(message.Reason);
         var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
-        
-        Message("##teamcity[testStarted name='{0}']", testCase);
-        Message("##teamcity[testIgnored name='{0}' message='{1}']", testCase, reason);
-        Message("##teamcity[testFinished name='{0}' duration='{1}']", testCase, duration);
+
+        environment.Console.WriteLine($"##teamcity[testStarted name='{testCase}']");
+        environment.Console.WriteLine($"##teamcity[testIgnored name='{testCase}' message='{reason}']");
+        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration}']");
         
         return Task.CompletedTask;
     }
@@ -51,9 +51,9 @@ class TeamCityReport :
     {
         var testCase = Encode(message.TestCase);
         var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
-        
-        Message("##teamcity[testStarted name='{0}']", testCase);
-        Message("##teamcity[testFinished name='{0}' duration='{1}']", testCase, duration);
+
+        environment.Console.WriteLine($"##teamcity[testStarted name='{testCase}']");
+        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration}']");
         
         return Task.CompletedTask;
     }
@@ -68,9 +68,9 @@ class TeamCityReport :
                    message.Reason.StackTraceSummary());
         var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
 
-        Message("##teamcity[testStarted name='{0}']", testCase);
-        Message("##teamcity[testFailed name='{0}' message='{1}' details='{2}']", testCase, reason, details);
-        Message("##teamcity[testFinished name='{0}' duration='{1}']", testCase, duration);
+        environment.Console.WriteLine($"##teamcity[testStarted name='{testCase}']");
+        environment.Console.WriteLine($"##teamcity[testFailed name='{testCase}' message='{reason}' details='{details}']");
+        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration}']");
         
         return Task.CompletedTask;
     }
@@ -78,15 +78,10 @@ class TeamCityReport :
     public Task Handle(ExecutionCompleted message)
     {
         var assembly = Encode(environment.Assembly.GetName().Name);
-        
-        Message("##teamcity[testSuiteFinished name='{0}']", assembly);
+
+        environment.Console.WriteLine($"##teamcity[testSuiteFinished name='{assembly}']");
         
         return Task.CompletedTask;
-    }
-
-    void Message(string format, params object?[] args)
-    {
-        environment.Console.WriteLine(format, args);
     }
 
     static string Encode(string? value)

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -93,20 +93,23 @@ class TeamCityReport :
 
         foreach (var ch in value)
         {
-            switch (ch)
+            var escapeSequence = ch switch
             {
-                case '|': builder.Append("||"); break;
-                case '\'': builder.Append("|'"); break;
-                case '[': builder.Append("|["); break;
-                case ']': builder.Append("|]"); break;
-                case '\n': builder.Append("|n"); break;
-                case '\r': builder.Append("|r"); break;
-                case > '\x007f': // Hex escape is required.
-                    builder.Append("|0x");
-                    builder.Append(((int)ch).ToString("x4"));
-                    break;
-                default: builder.Append(ch); break;
-            }
+                '|' => "||",
+                '\'' => "|'",
+                '[' => "|[",
+                ']' => "|]",
+                '\n' => "|n",
+                '\r' => "|r",
+                > '\x007f' => // Hex escape is required.
+                    "|0x" + ((int)ch).ToString("x4"),
+                _ => null
+            };
+
+            if (escapeSequence == null)
+                builder.Append(ch);
+            else
+                builder.Append(escapeSequence);
         }
 
         return builder.ToString();

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -38,11 +38,11 @@ class TeamCityReport :
     {
         var testCase = Encode(message.TestCase);
         var reason = Encode(message.Reason);
-        var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
+        var duration = message.Duration.TotalMilliseconds;
 
         environment.Console.WriteLine($"##teamcity[testStarted name='{testCase}']");
         environment.Console.WriteLine($"##teamcity[testIgnored name='{testCase}' message='{reason}']");
-        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration}']");
+        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration:0}']");
         
         return Task.CompletedTask;
     }
@@ -50,10 +50,10 @@ class TeamCityReport :
     public Task Handle(TestPassed message)
     {
         var testCase = Encode(message.TestCase);
-        var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
+        var duration = message.Duration.TotalMilliseconds;
 
         environment.Console.WriteLine($"##teamcity[testStarted name='{testCase}']");
-        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration}']");
+        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration:0}']");
         
         return Task.CompletedTask;
     }
@@ -66,11 +66,11 @@ class TeamCityReport :
             Encode(message.Reason.GetType().FullName +
                    NewLine +
                    message.Reason.StackTraceSummary());
-        var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
+        var duration = message.Duration.TotalMilliseconds;
 
         environment.Console.WriteLine($"##teamcity[testStarted name='{testCase}']");
         environment.Console.WriteLine($"##teamcity[testFailed name='{testCase}' message='{reason}' details='{details}']");
-        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration}']");
+        environment.Console.WriteLine($"##teamcity[testFinished name='{testCase}' duration='{duration:0}']");
         
         return Task.CompletedTask;
     }

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -27,41 +27,60 @@ class TeamCityReport :
 
     public Task Handle(ExecutionStarted message)
     {
-        Message("##teamcity[testSuiteStarted name='{0}']", environment.Assembly.GetName().Name);
+        var assembly = environment.Assembly.GetName().Name;
+        
+        Message("##teamcity[testSuiteStarted name='{0}']", assembly);
+        
         return Task.CompletedTask;
     }
 
     public Task Handle(TestSkipped message)
     {
-        Message("##teamcity[testStarted name='{0}']", message.TestCase);
-        Message("##teamcity[testIgnored name='{0}' message='{1}']", message.TestCase, message.Reason);
-        Message("##teamcity[testFinished name='{0}' duration='{1}']", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
+        var testCase = message.TestCase;
+        var reason = message.Reason;
+        var duration = $"{message.Duration.TotalMilliseconds:0}";
+        
+        Message("##teamcity[testStarted name='{0}']", testCase);
+        Message("##teamcity[testIgnored name='{0}' message='{1}']", testCase, reason);
+        Message("##teamcity[testFinished name='{0}' duration='{1}']", testCase, duration);
+        
         return Task.CompletedTask;
     }
 
     public Task Handle(TestPassed message)
     {
-        Message("##teamcity[testStarted name='{0}']", message.TestCase);
-        Message("##teamcity[testFinished name='{0}' duration='{1}']", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
+        var testCase = message.TestCase;
+        var duration = $"{message.Duration.TotalMilliseconds:0}";
+        
+        Message("##teamcity[testStarted name='{0}']", testCase);
+        Message("##teamcity[testFinished name='{0}' duration='{1}']", testCase, duration);
+        
         return Task.CompletedTask;
     }
 
     public Task Handle(TestFailed message)
     {
+        var testCase = message.TestCase;
+        var reason = message.Reason.Message;
         var details =
             message.Reason.GetType().FullName +
             NewLine +
             message.Reason.StackTraceSummary();
+        var duration = $"{message.Duration.TotalMilliseconds:0}";
 
-        Message("##teamcity[testStarted name='{0}']", message.TestCase);
-        Message("##teamcity[testFailed name='{0}' message='{1}' details='{2}']", message.TestCase, message.Reason.Message, details);
-        Message("##teamcity[testFinished name='{0}' duration='{1}']", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
+        Message("##teamcity[testStarted name='{0}']", testCase);
+        Message("##teamcity[testFailed name='{0}' message='{1}' details='{2}']", testCase, reason, details);
+        Message("##teamcity[testFinished name='{0}' duration='{1}']", testCase, duration);
+        
         return Task.CompletedTask;
     }
 
     public Task Handle(ExecutionCompleted message)
     {
-        Message("##teamcity[testSuiteFinished name='{0}']", environment.Assembly.GetName().Name);
+        var assembly = environment.Assembly.GetName().Name;
+        
+        Message("##teamcity[testSuiteFinished name='{0}']", assembly);
+        
         return Task.CompletedTask;
     }
 

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -3,26 +3,19 @@ using static System.Environment;
 
 namespace Fixie.Reports;
 
-class TeamCityReport :
+class TeamCityReport(TestEnvironment environment) :
     IHandler<ExecutionStarted>,
     IHandler<TestSkipped>,
     IHandler<TestPassed>,
     IHandler<TestFailed>,
     IHandler<ExecutionCompleted>
 {
-    readonly TestEnvironment environment;
-
     internal static TeamCityReport? Create(TestEnvironment environment)
     {
         if (GetEnvironmentVariable("TEAMCITY_PROJECT_NAME") != null)
             return new TeamCityReport(environment);
 
         return null;
-    }
-
-    public TeamCityReport(TestEnvironment environment)
-    {
-        this.environment = environment;
     }
 
     public Task Handle(ExecutionStarted message)

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -101,24 +101,14 @@ class TeamCityReport :
                 case ']': builder.Append("|]"); break;
                 case '\n': builder.Append("|n"); break;
                 case '\r': builder.Append("|r"); break;
-                default:
-                    if (RequiresHexEscape(ch))
-                    {
-                        builder.Append("|0x");
-                        builder.Append(((int) ch).ToString("x4"));
-                    }
-                    else
-                    {
-                        builder.Append(ch);
-                    }
-
+                case > '\x007f': // Hex escape is required.
+                    builder.Append("|0x");
+                    builder.Append(((int)ch).ToString("x4"));
                     break;
+                default: builder.Append(ch); break;
             }
         }
 
         return builder.ToString();
     }
-
-    static bool RequiresHexEscape(char ch)
-        => ch > '\x007f';
 }

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -27,7 +27,7 @@ class TeamCityReport :
 
     public Task Handle(ExecutionStarted message)
     {
-        var assembly = environment.Assembly.GetName().Name;
+        var assembly = Encode(environment.Assembly.GetName().Name);
         
         Message("##teamcity[testSuiteStarted name='{0}']", assembly);
         
@@ -36,9 +36,9 @@ class TeamCityReport :
 
     public Task Handle(TestSkipped message)
     {
-        var testCase = message.TestCase;
-        var reason = message.Reason;
-        var duration = $"{message.Duration.TotalMilliseconds:0}";
+        var testCase = Encode(message.TestCase);
+        var reason = Encode(message.Reason);
+        var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
         
         Message("##teamcity[testStarted name='{0}']", testCase);
         Message("##teamcity[testIgnored name='{0}' message='{1}']", testCase, reason);
@@ -49,8 +49,8 @@ class TeamCityReport :
 
     public Task Handle(TestPassed message)
     {
-        var testCase = message.TestCase;
-        var duration = $"{message.Duration.TotalMilliseconds:0}";
+        var testCase = Encode(message.TestCase);
+        var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
         
         Message("##teamcity[testStarted name='{0}']", testCase);
         Message("##teamcity[testFinished name='{0}' duration='{1}']", testCase, duration);
@@ -60,13 +60,13 @@ class TeamCityReport :
 
     public Task Handle(TestFailed message)
     {
-        var testCase = message.TestCase;
-        var reason = message.Reason.Message;
+        var testCase = Encode(message.TestCase);
+        var reason = Encode(message.Reason.Message);
         var details =
-            message.Reason.GetType().FullName +
-            NewLine +
-            message.Reason.StackTraceSummary();
-        var duration = $"{message.Duration.TotalMilliseconds:0}";
+            Encode(message.Reason.GetType().FullName +
+                   NewLine +
+                   message.Reason.StackTraceSummary());
+        var duration = Encode($"{message.Duration.TotalMilliseconds:0}");
 
         Message("##teamcity[testStarted name='{0}']", testCase);
         Message("##teamcity[testFailed name='{0}' message='{1}' details='{2}']", testCase, reason, details);
@@ -77,17 +77,16 @@ class TeamCityReport :
 
     public Task Handle(ExecutionCompleted message)
     {
-        var assembly = environment.Assembly.GetName().Name;
+        var assembly = Encode(environment.Assembly.GetName().Name);
         
         Message("##teamcity[testSuiteFinished name='{0}']", assembly);
         
         return Task.CompletedTask;
     }
 
-    void Message(string format, params string?[] args)
+    void Message(string format, params object?[] args)
     {
-        var encodedArgs = args.Select(Encode).Cast<object>().ToArray();
-        environment.Console.WriteLine(format, encodedArgs);
+        environment.Console.WriteLine(format, args);
     }
 
     static string Encode(string? value)

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -33,16 +33,16 @@ class TeamCityReport :
 
     public Task Handle(TestSkipped message)
     {
-        TestStarted(message);
+        Message("##teamcity[testStarted name='{0}']", message.TestCase);
         Message("##teamcity[testIgnored name='{0}' message='{1}']", message.TestCase, message.Reason);
-        TestFinished(message);
+        Message("##teamcity[testFinished name='{0}' duration='{1}']", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
         return Task.CompletedTask;
     }
 
     public Task Handle(TestPassed message)
     {
-        TestStarted(message);
-        TestFinished(message);
+        Message("##teamcity[testStarted name='{0}']", message.TestCase);
+        Message("##teamcity[testFinished name='{0}' duration='{1}']", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
         return Task.CompletedTask;
     }
 
@@ -53,9 +53,9 @@ class TeamCityReport :
             NewLine +
             message.Reason.StackTraceSummary();
 
-        TestStarted(message);
+        Message("##teamcity[testStarted name='{0}']", message.TestCase);
         Message("##teamcity[testFailed name='{0}' message='{1}' details='{2}']", message.TestCase, message.Reason.Message, details);
-        TestFinished(message);
+        Message("##teamcity[testFinished name='{0}' duration='{1}']", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
         return Task.CompletedTask;
     }
 
@@ -63,16 +63,6 @@ class TeamCityReport :
     {
         Message("##teamcity[testSuiteFinished name='{0}']", environment.Assembly.GetName().Name);
         return Task.CompletedTask;
-    }
-
-    void TestStarted(TestCompleted message)
-    {
-        Message("##teamcity[testStarted name='{0}']", message.TestCase);
-    }
-
-    void TestFinished(TestCompleted message)
-    {
-        Message("##teamcity[testFinished name='{0}' duration='{1}']", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
     }
 
     void Message(string format, params string?[] args)

--- a/src/Fixie/Reports/TeamCityReport.cs
+++ b/src/Fixie/Reports/TeamCityReport.cs
@@ -27,14 +27,14 @@ class TeamCityReport :
 
     public Task Handle(ExecutionStarted message)
     {
-        Message("testSuiteStarted name='{0}'", environment.Assembly.GetName().Name);
+        Message("##teamcity[testSuiteStarted name='{0}']", environment.Assembly.GetName().Name);
         return Task.CompletedTask;
     }
 
     public Task Handle(TestSkipped message)
     {
         TestStarted(message);
-        Message("testIgnored name='{0}' message='{1}'", message.TestCase, message.Reason);
+        Message("##teamcity[testIgnored name='{0}' message='{1}']", message.TestCase, message.Reason);
         TestFinished(message);
         return Task.CompletedTask;
     }
@@ -54,31 +54,31 @@ class TeamCityReport :
             message.Reason.StackTraceSummary();
 
         TestStarted(message);
-        Message("testFailed name='{0}' message='{1}' details='{2}'", message.TestCase, message.Reason.Message, details);
+        Message("##teamcity[testFailed name='{0}' message='{1}' details='{2}']", message.TestCase, message.Reason.Message, details);
         TestFinished(message);
         return Task.CompletedTask;
     }
 
     public Task Handle(ExecutionCompleted message)
     {
-        Message("testSuiteFinished name='{0}'", environment.Assembly.GetName().Name);
+        Message("##teamcity[testSuiteFinished name='{0}']", environment.Assembly.GetName().Name);
         return Task.CompletedTask;
     }
 
     void TestStarted(TestCompleted message)
     {
-        Message("testStarted name='{0}'", message.TestCase);
+        Message("##teamcity[testStarted name='{0}']", message.TestCase);
     }
 
     void TestFinished(TestCompleted message)
     {
-        Message("testFinished name='{0}' duration='{1}'", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
+        Message("##teamcity[testFinished name='{0}' duration='{1}']", message.TestCase, $"{message.Duration.TotalMilliseconds:0}");
     }
 
     void Message(string format, params string?[] args)
     {
         var encodedArgs = args.Select(Encode).Cast<object>().ToArray();
-        environment.Console.WriteLine("##teamcity[" + format + "]", encodedArgs);
+        environment.Console.WriteLine(format, encodedArgs);
     }
 
     static string Encode(string? value)


### PR DESCRIPTION
Background: During test runs under TeamCity, every testing event is written to standard out using a TeamCity specific format so that they can be picked up and extracted from the log by TeamCity for special presentation in the Tests reporting screen. The `TeamCityReport` has been largely untouched since inception, and a few language features have since become available to improve performance and readability in the implementation.

This improves performance in several ways, largely focusing on the now-available string interpolation syntax and the low level optimizations that the compiler provides for such literals. After moving to that syntax, it became clear that there were a few more opportunities for improvement, largely around avoiding redundant or irrelevant attempts to escape individual values character by character. Lastly, this adopts `switch`-expression syntax for readability when escaping special characters.

Overall, this reduces wasteful casts and string allocations in a fairly busy bit of I/O for every test result in the run.