### PR TITLE
Remove target framework `net9.0`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,6 +57,6 @@ Please start by opening an Issue to discuss the motivation, the proposed change,
 
 ## Target Framework Changes
 
-**Honestly, you don't want to do this.** Adding or removing a target framework (eg. `net9.0`) is especially impactful and carries with it several gotchas specific to Fixie's roadmap planning, implementation, packaging, end to end testing, and end user environment support goals.
+**Honestly, you don't want to do this.** Adding or removing a target framework is especially impactful and carries with it several gotchas specific to Fixie's roadmap planning, implementation, packaging, end to end testing, and end user environment support goals.
 
 **An unanticipated PR for adding or removing a target framework will be rejected.**

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug_net9.0/Fixie.Tests.dll",
+            "program": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug/Fixie.Tests.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug_net9.0",
+            "cwd": "${workspaceFolder}/src/artifacts/bin/Fixie.Tests/debug",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
             "stopAtEntry": false

--- a/src/Fixie.Console/Fixie.Console.csproj
+++ b/src/Fixie.Console/Fixie.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>fixie</ToolCommandName>
     <Description>`dotnet fixie` console test runner for the Fixie test framework.</Description>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -11,7 +11,7 @@
   </Target>
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Visual Studio integration for the Fixie test framework.</Description>
     <NuspecFile>Fixie.TestAdapter.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -15,11 +15,6 @@
     <copyright>$copyright$</copyright>
     <repository url="https://github.com/fixie/fixie" />
     <dependencies>
-      <group targetFramework="net9.0">
-        <dependency id="Fixie" version="[$version$]" />
-        <dependency id="Mono.Cecil" version="0.11.5" />
-        <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
-      </group>
       <group targetFramework="net10.0">
         <dependency id="Fixie" version="[$version$]" />
         <dependency id="Mono.Cecil" version="0.11.5" />
@@ -33,9 +28,7 @@
     <file target="icon.png" src="..\..\img\fixie_256.png" />
 
     <!-- Run-Time Assets -->
-    <file target="lib\net9.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net9.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net9.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net9.0\Fixie.TestAdapter.pdb" />
-    <file target="lib\net10.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net10.0\Fixie.TestAdapter.dll" />
-    <file target="lib\net10.0" src="..\artifacts\bin\Fixie.TestAdapter\release_net10.0\Fixie.TestAdapter.pdb" />
+    <file target="lib\net10.0" src="..\artifacts\bin\Fixie.TestAdapter\release\Fixie.TestAdapter.dll" />
+    <file target="lib\net10.0" src="..\artifacts\bin\Fixie.TestAdapter\release\Fixie.TestAdapter.pdb" />
   </files>
 </package>

--- a/src/Fixie.Tests/Fixie.Tests.csproj
+++ b/src/Fixie.Tests/Fixie.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\Fixie.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fixie.Tests/Utility.cs
+++ b/src/Fixie.Tests/Utility.cs
@@ -9,13 +9,7 @@ public static class Utility
     public static TestEnvironment GetTestEnvironment(TextWriter console) =>
         new(typeof(TestProject).Assembly, null, console, customArguments: []);
 
-    public const string TargetFrameworkVersion =
-        #if NET9_0
-        "9.0"
-        #elif NET10_0
-        "10.0"
-        #endif
-        ;
+    public const string TargetFrameworkVersion = "10.0";
 
     public static string FullName<T>()
     {

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Ergonomic Testing for .NET</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This phases out deprecated target framework `net9.0`, which will not pass the end of it's own support window until November 10, 2026.

The rationale is that Fixie 5.0 is intended to target `net10.0` which was released in November 2025, marking the start of a new LTS cycle. Leaving in support for `net9.0` would put us several years behind on adopting modern C# and .NET features.

This raises the "floor" for the solution from `net9.0` and `C# 13` to `net10.0` and `C# 14`.