### PR TITLE
Remove target framework `net8.0`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug_net8.0/Fixie.Tests.dll",
+            "program": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug/Fixie.Tests.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug_net8.0",
+            "cwd": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
             "stopAtEntry": false

--- a/src/Fixie.Console/Fixie.Console.csproj
+++ b/src/Fixie.Console/Fixie.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>fixie</ToolCommandName>
     <Description>`dotnet fixie` console test runner for the Fixie test framework.</Description>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -15,10 +15,6 @@
     <copyright>$copyright$</copyright>
     <repository url="https://github.com/fixie/fixie" />
     <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="Fixie" version="[$version$]" />
-        <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
-      </group>
       <group targetFramework="net9.0">
         <dependency id="Fixie" version="[$version$]" />
         <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
@@ -31,9 +27,7 @@
     <file target="icon.png" src="..\..\img\fixie_256.png" />
 
     <!-- Run-Time Assets -->
-    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net8.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net8.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net8.0\Fixie.TestAdapter.pdb" />
-    <file target="lib\net9.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net9.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net9.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net9.0\Fixie.TestAdapter.pdb" />
+    <file target="lib\net9.0" src="..\artifacts\bin\Fixie.TestAdapter\release\Fixie.TestAdapter.dll" />
+    <file target="lib\net9.0" src="..\artifacts\bin\Fixie.TestAdapter\release\Fixie.TestAdapter.pdb" />
   </files>
 </package>

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -169,11 +169,7 @@ public class CaseNameTests
             "StringParametersTestClass.String(\"\\u0006 \\u000E \\u000F \\u0010 \\u0011\")",
             "StringParametersTestClass.String(\"\\u0012 \\u0013 \\u0014 \\u0015 \\u0016\")",
 
-            #if NET8_0
-            "StringParametersTestClass.String(\"\\u0017 \\u0018 \\u0019 \\u001A \\u001B\")",
-            #else
-            "StringParametersTestClass.String(\"\\u0017 \\u0018 \\u0019 \\u001A\")",
-            #endif
+            "StringParametersTestClass.String(\"\\u0017 \\u0018 \\u0019 \\u001A\")", //we omitted the one for 'escape' since it was explicit earlier.
 
             "StringParametersTestClass.String(\"\\u001C \\u001D \\u001E \\u001F \\u007F\")",
             "StringParametersTestClass.String(\"\\u0080 \\u0081 \\u0082 \\u0083 \\u0084\")",

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -39,9 +39,7 @@ public class CaseNameTests
             foreach (var c in new[] {'\\', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v'})
                 await Run(test, c);
 
-            #if NET9_0_OR_GREATER
             await Run(test, '\e');
-            #endif
             
             foreach (var c in new[] {'\u0000', '\u0085', '\u2028', '\u2029', '\u263A'})
                 await Run(test, c);
@@ -56,18 +54,14 @@ public class CaseNameTests
                 await Run(test, c);
 
             foreach (var c in UnicodeEscapedCharacters()
-                        #if NET9_0_OR_GREATER
                         .Where(c => c != '\e')
-                        #endif
                     )
                 await Run(test, c);
         });
 
         var unicodeEscapeExpectations = UnicodeEscapedCharacters()
 
-            #if NET9_0_OR_GREATER
             .Where(c => c != '\e')
-            #endif
 
             .Select(c => $"""
                           CharParametersTestClass.Char('\u{(int)c:X4}')
@@ -87,10 +81,7 @@ public class CaseNameTests
             "CharParametersTestClass.Char('\\r')",
             "CharParametersTestClass.Char('\\t')",
             "CharParametersTestClass.Char('\\v')",
-
-            #if NET9_0_OR_GREATER
             "CharParametersTestClass.Char('\\e')",
-            #endif
             
             "CharParametersTestClass.Char('\\0')",
             "CharParametersTestClass.Char('\\u0085')",
@@ -132,10 +123,7 @@ public class CaseNameTests
             await Run(test, " \' ' \" ");
             await Run(test, " \\ \0 \a \b ");
             await Run(test, " \f \n \r \t \v ");
-
-            #if NET9_0_OR_GREATER
             await Run(test, " \e ");
-            #endif
 
             await Run(test, " \u0000 \u0085 \u2028 \u2029 \u263A ");
             await Run(test, " \x0000 \x000 \x00 \x0 ");
@@ -144,9 +132,7 @@ public class CaseNameTests
             
             foreach (var c in UnicodeEscapedCharacters().Chunk(5)
 
-                         #if NET9_0_OR_GREATER
                          .Select(chunk => chunk.Where(c => c != '\e'))
-                         #endif
                          
                          .Select(chunk => string.Join(' ', chunk)))
                 await Run(test, c);
@@ -156,10 +142,7 @@ public class CaseNameTests
             "StringParametersTestClass.String(\" ' ' \\\" \")",
             "StringParametersTestClass.String(\" \\\\ \\0 \\a \\b \")",
             "StringParametersTestClass.String(\" \\f \\n \\r \\t \\v \")",
-
-            #if NET9_0_OR_GREATER
             "StringParametersTestClass.String(\" \\e \")",
-            #endif
 
             "StringParametersTestClass.String(\" \\0 \\u0085 \\u2028 \\u2029 ☺ \")",
             "StringParametersTestClass.String(\" \\0 \\0 \\0 \\0 \")",

--- a/src/Fixie.Tests/CaseNameTests.cs
+++ b/src/Fixie.Tests/CaseNameTests.cs
@@ -36,11 +36,9 @@ public class CaseNameTests
             foreach (var c in new[] {'\"', '"', '\''})
                 await Run(test, c);
             
-            foreach (var c in new[] {'\\', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v'})
+            foreach (var c in new[] {'\\', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\e'})
                 await Run(test, c);
 
-            await Run(test, '\e');
-            
             foreach (var c in new[] {'\u0000', '\u0085', '\u2028', '\u2029', '\u263A'})
                 await Run(test, c);
             
@@ -53,16 +51,11 @@ public class CaseNameTests
             foreach (var c in new[] {'\U00000000', '\U00000085', '\U00002028', '\U00002029', '\U0000263A'})
                 await Run(test, c);
 
-            foreach (var c in UnicodeEscapedCharacters()
-                        .Where(c => c != '\e')
-                    )
+            foreach (var c in UnicodeEscapedCharacters())
                 await Run(test, c);
         });
 
         var unicodeEscapeExpectations = UnicodeEscapedCharacters()
-
-            .Where(c => c != '\e')
-
             .Select(c => $"""
                           CharParametersTestClass.Char('\u{(int)c:X4}')
                           """);
@@ -122,8 +115,7 @@ public class CaseNameTests
         {
             await Run(test, " \' ' \" ");
             await Run(test, " \\ \0 \a \b ");
-            await Run(test, " \f \n \r \t \v ");
-            await Run(test, " \e ");
+            await Run(test, " \f \n \r \t \v \e ");
 
             await Run(test, " \u0000 \u0085 \u2028 \u2029 \u263A ");
             await Run(test, " \x0000 \x000 \x00 \x0 ");
@@ -131,9 +123,6 @@ public class CaseNameTests
             await Run(test, " \U00000000 \U00000085 \U00002028 \U00002029 \U0000263A ");
             
             foreach (var c in UnicodeEscapedCharacters().Chunk(5)
-
-                         .Select(chunk => chunk.Where(c => c != '\e'))
-                         
                          .Select(chunk => string.Join(' ', chunk)))
                 await Run(test, c);
         });
@@ -141,8 +130,7 @@ public class CaseNameTests
         ShouldHaveNames(output,
             "StringParametersTestClass.String(\" ' ' \\\" \")",
             "StringParametersTestClass.String(\" \\\\ \\0 \\a \\b \")",
-            "StringParametersTestClass.String(\" \\f \\n \\r \\t \\v \")",
-            "StringParametersTestClass.String(\" \\e \")",
+            "StringParametersTestClass.String(\" \\f \\n \\r \\t \\v \\e \")",
 
             "StringParametersTestClass.String(\" \\0 \\u0085 \\u2028 \\u2029 ☺ \")",
             "StringParametersTestClass.String(\" \\0 \\0 \\0 \\0 \")",
@@ -152,20 +140,19 @@ public class CaseNameTests
             "StringParametersTestClass.String(\"\\u0006 \\u000E \\u000F \\u0010 \\u0011\")",
             "StringParametersTestClass.String(\"\\u0012 \\u0013 \\u0014 \\u0015 \\u0016\")",
 
-            "StringParametersTestClass.String(\"\\u0017 \\u0018 \\u0019 \\u001A\")", //we omitted the one for 'escape' since it was explicit earlier.
+            "StringParametersTestClass.String(\"\\u0017 \\u0018 \\u0019 \\u001A \\u001C\")",
 
-            "StringParametersTestClass.String(\"\\u001C \\u001D \\u001E \\u001F \\u007F\")",
-            "StringParametersTestClass.String(\"\\u0080 \\u0081 \\u0082 \\u0083 \\u0084\")",
-            "StringParametersTestClass.String(\"\\u0085 \\u0086 \\u0087 \\u0088 \\u0089\")",
-            "StringParametersTestClass.String(\"\\u008A \\u008B \\u008C \\u008D \\u008E\")",
-            "StringParametersTestClass.String(\"\\u008F \\u0090 \\u0091 \\u0092 \\u0093\")",
-            "StringParametersTestClass.String(\"\\u0094 \\u0095 \\u0096 \\u0097 \\u0098\")",
-            "StringParametersTestClass.String(\"\\u0099 \\u009A \\u009B \\u009C \\u009D\")",
-            "StringParametersTestClass.String(\"\\u009E \\u009F \\u0085 \\u00A0 \\u1680\")",
-            "StringParametersTestClass.String(\"\\u2000 \\u2001 \\u2002 \\u2003 \\u2004\")",
-            "StringParametersTestClass.String(\"\\u2005 \\u2006 \\u2007 \\u2008 \\u2009\")",
-            "StringParametersTestClass.String(\"\\u200A \\u2028 \\u2029 \\u202F \\u205F\")",
-            "StringParametersTestClass.String(\"\\u3000\")"
+            "StringParametersTestClass.String(\"\\u001D \\u001E \\u001F \\u007F \\u0080\")",
+            "StringParametersTestClass.String(\"\\u0081 \\u0082 \\u0083 \\u0084 \\u0085\")",
+            "StringParametersTestClass.String(\"\\u0086 \\u0087 \\u0088 \\u0089 \\u008A\")",
+            "StringParametersTestClass.String(\"\\u008B \\u008C \\u008D \\u008E \\u008F\")",
+            "StringParametersTestClass.String(\"\\u0090 \\u0091 \\u0092 \\u0093 \\u0094\")",
+            "StringParametersTestClass.String(\"\\u0095 \\u0096 \\u0097 \\u0098 \\u0099\")",
+            "StringParametersTestClass.String(\"\\u009A \\u009B \\u009C \\u009D \\u009E\")",
+            "StringParametersTestClass.String(\"\\u009F \\u0085 \\u00A0 \\u1680 \\u2000\")",
+            "StringParametersTestClass.String(\"\\u2001 \\u2002 \\u2003 \\u2004 \\u2005\")",
+            "StringParametersTestClass.String(\"\\u2006 \\u2007 \\u2008 \\u2009 \\u200A\")",
+            "StringParametersTestClass.String(\"\\u2028 \\u2029 \\u202F \\u205F \\u3000\")"
         );
     }
 
@@ -277,7 +264,8 @@ public class CaseNameTests
         // '\uHHHH' hex escape sequences.
 
         for (char c = '\u0001'; c <= '\u0006'; c++) yield return c;
-        for (char c = '\u000E'; c <= '\u001F'; c++) yield return c;
+        for (char c = '\u000E'; c <= '\u001A'; c++) yield return c;
+        for (char c = '\u001C'; c <= '\u001F'; c++) yield return c;
         yield return '\u007F';
         for (char c = '\u0080'; c <= '\u009F'; c++) yield return c;
 

--- a/src/Fixie.Tests/Console/CommandLineTests.cs
+++ b/src/Fixie.Tests/Console/CommandLineTests.cs
@@ -7,11 +7,11 @@ public class CommandLineTests
     public void ShouldPartitionRunnerArgumentsFromCustomArguments()
     {
         CommandLine.Partition([
-            "Example.Tests", "--configuration", "Release", "--framework", "net8.0",
+            "Example.Tests", "--configuration", "Release", "--framework", "net9.0",
             "--",
             "customA", "customB", "customC"
         ], out var runnerArguments, out var customArguments);
-        runnerArguments.ShouldMatch(["Example.Tests", "--configuration", "Release", "--framework", "net8.0"]);
+        runnerArguments.ShouldMatch(["Example.Tests", "--configuration", "Release", "--framework", "net9.0"]);
         customArguments.ShouldMatch(["customA", "customB", "customC"]);
 
         CommandLine.Partition(["Example.Tests", "--", "custom"], out runnerArguments, out customArguments);

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Fixie.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -9,13 +9,7 @@ public static class Utility
     public static TestEnvironment GetTestEnvironment(TextWriter console) =>
         new(typeof(TestProject).Assembly, null, console, customArguments: []);
 
-    public const string TargetFrameworkVersion =
-        #if NET8_0
-        "8.0"
-        #elif NET9_0
-        "9.0"
-        #endif
-        ;
+    public const string TargetFrameworkVersion = "9.0";
 
     public static string FullName<T>()
     {

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <Description>Ergonomic Testing for .NET</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Fixie/Internal/CaseNameBuilder.cs
+++ b/src/Fixie/Internal/CaseNameBuilder.cs
@@ -76,11 +76,7 @@ static class CaseNameBuilder
             '\v' => @"\v",
             '\f' => @"\f",
             '\r' => @"\r",
-
-            #if NET9_0_OR_GREATER
             '\e' => @"\e",
-            #endif
-
             ' ' => " ",
             '\"' => literal == Literal.String ? @"\""" : char.ToString(ch),
             '\'' => literal == Literal.Character ? @"\'" : char.ToString(ch),


### PR DESCRIPTION
This phases out deprecated target framework `net8.0`, which will not pass the end of it's own support window until November 10, 2026.

The rationale is that Fixie 5.0 is intended to be released sometime after `net10.0` is released in late 2025, marking the start of a new LTS cycle. Leaving in support for `net8.0` at that time would put us several years behind on adopting modern C# and .NET features.

This raises the "floor" for the solution from `net8.0` and `C# 12` to `net9.0` and `C# 13`.