### PR TITLE
Simplify runner filtering

### DIFF
--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -128,13 +128,13 @@ class Runner
 
         foreach (var @class in classes)
         {
-            var methods = methodDiscoverer.TestMethods(@class);
+            IEnumerable<MethodInfo> methods = methodDiscoverer.TestMethods(@class);
 
             if (selectedTests.Count > 0)
-                methods = methods.Where(method => selectedTests.Contains(method.TestName())).ToList();
+                methods = methods.Where(method => selectedTests.Contains(method.TestName()));
 
             if (testPattern != null)
-                methods = methods.Where(method => testPattern.Matches(method.TestName())).ToList();
+                methods = methods.Where(method => testPattern.Matches(method.TestName()));
 
             var testMethods = methods
                 .Select(method => new Test(channelWriter, method))

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -149,14 +149,12 @@ class Runner
             if (testPattern != null)
                 methods = methods.Where(method => testPattern.Matches(method.TestName())).ToList();
 
-            if (methods.Count > 0)
-            {
-                var testMethods = methods
-                    .Select(method => new Test(channelWriter, method))
-                    .ToList();
+            var testMethods = methods
+                .Select(method => new Test(channelWriter, method))
+                .ToList();
 
+            if (testMethods.Count > 0)
                 testClasses.Add(new TestClass(@class, testMethods));
-            }
         }
 
         return new TestSuite(testClasses);

--- a/src/Fixie/Internal/Runner.cs
+++ b/src/Fixie/Internal/Runner.cs
@@ -125,26 +125,13 @@ class Runner
         var methodDiscoverer = new MethodDiscoverer(discovery);
 
         var testClasses = new List<TestClass>(selectedTests.Count > 0 ? 0 : classes.Count);
-        List<MethodInfo> selectionWorkingList = [];
 
         foreach (var @class in classes)
         {
             var methods = methodDiscoverer.TestMethods(@class);
 
             if (selectedTests.Count > 0)
-            {
-                selectionWorkingList.AddRange(methods.Where(method => selectedTests.Contains(method.TestName())));
-
-                if (selectionWorkingList.Count == 0)
-                {
-                    methods = [];
-                }
-                else
-                {
-                    methods = selectionWorkingList;
-                    selectionWorkingList = [];
-                }
-            }
+                methods = methods.Where(method => selectedTests.Contains(method.TestName())).ToList();
 
             if (testPattern != null)
                 methods = methods.Where(method => testPattern.Matches(method.TestName())).ToList();


### PR DESCRIPTION
This refactors the code for taking the discovered test methods and further filtering them down by either selected tests (ie IDE tree selections) or a filter pattern (command line `--tests`. The old implementation was needlessly complex, preoccupied with reducing allocations of many short-lived lists. The simpler solution also avoids building excessive lists, but does so by simply conditionally building up a a lazy `IEnumerable<MethodInfo>` LINQ query that can be iterated once.