### PR TITLE
GitHub Actions workflows skip deployment attempts (which would safely fail anyway) for forks

### DIFF
--- a/release.ps1
+++ b/release.ps1
@@ -1,6 +1,10 @@
 ﻿$packages = get-childitem packages/*.nupkg
 
-foreach ($package in $packages) {
-    dotnet nuget push $package --source $env:PACKAGE_URL --api-key $env:PACKAGE_API_KEY
-    if ($lastexitcode -ne 0) { throw $lastexitcode }
+if ([string]::IsNullOrEmpty($env:PACKAGE_API_KEY)) {
+    Write-Host "$($MyInvocation.MyCommand.Name): PACKAGE_API_KEY is empty or not set. No packages will be pushed."
+} else {
+    foreach ($package in $packages) {
+        dotnet nuget push $package --source $env:PACKAGE_URL --api-key $env:PACKAGE_API_KEY
+        if ($lastexitcode -ne 0) { throw $lastexitcode }
+    }
 }


### PR DESCRIPTION
When third party forks submit pull requests, the github actions workflow builds and runs tests, and then on success attempts to publish to a developer builds package feed. Since such forks correctly cannot push to that feed, those attempts fail. This makes the PR appear at first to be in a bad state such as for a failing test, even when it's truly ready for review.

This PR alters the workflows so that we don't even bother attempting the package push when not applicable.