### PR TITLE
Move Source Location Lookup

### DIFF
--- a/src/Fixie.TestAdapter/VsDiscoveryRecorder.cs
+++ b/src/Fixie.TestAdapter/VsDiscoveryRecorder.cs
@@ -1,45 +1,21 @@
 ﻿using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace Fixie.TestAdapter;
 
-class VsDiscoveryRecorder
+class VsDiscoveryRecorder(ITestCaseDiscoverySink discoverySink, string assemblyPath)
 {
-    readonly IMessageLogger log;
-    readonly ITestCaseDiscoverySink discoverySink;
-    readonly string assemblyPath;
-    readonly SourceLocationProvider sourceLocationProvider;
-
-    public VsDiscoveryRecorder(IMessageLogger log, ITestCaseDiscoverySink discoverySink, string assemblyPath)
-    {
-        this.log = log;
-        this.discoverySink = discoverySink;
-        this.assemblyPath = assemblyPath;
-
-        sourceLocationProvider = new SourceLocationProvider(assemblyPath);
-    }
-
     public void Record(PipeMessage.TestDiscovered testDiscovered)
     {
         var test = testDiscovered.Test;
-
-        SourceLocation? sourceLocation = null;
-
-        try
-        {
-            sourceLocationProvider.TryGetSourceLocation(test, out sourceLocation);
-        }
-        catch (Exception exception)
-        {
-            log.Error(exception.ToString());
-        }
 
         var discoveredTest = new TestCase(test, VsTestExecutor.Uri, assemblyPath)
         {
             DisplayName = test
         };
+
+        var sourceLocation = testDiscovered.SourceLocation;
 
         if (sourceLocation != null)
         {

--- a/src/Fixie.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.TestAdapter/VsTestDiscoverer.cs
@@ -48,7 +48,7 @@ class VsTestDiscoverer : ITestDiscoverer
 
             pipe.Send<PipeMessage.DiscoverTests>();
 
-            var recorder = new VsDiscoveryRecorder(log, discoverySink, assemblyPath);
+            var recorder = new VsDiscoveryRecorder(discoverySink, assemblyPath);
 
             while (true)
             {

--- a/src/Fixie.Tests/Internal/PipeMessageSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/PipeMessageSerializationTests.cs
@@ -25,8 +25,21 @@ public class PipeMessageSerializationTests : MessagingTests
 
     public void ShouldSerializeTestDiscoveredMessage()
     {
-        Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass" },
-            "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
+        Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass", SourceLocation = null },
+            """
+            {"Test":"Fixie.Tests.Reports.MessagingTests\u002BSampleTestClass.Pass","SourceLocation":null}
+            """);
+
+        var sourceLocation = new SourceLocation
+        {
+            CodeFilePath = "full-path-to-code-file",
+            LineNumber = 123
+        };
+
+        Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass", SourceLocation = sourceLocation },
+            """
+            {"Test":"Fixie.Tests.Reports.MessagingTests\u002BSampleTestClass.Pass","SourceLocation":{"CodeFilePath":"full-path-to-code-file","LineNumber":123}}
+            """);
     }
 
     public void ShouldSerializeTestStartedMessage()

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -44,7 +44,7 @@ public class EntryPoint
             pipeStream.Connect();
             pipeStream.ReadMode = PipeTransmissionMode.Byte;
                 
-            var testAdapterReport = new TestAdapterReport(pipe);
+            var testAdapterReport = new TestAdapterReport(environment, pipe);
 
             var exitCode = ExitCode.Success;
 

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -31,6 +31,7 @@ static class PipeMessage
     public class TestDiscovered
     {
         public required string Test { get; init; }
+        public required SourceLocation? SourceLocation { get; init; }
     }
 
     public class TestStarted

--- a/src/Fixie/Internal/SourceLocation.cs
+++ b/src/Fixie/Internal/SourceLocation.cs
@@ -2,12 +2,6 @@
 
 class SourceLocation
 {
-    public SourceLocation(string codeFilePath, int lineNumber)
-    {
-        CodeFilePath = codeFilePath;
-        LineNumber = lineNumber;
-    }
-
-    public string CodeFilePath { get; }
-    public int LineNumber { get; }
+    public required string CodeFilePath { get; init; }
+    public required int LineNumber { get; init; }
 }

--- a/src/Fixie/Internal/SourceLocationProvider.cs
+++ b/src/Fixie/Internal/SourceLocationProvider.cs
@@ -80,7 +80,11 @@ class SourceLocationProvider
         var sequencePoint = FirstOrDefaultSequencePoint(method);
 
         if (sequencePoint != null)
-            return new SourceLocation(sequencePoint.Document.Url, sequencePoint.StartLine);
+            return new SourceLocation
+            {
+                CodeFilePath = sequencePoint.Document.Url,
+                LineNumber = sequencePoint.StartLine
+            };
             
         return null;
     }

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -2,18 +2,38 @@
 
 namespace Fixie.Reports;
 
-class TestAdapterReport(TestAdapterPipe pipe) :
+class TestAdapterReport(TestEnvironment environment, TestAdapterPipe pipe) :
     IHandler<TestDiscovered>,
     IHandler<TestStarted>,
     IHandler<TestSkipped>,
     IHandler<TestPassed>,
     IHandler<TestFailed>
 {
+    readonly SourceLocationProvider sourceLocationProvider = new(environment.Assembly.Location);
+
     public Task Handle(TestDiscovered message)
     {
+        SourceLocation? sourceLocation = null;
+
+        try
+        {
+            sourceLocationProvider.TryGetSourceLocation(message.Test, out sourceLocation);
+        }
+        catch (Exception exception)
+        {
+            using (Foreground.Yellow)
+                environment.Console.WriteLine(
+                    $"{GetType().FullName} threw an exception while " +
+                    $"attempting to handle a message of type {typeof(TestDiscovered).FullName}:");
+            environment.Console.WriteLine();
+            environment.Console.WriteLine(exception.ToString());
+            environment.Console.WriteLine();
+        }
+
         pipe.Send(new PipeMessage.TestDiscovered
         {
-            Test = message.Test
+            Test = message.Test,
+            SourceLocation = sourceLocation
         });
 
         return Task.CompletedTask;


### PR DESCRIPTION
`TestAdapterReport` in the primary `Fixie` project is responsible for attempting source location lookups, instead of `VsDiscoveryRecorder` in the `Fixie.TestAdapter` project, because the test adapter project is deprecated.
