### PR TITLE
Move SourceLocationProvider from deprecated `Fixie.TestAdapter` project to `Fixie` project.

### DIFF
--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -17,12 +17,10 @@
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Fixie" version="[$version$]" />
-        <dependency id="Mono.Cecil" version="0.11.5" />
         <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
       </group>
       <group targetFramework="net9.0">
         <dependency id="Fixie" version="[$version$]" />
-        <dependency id="Mono.Cecil" version="0.11.5" />
         <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
       </group>
     </dependencies>

--- a/src/Fixie.Tests/Internal/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/Internal/SourceLocationProviderTests.cs
@@ -1,7 +1,7 @@
 ﻿using Fixie.Internal;
 using static Fixie.Tests.Utility;
 
-namespace Fixie.Tests.TestAdapter;
+namespace Fixie.Tests.Internal;
 
 public class SourceLocationProviderTests
 {

--- a/src/Fixie.Tests/Internal/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/Internal/SourceLocationSamples.cs
@@ -1,4 +1,4 @@
-﻿namespace Fixie.Tests.TestAdapter;
+﻿namespace Fixie.Tests.Internal;
 
 // Avoid changes in this file that would move the well-known line numbers indicated in comments.
 // Otherwise, these comments and the associated assertions would need to be updated together

--- a/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using Fixie.TestAdapter;
+﻿using Fixie.Internal;
 using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.TestAdapter;

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -15,4 +15,8 @@
     <None Include="..\..\buildMultiTargeting\**" Pack="true" PackagePath="buildMultiTargeting" Visible="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" />
+  </ItemGroup>
+
 </Project>

--- a/src/Fixie/Internal/SourceLocation.cs
+++ b/src/Fixie/Internal/SourceLocation.cs
@@ -1,4 +1,4 @@
-﻿namespace Fixie.TestAdapter;
+﻿namespace Fixie.Internal;
 
 class SourceLocation
 {

--- a/src/Fixie/Internal/SourceLocationProvider.cs
+++ b/src/Fixie/Internal/SourceLocationProvider.cs
@@ -4,7 +4,7 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
 
-namespace Fixie.TestAdapter;
+namespace Fixie.Internal;
 
 class SourceLocationProvider
 {


### PR DESCRIPTION
The upcoming pivot from the legacy MS Test SDK to the new MS Testing Platform involves dropping the deprecated `Fixie.TestAdapter` project in favor of the modern equivalent. Prior to dropping that project, though, we want to salvage the last useful aspect of it which may come in handy during the MS Testing Platform integration: `SourceLocationProvider`'s ability to infer line numbers for test methods.

Early experimentation with MS Testing Platform suggests that in at least some circumstances, we won't need to calculate line numbers ourselves anymore. However, some of that testing revealed that allowing the test platform to do the work for us is inconsistent (as soon as we started to explicitly indicate which test method we discovered, instead of relying only on the implication of its name, the test platform would start dropping the ball and skipping line number inference). So ultimately we might be able to drop `SourceLocationProvider`, but during the pivot to the MS Testing Platform we need to assume that it'll be necessary.

`SourceLocationProvider` is the last remaining aspect of `Fixie.TestAdapter` worth salvaging, and so we move it and its `Mono.Cecil` dependency from `Fixie.TestAdapter` to `Fixie` proper.

Note that as long as the `Mono.Cecil` package had been referenced by `Fixie.TestAdapter.csproj`, we had to redundantly mention it in the project's `nuspec` file. Since `Fixie.csproj` is built with modern `dotnet pack` behavior without an explicit `nuspec`, the same effect is happening for us automatically and need not be replicated in that project. The resulting package contents do include corresponding changes to the `dependencies` section of the automatically generated `nuspec` within the package file.