### PR TITLE
Escape the Escape Character

### DIFF
--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -76,6 +76,11 @@ static class CaseNameBuilder
             '\v' => @"\v",
             '\f' => @"\f",
             '\r' => @"\r",
+
+            #if NET9_0_OR_GREATER
+            '\e' => @"\e",
+            #endif
+
             ' ' => " ",
             '\"' => literal == Literal.String ? @"\""" : char.ToString(ch),
             '\'' => literal == Literal.Character ? @"\'" : char.ToString(ch),


### PR DESCRIPTION
String and char serialization in parameterized case names respects the `'\e'` escape sequence introduced in C# 13. For earlier C# versions, continue to use the supported sequence `\u001B`.
