### PR TITLE
Modernize `CommandLine.Partition`

### DIFF
--- a/src/Fixie.Console/CommandLine.cs
+++ b/src/Fixie.Console/CommandLine.cs
@@ -7,25 +7,17 @@ public class CommandLine
 
     public static void Partition(string[] arguments, out string[] runnerArguments, out string[] customArguments)
     {
-        List<string> runnerArgumentsList = [];
-        List<string> customArgumentsList = [];
+        var index = Array.IndexOf(arguments, "--");
 
-        bool separatorFound = false;
-        foreach (var arg in arguments)
+        if (index >= 0)
         {
-            if (arg == "--")
-            {
-                separatorFound = true;
-                continue;
-            }
-
-            if (separatorFound)
-                customArgumentsList.Add(arg);
-            else
-                runnerArgumentsList.Add(arg);
+            runnerArguments = arguments[..index];
+            customArguments = arguments[(index + 1)..];
         }
-
-        runnerArguments = runnerArgumentsList.ToArray();
-        customArguments = customArgumentsList.ToArray();
+        else
+        {
+            runnerArguments = [..arguments];
+            customArguments = [];
+        }
     }
 }

--- a/src/Fixie.Tests/Console/CommandLineTests.cs
+++ b/src/Fixie.Tests/Console/CommandLineTests.cs
@@ -18,10 +18,9 @@ public class CommandLineTests
         runnerArguments.ShouldBe(["Example.Tests"]);
         customArguments.ShouldBe(["custom"]);
 
-        //Characterization coverage of undesirable behavior.
         CommandLine.Partition(["Example.Tests", "--", "--", "customA", "--", "--", "customB"], out runnerArguments, out customArguments);
         runnerArguments.ShouldBe(["Example.Tests"]);
-        customArguments.ShouldBe(["customA", "customB"]);
+        customArguments.ShouldBe(["--", "customA", "--", "--", "customB"]);
 
         CommandLine.Partition(["--", "custom"], out runnerArguments, out customArguments);
         runnerArguments.ShouldBe([]);
@@ -37,6 +36,10 @@ public class CommandLineTests
 
         CommandLine.Partition([], out runnerArguments, out customArguments);
         runnerArguments.ShouldBe([]);
+        customArguments.ShouldBe([]);
+
+        CommandLine.Partition(["Example.Tests"], out runnerArguments, out customArguments);
+        runnerArguments.ShouldBe(["Example.Tests"]);
         customArguments.ShouldBe([]);
 
         CommandLine.Partition(["Example.Tests", "unexpectedCustom"], out runnerArguments, out customArguments);

--- a/src/Fixie.Tests/Console/CommandLineTests.cs
+++ b/src/Fixie.Tests/Console/CommandLineTests.cs
@@ -1,0 +1,37 @@
+﻿using Fixie.Console;
+
+namespace Fixie.Tests.Console;
+
+public class CommandLineTests
+{
+    public void ShouldPartitionRunnerArgumentsFromCustomArguments()
+    {
+        CommandLine.Partition([
+            "Example.Tests", "--configuration", "Release", "--framework", "net8.0",
+            "--",
+            "customA", "customB", "customC"
+        ], out var runnerArguments, out var customArguments);
+        runnerArguments.ShouldBe(["Example.Tests", "--configuration", "Release", "--framework", "net8.0"]);
+        customArguments.ShouldBe(["customA", "customB", "customC"]);
+
+        CommandLine.Partition(["Example.Tests", "--", "custom"], out runnerArguments, out customArguments);
+        runnerArguments.ShouldBe(["Example.Tests"]);
+        customArguments.ShouldBe(["custom"]);
+
+        CommandLine.Partition(["--", "custom"], out runnerArguments, out customArguments);
+        runnerArguments.ShouldBe([]);
+        customArguments.ShouldBe(["custom"]);
+
+        CommandLine.Partition(["Example.Tests", "--"], out runnerArguments, out customArguments);
+        runnerArguments.ShouldBe(["Example.Tests"]);
+        customArguments.ShouldBe([]);
+
+        CommandLine.Partition(["--"], out runnerArguments, out customArguments);
+        runnerArguments.ShouldBe([]);
+        customArguments.ShouldBe([]);
+
+        CommandLine.Partition(["Example.Tests", "unexpectedCustom"], out runnerArguments, out customArguments);
+        runnerArguments.ShouldBe(["Example.Tests", "unexpectedCustom"]);
+        customArguments.ShouldBe([]);
+    }
+}

--- a/src/Fixie.Tests/Console/CommandLineTests.cs
+++ b/src/Fixie.Tests/Console/CommandLineTests.cs
@@ -35,6 +35,10 @@ public class CommandLineTests
         runnerArguments.ShouldBe([]);
         customArguments.ShouldBe([]);
 
+        CommandLine.Partition([], out runnerArguments, out customArguments);
+        runnerArguments.ShouldBe([]);
+        customArguments.ShouldBe([]);
+
         CommandLine.Partition(["Example.Tests", "unexpectedCustom"], out runnerArguments, out customArguments);
         runnerArguments.ShouldBe(["Example.Tests", "unexpectedCustom"]);
         customArguments.ShouldBe([]);

--- a/src/Fixie.Tests/Console/CommandLineTests.cs
+++ b/src/Fixie.Tests/Console/CommandLineTests.cs
@@ -18,6 +18,11 @@ public class CommandLineTests
         runnerArguments.ShouldBe(["Example.Tests"]);
         customArguments.ShouldBe(["custom"]);
 
+        //Characterization coverage of undesirable behavior.
+        CommandLine.Partition(["Example.Tests", "--", "--", "customA", "--", "--", "customB"], out runnerArguments, out customArguments);
+        runnerArguments.ShouldBe(["Example.Tests"]);
+        customArguments.ShouldBe(["customA", "customB"]);
+
         CommandLine.Partition(["--", "custom"], out runnerArguments, out customArguments);
         runnerArguments.ShouldBe([]);
         customArguments.ShouldBe(["custom"]);


### PR DESCRIPTION
This modernizes `CommandLine.Partition` as it is a natural fit for `..` spread operators and collection literals. This work also reveals and then fixes an unintentional omission of any `"--"` that happen to appear within the custom arguments after the initial substantive `"--"` separator argument.