### PR TITLE
Method invocation error signatures

### DIFF
--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -221,7 +221,7 @@ public class CaseNameTests
         var expectedVariants = expected.Select(name => new[]
         {
             name.Contains("Incompatible")
-                ? $"{name} failed: The type parameters for generic method ConstrainedGeneric could not be resolved."
+                ? $"{name} failed: The type parameters for generic method ConstrainedGeneric<T>(T) could not be resolved."
                 : $"{name} passed",
             $"{name} passed",
             $"{name} failed: 'Run' failed!",

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -158,7 +158,7 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
         var output = await Run<FailDueToNonStartedTaskTestClass, MethodInfoAccessingExecution>();
 
         output.ShouldHaveResults(
-            "FailDueToNonStartedTaskTestClass.Test failed: The method Test returned a non-started task, which cannot " +
+            "FailDueToNonStartedTaskTestClass.Test failed: The method Test() returned a non-started task, which cannot " +
             "be awaited. Consider using Task.Run or Task.Factory.StartNew.");
 
         output.ShouldHaveLifecycle("Test");

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -170,13 +170,13 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
 
         output.ShouldHaveResults(
             "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerable failed: " +
-            "The return type of method AsyncEnumerable is an unsupported awaitable type. " +
+            "The return type of method AsyncEnumerable() is an unsupported awaitable type. " +
             "To ensure the reliability of the test runner, declare " +
             "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
             "or `ValueTask<T>`.",
 
             "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerator failed: " +
-            "The return type of method AsyncEnumerator is an unsupported awaitable type. " +
+            "The return type of method AsyncEnumerator() is an unsupported awaitable type. " +
             "To ensure the reliability of the test runner, declare " +
             "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
             "or `ValueTask<T>`.",
@@ -187,7 +187,7 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
             "the method as `async Task`.",
 
             "UnsupportedReturnTypeDeclarationsTestClass.UntrustworthyAwaitable failed: " +
-            "The return type of method UntrustworthyAwaitable is an unsupported awaitable type. " +
+            "The return type of method UntrustworthyAwaitable() is an unsupported awaitable type. " +
             "To ensure the reliability of the test runner, declare " +
             "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
             "or `ValueTask<T>`."

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -182,7 +182,7 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
             "or `ValueTask<T>`.",
 
             "UnsupportedReturnTypeDeclarationsTestClass.AsyncVoid failed: " +
-            "The method AsyncVoid is declared as `async void`, which is not supported. " +
+            "The method AsyncVoid() is declared as `async void`, which is not supported. " +
             "To ensure the reliability of the test runner, declare " +
             "the method as `async Task`.",
 

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -79,12 +79,12 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
 
             "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(1, 'a', System.Int32, System.Char) passed",
             "GenericTestClass.ConstrainedArgs<System.Int32, System.Char>(2, 'b', System.Int32, System.Int32) failed: typeof(T2) should be typeof(int) but was typeof(char)",
-            "GenericTestClass.ConstrainedArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
-            "GenericTestClass.ConstrainedArgs<T1, T2>(null, 2, System.Object, System.Int32) failed: The type parameters for generic method ConstrainedArgs could not be resolved.",
+            "GenericTestClass.ConstrainedArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method ConstrainedArgs<T1, T2>(T1, T2, System.Type, System.Type) could not be resolved.",
+            "GenericTestClass.ConstrainedArgs<T1, T2>(null, 2, System.Object, System.Int32) failed: The type parameters for generic method ConstrainedArgs<T1, T2>(T1, T2, System.Type, System.Type) could not be resolved.",
 
             "GenericTestClass.NullableValueTypeArgs<System.Int32, System.Int32>(1, 2, System.Int32, System.Int32) passed",
             "GenericTestClass.NullableValueTypeArgs<System.Char, System.Double>('a', 3, System.Char, System.Double) passed",
-            "GenericTestClass.NullableValueTypeArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method NullableValueTypeArgs could not be resolved.");
+            "GenericTestClass.NullableValueTypeArgs<T1, T2>(1, null, System.Int32, System.Object) failed: The type parameters for generic method NullableValueTypeArgs<T1, T2>(T1, System.Nullable`1[T2], System.Type, System.Type) could not be resolved.");
 
         output.ShouldHaveLifecycle("Args", "Args", "ConstrainedArgs", "ConstrainedArgs", "NullableValueTypeArgs", "NullableValueTypeArgs");
     }

--- a/src/Fixie.Tests/MethodInfoExtensionsTests.cs
+++ b/src/Fixie.Tests/MethodInfoExtensionsTests.cs
@@ -109,7 +109,7 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
             "AsyncTestClass.GenericAsyncValueTaskWithResult passed",
             "AsyncTestClass.GenericTaskFail failed: One or more errors occurred. (Attempted to divide by zero.)",
             "AsyncTestClass.GenericTaskWithResult passed",
-            "AsyncTestClass.NullTask failed: The asynchronous method NullTask returned null, " +
+            "AsyncTestClass.NullTask failed: The asynchronous method NullTask() returned null, " +
             "but a non-null awaitable object was expected.");
 
         output.ShouldHaveLifecycle(
@@ -142,7 +142,7 @@ public class MethodInfoExtensionsTests : InstrumentedExecutionTests
             "FSharpAsyncTestClass.AsyncPass passed",
             "FSharpAsyncTestClass.FailBeforeAsync failed: 'FailBeforeAsync' failed!",
             "FSharpAsyncTestClass.FailFromAsync failed: result should be 0 but was 3",
-            "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync returned null, " +
+            "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync() returned null, " +
             "but a non-null awaitable object was expected.");
 
         output.ShouldHaveLifecycle(

--- a/src/Fixie.Tests/ParameterizationTests.cs
+++ b/src/Fixie.Tests/ParameterizationTests.cs
@@ -155,29 +155,29 @@ public class ParameterizationTests : InstrumentedExecutionTests
 
         output.ShouldHaveResults(
             "GenericTestClass.ConstrainedGeneric<System.Int32>(1) passed",
-            "GenericTestClass.ConstrainedGeneric<T>(\"Oops\") failed: The type parameters for generic method ConstrainedGeneric could not be resolved.",
+            "GenericTestClass.ConstrainedGeneric<T>(\"Oops\") failed: The type parameters for generic method ConstrainedGeneric<T>(T) could not be resolved.",
 
             "GenericTestClass.ConstrainedGenericMethodWithNoInputsProvided<T> failed: Cannot create an instance of T because Type.ContainsGenericParameters is true.",
 
             "GenericTestClass.GenericMethodWithIncorrectParameterCountProvided<System.Int32>(123, 123) failed: Parameter count mismatch.",
 
-            "GenericTestClass.GenericMethodWithNoInputsProvided<T>(null) failed: The type parameters for generic method GenericMethodWithNoInputsProvided could not be resolved.",
+            "GenericTestClass.GenericMethodWithNoInputsProvided<T>(null) failed: The type parameters for generic method GenericMethodWithNoInputsProvided<T>(T) could not be resolved.",
 
-            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(123, null, 456, System.Int32, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
+            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(123, null, 456, System.Int32, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters<T1, T2>(T1, T2, T1, System.Type, System.Type) could not be resolved.",
             "GenericTestClass.MultipleGenericArgumentsMultipleParameters<System.Int32, System.String>(123, \"stringArg1\", 456, System.Int32, System.String) passed",
-            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg\", null, null, System.String, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
-            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg1\", null, \"stringArg2\", System.String, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters could not be resolved.",
+            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg\", null, null, System.String, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters<T1, T2>(T1, T2, T1, System.Type, System.Type) could not be resolved.",
+            "GenericTestClass.MultipleGenericArgumentsMultipleParameters<T1, T2>(\"stringArg1\", null, \"stringArg2\", System.String, System.Object) failed: The type parameters for generic method MultipleGenericArgumentsMultipleParameters<T1, T2>(T1, T2, T1, System.Type, System.Type) could not be resolved.",
             "GenericTestClass.MultipleGenericArgumentsMultipleParameters<System.String, System.String>(null, \"stringArg1\", \"stringArg2\", System.String, System.String) passed",
 
             "GenericTestClass.SingleGenericArgument<System.Int32>(123, System.Int32) passed",
-            "GenericTestClass.SingleGenericArgument<T>(null, System.Object) failed: The type parameters for generic method SingleGenericArgument could not be resolved.",
+            "GenericTestClass.SingleGenericArgument<T>(null, System.Object) failed: The type parameters for generic method SingleGenericArgument<T>(T, System.Type) could not be resolved.",
             "GenericTestClass.SingleGenericArgument<System.String>(\"stringArg\", System.String) passed",
 
             "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, 456, System.Int32) passed",
             "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", 123, System.Object) failed: Object of type 'System.Int32' cannot be converted to type 'System.String'.",
             "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, \"stringArg\", System.Object) failed: Object of type 'System.String' cannot be converted to type 'System.Int32'.",
             "GenericTestClass.SingleGenericArgumentMultipleParameters<System.Int32>(123, null, System.Int32) passed", //MethodInfo.Invoke converts nulls to default(T) for value types.
-            "GenericTestClass.SingleGenericArgumentMultipleParameters<T>(null, null, System.Object) failed: The type parameters for generic method SingleGenericArgumentMultipleParameters could not be resolved.",
+            "GenericTestClass.SingleGenericArgumentMultipleParameters<T>(null, null, System.Object) failed: The type parameters for generic method SingleGenericArgumentMultipleParameters<T>(T, T, System.Type) could not be resolved.",
             "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg\", null, System.String) passed",
             "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(\"stringArg1\", \"stringArg2\", System.String) passed",
             "GenericTestClass.SingleGenericArgumentMultipleParameters<System.String>(null, \"stringArg\", System.String) passed");

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -112,7 +112,7 @@ public class ReturnTypeTests : InstrumentedExecutionTests
             "or `ValueTask<T>`.",
 
             "UnsupportedReturnTypeDeclarationsTestClass.AsyncVoid failed: " +
-            "The method AsyncVoid is declared as `async void`, which is not supported. " +
+            "The method AsyncVoid() is declared as `async void`, which is not supported. " +
             "To ensure the reliability of the test runner, declare " +
             "the method as `async Task`.",
 

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -88,7 +88,7 @@ public class ReturnTypeTests : InstrumentedExecutionTests
         var output = await Run<FailDueToNonStartedTaskTestClass>();
 
         output.ShouldHaveResults(
-            "FailDueToNonStartedTaskTestClass.Test failed: The method Test returned a non-started task, which cannot " +
+            "FailDueToNonStartedTaskTestClass.Test failed: The method Test() returned a non-started task, which cannot " +
             "be awaited. Consider using Task.Run or Task.Factory.StartNew.");
 
         output.ShouldHaveLifecycle("Test");

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -43,7 +43,7 @@ public class ReturnTypeTests : InstrumentedExecutionTests
             "AsyncTestClass.GenericAsyncValueTaskWithResult passed",
             "AsyncTestClass.GenericTaskFail failed: One or more errors occurred. (Attempted to divide by zero.)",
             "AsyncTestClass.GenericTaskWithResult passed",
-            "AsyncTestClass.NullTask failed: The asynchronous method NullTask returned null, " +
+            "AsyncTestClass.NullTask failed: The asynchronous method NullTask() returned null, " +
             "but a non-null awaitable object was expected.");
 
         output.ShouldHaveLifecycle(
@@ -73,7 +73,7 @@ public class ReturnTypeTests : InstrumentedExecutionTests
             "FSharpAsyncTestClass.AsyncPass passed",
             "FSharpAsyncTestClass.FailBeforeAsync failed: 'FailBeforeAsync' failed!",
             "FSharpAsyncTestClass.FailFromAsync failed: result should be 0 but was 3",
-            "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync returned null, " +
+            "FSharpAsyncTestClass.NullAsync failed: The asynchronous method NullAsync() returned null, " +
             "but a non-null awaitable object was expected.");
 
         output.ShouldHaveLifecycle(

--- a/src/Fixie.Tests/ReturnTypeTests.cs
+++ b/src/Fixie.Tests/ReturnTypeTests.cs
@@ -100,13 +100,13 @@ public class ReturnTypeTests : InstrumentedExecutionTests
 
         output.ShouldHaveResults(
             "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerable failed: " +
-            "The return type of method AsyncEnumerable is an unsupported awaitable type. " +
+            "The return type of method AsyncEnumerable() is an unsupported awaitable type. " +
             "To ensure the reliability of the test runner, declare " +
             "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
             "or `ValueTask<T>`.",
 
             "UnsupportedReturnTypeDeclarationsTestClass.AsyncEnumerator failed: " +
-            "The return type of method AsyncEnumerator is an unsupported awaitable type. " +
+            "The return type of method AsyncEnumerator() is an unsupported awaitable type. " +
             "To ensure the reliability of the test runner, declare " +
             "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
             "or `ValueTask<T>`.",
@@ -117,7 +117,7 @@ public class ReturnTypeTests : InstrumentedExecutionTests
             "the method as `async Task`.",
 
             "UnsupportedReturnTypeDeclarationsTestClass.UntrustworthyAwaitable failed: " +
-            "The return type of method UntrustworthyAwaitable is an unsupported awaitable type. " +
+            "The return type of method UntrustworthyAwaitable() is an unsupported awaitable type. " +
             "To ensure the reliability of the test runner, declare " +
             "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
             "or `ValueTask<T>`."

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -141,7 +141,7 @@ public static class MethodInfoExtensions
     [DoesNotReturn]
     static void ThrowForUnsupportedAwaitable(MethodInfo method)
         => throw new NotSupportedException(
-            $"The return type of method {method.Name} is an unsupported awaitable type. " +
+            $"The return type of method {Signature(method)} is an unsupported awaitable type. " +
             "To ensure the reliability of the test runner, declare " +
             "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
             "or `ValueTask<T>`.");

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -123,7 +123,7 @@ public static class MethodInfoExtensions
     [DoesNotReturn]
     static void ThrowForUnresolvedTypeParameters(MethodInfo resolvedMethod)
         => throw new InvalidOperationException(
-            $"The type parameters for generic method {resolvedMethod.Name} " +
+            $"The type parameters for generic method {Signature(resolvedMethod)} " +
             "could not be resolved.");
 
     [DoesNotReturn]
@@ -157,6 +157,7 @@ public static class MethodInfoExtensions
 
         return description;
     }
+
     static bool HasAsyncKeyword(this MethodInfo method)
     {
         return method.Has<AsyncStateMachineAttribute>();

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -129,7 +129,7 @@ public static class MethodInfoExtensions
     [DoesNotReturn]
     static void ThrowForNullAwaitable(MethodInfo method)
         => throw new NullReferenceException(
-            $"The asynchronous method {method.Name} returned null, but " +
+            $"The asynchronous method {Signature(method)} returned null, but " +
             "a non-null awaitable object was expected.");
 
     [DoesNotReturn]

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -146,6 +146,17 @@ public static class MethodInfoExtensions
             "the method return type as `Task`, `Task<T>`, `ValueTask`, " +
             "or `ValueTask<T>`.");
 
+    static string Signature(MethodInfo method)
+    {
+        var description = method.Name;
+
+        if (method.IsGenericMethod)
+            description += $"<{string.Join(", ", method.GetGenericArguments().Select(x => x.IsGenericParameter ? x.Name : x.FullName))}>";
+
+        description += $"({string.Join(", ", method.GetParameters().Select(x => $"{x.ParameterType}"))})";
+
+        return description;
+    }
     static bool HasAsyncKeyword(this MethodInfo method)
     {
         return method.Has<AsyncStateMachineAttribute>();

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -116,7 +116,7 @@ public static class MethodInfoExtensions
     [DoesNotReturn]
     static void ThrowForAsyncVoid(MethodInfo resolvedMethod)
         => throw new NotSupportedException(
-            $"The method {resolvedMethod.Name} is declared as `async void`, " +
+            $"The method {Signature(resolvedMethod)} is declared as `async void`, " +
             "which is not supported. To ensure the reliability of the test " +
             "runner, declare the method as `async Task`.");
 

--- a/src/Fixie/MethodInfoExtensions.cs
+++ b/src/Fixie/MethodInfoExtensions.cs
@@ -135,7 +135,7 @@ public static class MethodInfoExtensions
     [DoesNotReturn]
     static void ThrowForNonStartedTask(MethodInfo resolvedMethod)
         => throw new InvalidOperationException(
-            $"The method {resolvedMethod.Name} returned a non-started task, which " +
+            $"The method {Signature(resolvedMethod)} returned a non-started task, which " +
             "cannot be awaited. Consider using Task.Run or Task.Factory.StartNew.");
 
     [DoesNotReturn]


### PR DESCRIPTION
There are many reasons why an attempt to invoke an arbitrary method via reflection might fail, so for a long time now we've had a helper for ensuring that a given MethodInfo is not only invoked, but properly awaited, and properly complained about if the caller does anything atypical to thwart this effort such as using `async void` or if the method returns an unusable null or nonstarted Task. Historically, these exception messages have been clear and descriptive, but only included the method's short name when referring to the offending method. In common scenarios that was sufficient, but in the case of parameterized overloaded tests and especially in the case where one or more of those overloads is generic, the short name in the error puts more work on the developer to diagnose what test method is the actual offender and what is going wrong. This improves these rare error messages by including the declared signature of the offending method.

Before:

```
The type parameters for generic method NullableValueTypeArgs could not be resolved.
```

After:

```
The type parameters for generic method NullableValueTypeArgs<T1, T2>(T1, System.Nullable`1[T2], System.Type, System.Type) could not be resolved.
```