### PR TITLE
Calculate `TestEnvironment.RootPath` instead of relying on the caller to pass it in correctly.

### DIFF
--- a/src/Fixie.Tests/TestEnvironmentTests.cs
+++ b/src/Fixie.Tests/TestEnvironmentTests.cs
@@ -1,0 +1,36 @@
+﻿using Fixie.Internal;
+
+namespace Fixie.Tests;
+
+public class TestEnvironmentTests
+{
+    public void ShouldDescribeTheTestingEnvironment()
+    {
+        var assembly = typeof(TestProject).Assembly;
+        var targetFrameworkVersion = $"net{Utility.TargetFrameworkVersion}";
+        using var console = new StringWriter();
+        var currentDirectory = Directory.GetCurrentDirectory();
+        string[] customArguments = ["argumentA", "argumentB"];
+        
+        var environment = new TestEnvironment(assembly, targetFrameworkVersion, console, currentDirectory, customArguments);
+
+        environment.TestFramework.ShouldBe(Framework.Version);
+        environment.Assembly.ShouldBe(assembly);
+        environment.TargetFramework.ShouldBe(targetFrameworkVersion);
+        environment.Console.ShouldBe(console);
+        environment.RootPath.ShouldBe(currentDirectory);
+        environment.CustomArguments.ShouldBe(["argumentA", "argumentB"]);
+        environment.IsDevelopment().ShouldBe(!environment.IsContinuousIntegration());
+    }
+
+    public void ShouldInferTheTargetFrameworkFromAssemblyMetadataWhenOtherwiseUnavailable()
+    {
+        using var console = new StringWriter();
+
+        string? targetFramework = null;
+        
+        var environment = new TestEnvironment(typeof(TestProject).Assembly, targetFramework, console, Directory.GetCurrentDirectory(), []);
+
+        environment.TargetFramework.ShouldBe($"net{Utility.TargetFrameworkVersion}");
+    }
+}

--- a/src/Fixie.Tests/TestEnvironmentTests.cs
+++ b/src/Fixie.Tests/TestEnvironmentTests.cs
@@ -12,7 +12,7 @@ public class TestEnvironmentTests
         var currentDirectory = Directory.GetCurrentDirectory();
         string[] customArguments = ["argumentA", "argumentB"];
         
-        var environment = new TestEnvironment(assembly, targetFrameworkVersion, console, currentDirectory, customArguments);
+        var environment = new TestEnvironment(assembly, targetFrameworkVersion, console, customArguments);
 
         environment.TestFramework.ShouldBe(Framework.Version);
         environment.Assembly.ShouldBe(assembly);
@@ -29,7 +29,7 @@ public class TestEnvironmentTests
 
         string? targetFramework = null;
         
-        var environment = new TestEnvironment(typeof(TestProject).Assembly, targetFramework, console, Directory.GetCurrentDirectory(), []);
+        var environment = new TestEnvironment(typeof(TestProject).Assembly, targetFramework, console, []);
 
         environment.TargetFramework.ShouldBe($"net{Utility.TargetFrameworkVersion}");
     }

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -66,7 +66,7 @@ public static class Utility
         if (candidateTypes.Length == 0)
             throw new InvalidOperationException("At least one type must be specified.");
 
-        var environment = new TestEnvironment(typeof(TestProject).Assembly, null, console, Directory.GetCurrentDirectory());
+        var environment = GetTestEnvironment(console);
         var runner = new Runner(environment, report);
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -66,7 +66,7 @@ public static class Utility
         if (candidateTypes.Length == 0)
             throw new InvalidOperationException("At least one type must be specified.");
 
-        var environment = new TestEnvironment(candidateTypes[0].Assembly, null, console, Directory.GetCurrentDirectory());
+        var environment = new TestEnvironment(typeof(TestProject).Assembly, null, console, Directory.GetCurrentDirectory());
         var runner = new Runner(environment, report);
         var configuration = new TestConfiguration();
         configuration.Conventions.Add(discovery, execution);

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -6,15 +6,8 @@ namespace Fixie.Tests;
 
 public static class Utility
 {
-    public static TestEnvironment GetTestEnvironment(TextWriter console)
-    {
-        return new TestEnvironment(
-            typeof(TestProject).Assembly,
-            null,
-            console,
-            Directory.GetCurrentDirectory(),
-            customArguments: []);
-    }
+    public static TestEnvironment GetTestEnvironment(TextWriter console) =>
+        new(typeof(TestProject).Assembly, null, console, customArguments: []);
 
     public const string TargetFrameworkVersion = "8.0";
 

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -12,7 +12,8 @@ public static class Utility
             typeof(TestProject).Assembly,
             null,
             console,
-            Directory.GetCurrentDirectory());
+            Directory.GetCurrentDirectory(),
+            customArguments: []);
     }
 
     public const string TargetFrameworkVersion = "8.0";

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -18,9 +18,8 @@ public class EntryPoint
     public static async Task<int> Main(Assembly assembly, string[] customArguments)
     {
         var console = Console.Out;
-        var rootPath = Directory.GetCurrentDirectory();
         var targetFramework = GetEnvironmentVariable("FIXIE_TARGET_FRAMEWORK");
-        var environment = new TestEnvironment(assembly, targetFramework, console, rootPath, customArguments);
+        var environment = new TestEnvironment(assembly, targetFramework, console, customArguments);
 
         using var boundary = new ConsoleRedirectionBoundary();
 

--- a/src/Fixie/TestEnvironment.cs
+++ b/src/Fixie/TestEnvironment.cs
@@ -8,14 +8,13 @@ namespace Fixie;
 
 public class TestEnvironment
 {
-    internal TestEnvironment(Assembly assembly, string? targetFramework, TextWriter console, string rootPath,
-        IReadOnlyList<string> customArguments)
+    internal TestEnvironment(Assembly assembly, string? targetFramework, TextWriter console, IReadOnlyList<string> customArguments)
     {
         TargetFramework = targetFramework ?? InferTargetFramework(assembly);
         Assembly = assembly;
         CustomArguments = customArguments;
         Console = console;
-        RootPath = rootPath;
+        RootPath = Path.GetDirectoryName(assembly.Location) ?? "";
     }
 
     string? InferTargetFramework(Assembly assembly)

--- a/src/Fixie/TestEnvironment.cs
+++ b/src/Fixie/TestEnvironment.cs
@@ -8,9 +8,6 @@ namespace Fixie;
 
 public class TestEnvironment
 {
-    internal TestEnvironment(Assembly assembly, string? targetFramework, TextWriter console, string rootPath)
-        : this(assembly, targetFramework, console, rootPath, []) { }
-
     internal TestEnvironment(Assembly assembly, string? targetFramework, TextWriter console, string rootPath,
         IReadOnlyList<string> customArguments)
     {


### PR DESCRIPTION
`TestEnvironment` has historically received the test assembly and a string indicating the full folder path in which the assembly lives, so that custom reports can have access to it such as for saving a report file beside the test assembly. In practice, this was the test process's current directory (at time of test assembly Main() entry). To reduce the risk of ever passing in an incorrect value, this is now calculated from the `Assembly` instance, which already knows the full path to the assembly.