### PR TITLE
Refine case names

### DIFF
--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -22,7 +22,7 @@ public class CaseNameTests
         });
 
         ShouldHaveNames(output,
-            "ParameterizedTestClass.Parameterized(123, True, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseNameTests, Fixie.Tests.CaseNameTests+ObjectWithNullStringRepresentation)");
+            "ParameterizedTestClass.Parameterized(123, true, 'a', \"with \\\"quotes\\\"\", \"long \\\"string\\\" g...\", null, Fixie.Tests.CaseNameTests, Fixie.Tests.CaseNameTests+ObjectWithNullStringRepresentation)");
     }
 
     public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()
@@ -139,8 +139,8 @@ public class CaseNameTests
         });
 
         ShouldHaveNames(output,
-            "GenericTestClass.Generic<System.Boolean, System.String>(123, True, \"a\", \"b\")",
-            "GenericTestClass.Generic<System.Boolean, System.Int32>(123, True, 1, null)",
+            "GenericTestClass.Generic<System.Boolean, System.String>(123, true, \"a\", \"b\")",
+            "GenericTestClass.Generic<System.Boolean, System.Int32>(123, true, 1, null)",
             "GenericTestClass.Generic<System.Decimal, System.String>(123, 1.23, \"a\", null)"
         );
     }
@@ -156,7 +156,7 @@ public class CaseNameTests
 
         ShouldHaveNames(output,
             "ConstrainedGenericTestClass.ConstrainedGeneric<System.Int32>(1)",
-            "ConstrainedGenericTestClass.ConstrainedGeneric<System.Boolean>(True)",
+            "ConstrainedGenericTestClass.ConstrainedGeneric<System.Boolean>(true)",
             "ConstrainedGenericTestClass.ConstrainedGeneric<T>(\"Incompatible\")"
         );
     }

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -27,10 +27,6 @@ public class CaseNameTests
 
     public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasCharParameters()
     {
-        // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
-        // Just like \r and \n, we escape these in order to present a readable string literal. All other unicode sequences pass through
-        // with no additional special treatment.
-
         // \uxxxx - Unicode escape sequence for character with hex value xxxx.
         // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
         // \Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
@@ -60,21 +56,9 @@ public class CaseNameTests
         });
 
         var unicodeEscapeExpectations = UnicodeEscapedCharacters()
-            .Select(c =>
-            {
-                if (c is not ('\u0085' or '\u2028' or '\u2029'))
-                {
-                    // Characterization coverage of undesirable behavior. Note many control
-                    // characters and whitespace characters fail to be escaped.
-                    return $"""
-                            CharParametersTestClass.Char('{c}')
-                            """;
-                }
-
-                return $"""
-                        CharParametersTestClass.Char('\u{(int)c:X4}')
-                        """;
-            });
+            .Select(c => $"""
+                          CharParametersTestClass.Char('\u{(int)c:X4}')
+                          """);
 
         ShouldHaveNames(output, [
             "CharParametersTestClass.Char('\"')",
@@ -122,10 +106,6 @@ public class CaseNameTests
 
     public async Task ShouldIncludeEscapeSequencesInNameWhenTheUnderlyingMethodHasStringParameters()
     {
-        // Unicode characters 0085, 2028, and 2029 represent line endings Next Line, Line Separator, and Paragraph Separator, respectively.
-        // Just like \r and \n, we escape these in order to present a readable string literal. All other unicode sequences pass through
-        // with no additional special treatment.
-
         // \uxxxx - Unicode escape sequence for character with hex value xxxx.
         // \xn[n][n][n] - Unicode escape sequence for character with hex value nnnn (variable length version of \uxxxx).
         // \Uxxxxxxxx - Unicode escape sequence for character with hex value xxxxxxxx (for generating surrogates).
@@ -152,25 +132,22 @@ public class CaseNameTests
             "StringParametersTestClass.String(\" \\0 \\0 \\0 \\0 \")",
             "StringParametersTestClass.String(\" \\u0085 \\u0085 \\u0085 \\u2028 \\u2029 ☺ \")",
             "StringParametersTestClass.String(\" \\0 \\u0085 \\u2028 \\u2029 ☺ \")",
-
-            // Characterization coverage of undesirable behavior. Note many control
-            // characters and whitespace characters fail to be escaped.
-            "StringParametersTestClass.String(\"\u0001 \u0002 \u0003 \u0004 \u0005\")",
-            "StringParametersTestClass.String(\"\u0006 \u000E \u000F \u0010 \u0011\")",
-            "StringParametersTestClass.String(\"\u0012 \u0013 \u0014 \u0015 \u0016\")",
-            "StringParametersTestClass.String(\"\u0017 \u0018 \u0019 \u001A \u001B\")",
-            "StringParametersTestClass.String(\"\u001C \u001D \u001E \u001F \u007F\")",
-            "StringParametersTestClass.String(\"\u0080 \u0081 \u0082 \u0083 \u0084\")",
-            "StringParametersTestClass.String(\"\\u0085 \u0086 \u0087 \u0088 \u0089\")",
-            "StringParametersTestClass.String(\"\u008A \u008B \u008C \u008D \u008E\")",
-            "StringParametersTestClass.String(\"\u008F \u0090 \u0091 \u0092 \u0093\")",
-            "StringParametersTestClass.String(\"\u0094 \u0095 \u0096 \u0097 \u0098\")",
-            "StringParametersTestClass.String(\"\u0099 \u009A \u009B \u009C \u009D\")",
-            "StringParametersTestClass.String(\"\u009E \u009F \\u0085 \u00A0 \u1680\")",
-            "StringParametersTestClass.String(\"\u2000 \u2001 \u2002 \u2003 \u2004\")",
-            "StringParametersTestClass.String(\"\u2005 \u2006 \u2007 \u2008 \u2009\")",
-            "StringParametersTestClass.String(\"\u200A \\u2028 \\u2029 \u202F \u205F\")",
-            "StringParametersTestClass.String(\"\u3000\")"
+            "StringParametersTestClass.String(\"\\u0001 \\u0002 \\u0003 \\u0004 \\u0005\")",
+            "StringParametersTestClass.String(\"\\u0006 \\u000E \\u000F \\u0010 \\u0011\")",
+            "StringParametersTestClass.String(\"\\u0012 \\u0013 \\u0014 \\u0015 \\u0016\")",
+            "StringParametersTestClass.String(\"\\u0017 \\u0018 \\u0019 \\u001A \\u001B\")",
+            "StringParametersTestClass.String(\"\\u001C \\u001D \\u001E \\u001F \\u007F\")",
+            "StringParametersTestClass.String(\"\\u0080 \\u0081 \\u0082 \\u0083 \\u0084\")",
+            "StringParametersTestClass.String(\"\\u0085 \\u0086 \\u0087 \\u0088 \\u0089\")",
+            "StringParametersTestClass.String(\"\\u008A \\u008B \\u008C \\u008D \\u008E\")",
+            "StringParametersTestClass.String(\"\\u008F \\u0090 \\u0091 \\u0092 \\u0093\")",
+            "StringParametersTestClass.String(\"\\u0094 \\u0095 \\u0096 \\u0097 \\u0098\")",
+            "StringParametersTestClass.String(\"\\u0099 \\u009A \\u009B \\u009C \\u009D\")",
+            "StringParametersTestClass.String(\"\\u009E \\u009F \\u0085 \\u00A0 \\u1680\")",
+            "StringParametersTestClass.String(\"\\u2000 \\u2001 \\u2002 \\u2003 \\u2004\")",
+            "StringParametersTestClass.String(\"\\u2005 \\u2006 \\u2007 \\u2008 \\u2009\")",
+            "StringParametersTestClass.String(\"\\u200A \\u2028 \\u2029 \\u202F \\u205F\")",
+            "StringParametersTestClass.String(\"\\u3000\")"
         );
     }
 

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Fixie.Tests;
+namespace Fixie.Tests;
 
 public class CaseNameTests
 {
@@ -213,11 +213,6 @@ public class CaseNameTests
 
     void ShouldHaveNames(IEnumerable<string> actual, params string[] expected)
     {
-        const int variants = 4;
-
-        var actualArray = actual.ToArray();
-        actualArray.Length.ShouldBe(expected.Length * variants);
-
         var expectedVariants = expected.Select(name => new[]
         {
             name.Contains("Incompatible")
@@ -230,8 +225,7 @@ public class CaseNameTests
 
         var fullyQualifiedExpectation = expectedVariants.Select(x => GetType().FullName + "+" + x).ToArray();
 
-        foreach (var (first, second) in actualArray.Zip(fullyQualifiedExpectation))
-            first.ShouldBe(second);
+        actual.ToArray().ShouldMatch(fullyQualifiedExpectation);
     }
 
     class ObjectWithNullStringRepresentation

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -58,32 +58,26 @@ static class CaseNameBuilder
         return "\"" + sb + "\"";
     }
 
-    static string Escape(this char ch, Literal literal)
-    {
-        switch (ch)
+    static string Escape(this char ch, Literal literal) =>
+        ch switch
         {
-            case '\0': return @"\0";
-            case '\a': return @"\a";
-            case '\b': return @"\b";
-            case '\t': return @"\t";
-            case '\n': return @"\n";
-            case '\v': return @"\v";
-            case '\f': return @"\f";
-            case '\r': return @"\r";
+            '\0' => @"\0",
+            '\a' => @"\a",
+            '\b' => @"\b",
+            '\t' => @"\t",
+            '\n' => @"\n",
+            '\v' => @"\v",
+            '\f' => @"\f",
+            '\r' => @"\r",
+            '\"' => literal == Literal.String ? @"\""" : char.ToString(ch),
+            '\'' => literal == Literal.Character ? @"\'" : char.ToString(ch),
+            '\\' => @"\\",
 
-            case '\"': return literal == Literal.String ? @"\""" : char.ToString(ch);
-            case '\'': return literal == Literal.Character ? @"\'" : char.ToString(ch);
-            case '\\': return @"\\";
+            //Paragraph Separator, Line Separator, Next Line
+            '\u0085' or '\u2028' or '\u2029' => $"\\u{(int)ch:X4}",
 
-            case '\u0085': //Next Line
-            case '\u2028': //Line Separator
-            case '\u2029': //Paragraph Separator
-                return $"\\u{(int)ch:X4}";
-
-            default:
-                return char.ToString(ch);
-        }
-    }
+            _ => char.ToString(ch)
+        };
 
     enum Literal { Character, String }
 }

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -40,7 +40,7 @@ static class CaseNameBuilder
 
     static string CharacterLiteral(char ch)
     {
-        return "'" + ch.Escape(Literal.Character) + "'";
+        return "'" + Escape(ch, Literal.Character) + "'";
     }
 
     static string ShortStringLiteral(string s)
@@ -55,14 +55,14 @@ static class CaseNameBuilder
         sb.Append('"');
 
         foreach (var ch in s)
-            sb.Append(ch.Escape(Literal.String));
+            sb.Append(Escape(ch, Literal.String));
 
         sb.Append('"');
 
         return  sb.ToString();
     }
 
-    static string Escape(this char ch, Literal literal) =>
+    static string Escape(char ch, Literal literal) =>
         ch switch
         {
             '\0' => @"\0",

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -51,11 +51,15 @@ static class CaseNameBuilder
             s = s.Substring(0, trimLength) + "...";
 
         var sb = new StringBuilder();
+        
+        sb.Append('"');
 
         foreach (var ch in s)
             sb.Append(ch.Escape(Literal.String));
 
-        return "\"" + sb + "\"";
+        sb.Append('"');
+
+        return  sb.ToString();
     }
 
     static string Escape(this char ch, Literal literal) =>

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -30,6 +30,9 @@ static class CaseNameBuilder
         if (parameter is string s)
             return ShortStringLiteral(s);
 
+        if (parameter is bool b)
+            return b ? "true" : "false";
+
         var displayString = Convert.ToString(parameter, CultureInfo.InvariantCulture);
 
         if (displayString == null)

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -76,13 +76,11 @@ static class CaseNameBuilder
             '\v' => @"\v",
             '\f' => @"\f",
             '\r' => @"\r",
+            ' ' => " ",
             '\"' => literal == Literal.String ? @"\""" : char.ToString(ch),
             '\'' => literal == Literal.Character ? @"\'" : char.ToString(ch),
             '\\' => @"\\",
-
-            //Paragraph Separator, Line Separator, Next Line
-            '\u0085' or '\u2028' or '\u2029' => $"\\u{(int)ch:X4}",
-
+            _ when (char.IsControl(ch) || char.IsWhiteSpace(ch)) => $"\\u{(int)ch:X4}",
             _ => char.ToString(ch)
         };
 

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -62,8 +62,8 @@ static class CaseNameBuilder
     {
         switch (ch)
         {
-            case '\"': return literal == Literal.String ? @"\""" : Char.ToString(ch);
-            case '\'': return literal == Literal.Character ? @"\'" : Char.ToString(ch);
+            case '\"': return literal == Literal.String ? @"\""" : char.ToString(ch);
+            case '\'': return literal == Literal.Character ? @"\'" : char.ToString(ch);
 
             case '\\': return @"\\";
             case '\0': return @"\0";

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -62,18 +62,18 @@ static class CaseNameBuilder
     {
         switch (ch)
         {
-            case '\"': return literal == Literal.String ? @"\""" : char.ToString(ch);
-            case '\'': return literal == Literal.Character ? @"\'" : char.ToString(ch);
-
-            case '\\': return @"\\";
             case '\0': return @"\0";
             case '\a': return @"\a";
             case '\b': return @"\b";
-            case '\f': return @"\f";
-            case '\n': return @"\n";
-            case '\r': return @"\r";
             case '\t': return @"\t";
+            case '\n': return @"\n";
             case '\v': return @"\v";
+            case '\f': return @"\f";
+            case '\r': return @"\r";
+
+            case '\"': return literal == Literal.String ? @"\""" : char.ToString(ch);
+            case '\'': return literal == Literal.Character ? @"\'" : char.ToString(ch);
+            case '\\': return @"\\";
 
             case '\u0085': //Next Line
             case '\u2028': //Line Separator

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -78,8 +78,7 @@ static class CaseNameBuilder
             case '\u0085': //Next Line
             case '\u2028': //Line Separator
             case '\u2029': //Paragraph Separator
-                var digits = (int)ch;
-                return $"\\u{digits:X4}";
+                return $"\\u{(int)ch:X4}";
 
             default:
                 return char.ToString(ch);

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -62,18 +62,18 @@ static class CaseNameBuilder
     {
         switch (ch)
         {
-            case '\"': return literal == Literal.String ? "\\\"" : Char.ToString(ch);
-            case '\'': return literal == Literal.Character ? "\\\'" : Char.ToString(ch);
+            case '\"': return literal == Literal.String ? @"\""" : Char.ToString(ch);
+            case '\'': return literal == Literal.Character ? @"\'" : Char.ToString(ch);
 
-            case '\\': return "\\\\";
-            case '\0': return "\\0";
-            case '\a': return "\\a";
-            case '\b': return "\\b";
-            case '\f': return "\\f";
-            case '\n': return "\\n";
-            case '\r': return "\\r";
-            case '\t': return "\\t";
-            case '\v': return "\\v";
+            case '\\': return @"\\";
+            case '\0': return @"\0";
+            case '\a': return @"\a";
+            case '\b': return @"\b";
+            case '\f': return @"\f";
+            case '\n': return @"\n";
+            case '\r': return @"\r";
+            case '\t': return @"\t";
+            case '\v': return @"\v";
 
             case '\u0085': //Next Line
             case '\u2028': //Line Separator


### PR DESCRIPTION
This improves the handling of C# values serialized when building the name of a parameterized case, based on lessons learned during the development of rich serialization in the separate Fixie.Assertions repo.

1. Bools are serialized with the same lowercase as their keyword.
2. `\uxxxx` four-digit unicode escape sequences are used for all control characters and whitespace characters that do not already have a more terse unambiguous representation in char/string literals. Single-character escape sequences and the literal space " " take precedent, otherwise control/whitespace characters appear with `\uxxxx` format.