### PR TITLE
Add target framework `net9.0`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0
+            9.0
       - run: dotnet --info
       - name: Build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0
+            9.0
       - run: dotnet --info
       - name: Build
         env:

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -20,6 +20,11 @@
         <dependency id="Mono.Cecil" version="0.11.5" />
         <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
       </group>
+      <group targetFramework="net9.0">
+        <dependency id="Fixie" version="[$version$]" />
+        <dependency id="Mono.Cecil" version="0.11.5" />
+        <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -28,7 +33,9 @@
     <file target="icon.png" src="..\..\img\fixie_256.png" />
 
     <!-- Run-Time Assets -->
-    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release\Fixie.TestAdapter.dll" />
-    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release\Fixie.TestAdapter.pdb" />
+    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net8.0\Fixie.TestAdapter.dll" />
+    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net8.0\Fixie.TestAdapter.pdb" />
+    <file target="lib\net9.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net9.0\Fixie.TestAdapter.dll" />
+    <file target="lib\net9.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net9.0\Fixie.TestAdapter.pdb" />
   </files>
 </package>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Fixie.props" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -9,7 +9,13 @@ public static class Utility
     public static TestEnvironment GetTestEnvironment(TextWriter console) =>
         new(typeof(TestProject).Assembly, null, console, customArguments: []);
 
-    public const string TargetFrameworkVersion = "8.0";
+    public const string TargetFrameworkVersion =
+        #if NET8_0
+        "8.0"
+        #elif NET9_0
+        "9.0"
+        #endif
+        ;
 
     public static string FullName<T>()
     {

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Ergonomic Testing for .NET</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This adds target framework `net9.0` where appropriate:

- Ensure that the GitHub Actions build environment includes the .NET 9.0 SDK.
- Add target framework `net9.0` to the `Fixie`, `Fixie.TestAdapter`, and `Fixie.Tests` projects.
  - Deliberately leave the `Fixie.Console` project targeting our support window's lower bound of `net8.0`. As a `dotnet ...` tool definition, we target the lower bound and already compensate for that with `RollForward` behavior.
- Mirror `Fixie.TestAdapter` csproj changes in the corresponding nuspec.
- Address all test failures that appeared while running on `net8.0`.
  - This often involves changes to the careful cleanup of stack traces so that assertion failures are not complicated by `Method.Invoke` minutia, but this time it was limited to making sure that any assertions that include the target framework moniker in expectation text work whether the tests are running for `net8.0` or `net9.0`.
