### PR TITLE
Move source location lookup

### DIFF
--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 

--- a/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
+++ b/src/Fixie.TestAdapter/Fixie.TestAdapter.nuspec
@@ -17,7 +17,6 @@
     <dependencies>
       <group targetFramework="net10.0">
         <dependency id="Fixie" version="[$version$]" />
-        <dependency id="Mono.Cecil" version="0.11.5" />
         <dependency id="Microsoft.NET.Test.Sdk" version="17.8.0" />
       </group>
     </dependencies>

--- a/src/Fixie.TestAdapter/VsDiscoveryRecorder.cs
+++ b/src/Fixie.TestAdapter/VsDiscoveryRecorder.cs
@@ -1,45 +1,21 @@
 ﻿using Fixie.Internal;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace Fixie.TestAdapter;
 
-class VsDiscoveryRecorder
+class VsDiscoveryRecorder(ITestCaseDiscoverySink discoverySink, string assemblyPath)
 {
-    readonly IMessageLogger log;
-    readonly ITestCaseDiscoverySink discoverySink;
-    readonly string assemblyPath;
-    readonly SourceLocationProvider sourceLocationProvider;
-
-    public VsDiscoveryRecorder(IMessageLogger log, ITestCaseDiscoverySink discoverySink, string assemblyPath)
-    {
-        this.log = log;
-        this.discoverySink = discoverySink;
-        this.assemblyPath = assemblyPath;
-
-        sourceLocationProvider = new SourceLocationProvider(assemblyPath);
-    }
-
     public void Record(PipeMessage.TestDiscovered testDiscovered)
     {
         var test = testDiscovered.Test;
-
-        SourceLocation? sourceLocation = null;
-
-        try
-        {
-            sourceLocationProvider.TryGetSourceLocation(test, out sourceLocation);
-        }
-        catch (Exception exception)
-        {
-            log.Error(exception.ToString());
-        }
 
         var discoveredTest = new TestCase(test, VsTestExecutor.Uri, assemblyPath)
         {
             DisplayName = test
         };
+
+        var sourceLocation = testDiscovered.SourceLocation;
 
         if (sourceLocation != null)
         {

--- a/src/Fixie.TestAdapter/VsTestDiscoverer.cs
+++ b/src/Fixie.TestAdapter/VsTestDiscoverer.cs
@@ -48,7 +48,7 @@ class VsTestDiscoverer : ITestDiscoverer
 
             pipe.Send<PipeMessage.DiscoverTests>();
 
-            var recorder = new VsDiscoveryRecorder(log, discoverySink, assemblyPath);
+            var recorder = new VsDiscoveryRecorder(discoverySink, assemblyPath);
 
             while (true)
             {

--- a/src/Fixie.Tests/Internal/PipeMessageSerializationTests.cs
+++ b/src/Fixie.Tests/Internal/PipeMessageSerializationTests.cs
@@ -25,8 +25,21 @@ public class PipeMessageSerializationTests : MessagingTests
 
     public void ShouldSerializeTestDiscoveredMessage()
     {
-        Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass" },
-            "{\"Test\":\"Fixie.Tests.Reports.MessagingTests\\u002BSampleTestClass.Pass\"}");
+        Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass", SourceLocation = null },
+            """
+            {"Test":"Fixie.Tests.Reports.MessagingTests\u002BSampleTestClass.Pass","SourceLocation":null}
+            """);
+
+        var sourceLocation = new SourceLocation
+        {
+            CodeFilePath = "full-path-to-code-file",
+            LineNumber = 123
+        };
+
+        Expect(new PipeMessage.TestDiscovered { Test = TestClass + ".Pass", SourceLocation = sourceLocation },
+            """
+            {"Test":"Fixie.Tests.Reports.MessagingTests\u002BSampleTestClass.Pass","SourceLocation":{"CodeFilePath":"full-path-to-code-file","LineNumber":123}}
+            """);
     }
 
     public void ShouldSerializeTestStartedMessage()

--- a/src/Fixie.Tests/Internal/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/Internal/SourceLocationProviderTests.cs
@@ -1,7 +1,7 @@
 ﻿using Fixie.Internal;
 using static Fixie.Tests.Utility;
 
-namespace Fixie.Tests.TestAdapter;
+namespace Fixie.Tests.Internal;
 
 public class SourceLocationProviderTests
 {

--- a/src/Fixie.Tests/Internal/SourceLocationSamples.cs
+++ b/src/Fixie.Tests/Internal/SourceLocationSamples.cs
@@ -1,4 +1,4 @@
-﻿namespace Fixie.Tests.TestAdapter;
+﻿namespace Fixie.Tests.Internal;
 
 // Avoid changes in this file that would move the well-known line numbers indicated in comments.
 // Otherwise, these comments and the associated assertions would need to be updated together

--- a/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/SourceLocationProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using Fixie.TestAdapter;
+﻿using Fixie.Internal;
 using static Fixie.Tests.Utility;
 
 namespace Fixie.Tests.TestAdapter;

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -2,7 +2,6 @@
 using Fixie.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Fixie.Tests.Reports;
 
 namespace Fixie.Tests.TestAdapter;
@@ -15,9 +14,9 @@ public class VsDiscoveryRecorderTests : MessagingTests
 
         var discoverySink = new StubTestCaseDiscoverySink();
 
-        var vsDiscoveryRecorder = new VsDiscoveryRecorder(discoverySink, assemblyPath);
+        var discoveryRecorder = new VsDiscoveryRecorder(discoverySink, assemblyPath);
 
-        RecordAnticipatedPipeMessages(assemblyPath, vsDiscoveryRecorder, sourceLocationsExist: true);
+        RecordAnticipatedPipeMessages(assemblyPath, discoveryRecorder, sourceLocationsExist: true);
 
         discoverySink.TestCases.ItemsShouldSatisfy([
             x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Fail", assemblyPath),
@@ -97,14 +96,6 @@ public class VsDiscoveryRecorderTests : MessagingTests
             Test = test,
             SourceLocation = sourceLocation
         });
-    }
-
-    class StubMessageLogger : IMessageLogger
-    {
-        public List<string> Messages { get; } = [];
-
-        public void SendMessage(TestMessageLevel testMessageLevel, string message)
-            => Messages.Add($"{testMessageLevel}: {message}");
     }
 
     class StubTestCaseDiscoverySink : ITestCaseDiscoverySink

--- a/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
+++ b/src/Fixie.Tests/TestAdapter/VsDiscoveryRecorderTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Fixie.Tests.Reports;
-using static System.IO.Directory;
 
 namespace Fixie.Tests.TestAdapter;
 
@@ -14,14 +13,11 @@ public class VsDiscoveryRecorderTests : MessagingTests
     {
         var assemblyPath = typeof(MessagingTests).Assembly.Location;
 
-        var log = new StubMessageLogger();
         var discoverySink = new StubTestCaseDiscoverySink();
 
-        var vsDiscoveryRecorder = new VsDiscoveryRecorder(log, discoverySink, assemblyPath);
+        var vsDiscoveryRecorder = new VsDiscoveryRecorder(discoverySink, assemblyPath);
 
-        RecordAnticipatedPipeMessages(vsDiscoveryRecorder);
-
-        log.Messages.ShouldMatch([]);
+        RecordAnticipatedPipeMessages(assemblyPath, vsDiscoveryRecorder, sourceLocationsExist: true);
 
         discoverySink.TestCases.ItemsShouldSatisfy([
             x => x.ShouldBeDiscoveryTimeTest(TestClass + ".Fail", assemblyPath),
@@ -36,23 +32,11 @@ public class VsDiscoveryRecorderTests : MessagingTests
     {
         const string invalidAssemblyPath = "assembly.path.dll";
 
-        var log = new StubMessageLogger();
         var discoverySink = new StubTestCaseDiscoverySink();
 
-        var discoveryRecorder = new VsDiscoveryRecorder(log, discoverySink, invalidAssemblyPath);
+        var discoveryRecorder = new VsDiscoveryRecorder(discoverySink, invalidAssemblyPath);
 
-        RecordAnticipatedPipeMessages(discoveryRecorder);
-
-        var expectedError =
-            $"Error: {typeof(FileNotFoundException).FullName}: " +
-            $"Could not find file '{Path.Combine(GetCurrentDirectory(), invalidAssemblyPath)}'.";
-        log.Messages.ItemsShouldSatisfy([
-            x => x.Contains(expectedError).ShouldBe(true),
-            x => x.Contains(expectedError).ShouldBe(true),
-            x => x.Contains(expectedError).ShouldBe(true),
-            x => x.Contains(expectedError).ShouldBe(true),
-            x => x.Contains(expectedError).ShouldBe(true)
-        ]);
+        RecordAnticipatedPipeMessages(invalidAssemblyPath, discoveryRecorder, sourceLocationsExist: false);
 
         discoverySink.TestCases.ItemsShouldSatisfy([
             x => x.ShouldBeDiscoveryTimeTestMissingSourceLocation(TestClass + ".Fail", invalidAssemblyPath),
@@ -63,31 +47,55 @@ public class VsDiscoveryRecorderTests : MessagingTests
         ]);
     }
 
-    void RecordAnticipatedPipeMessages(VsDiscoveryRecorder vsDiscoveryRecorder)
+    void RecordAnticipatedPipeMessages(string assemblyPath, VsDiscoveryRecorder vsDiscoveryRecorder, bool sourceLocationsExist)
     {
+        SourceLocationProvider sourceLocationProvider = new(assemblyPath);
+        SourceLocation? sourceLocation = null;
+
+        var test = TestClass + ".Fail";
+        if (sourceLocationsExist)
+            sourceLocationProvider.TryGetSourceLocation(test, out sourceLocation).ShouldBe(true);
         vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
         {
-            Test = TestClass + ".Fail"
+            Test = test,
+            SourceLocation = sourceLocation
         });
 
+        test = TestClass + ".FailByAssertion";
+        if (sourceLocationsExist)
+            sourceLocationProvider.TryGetSourceLocation(test, out sourceLocation).ShouldBe(true);
         vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
         {
-            Test = TestClass + ".FailByAssertion"
+            Test = test,
+            SourceLocation = sourceLocation
         });
 
+        test = TestClass + ".Pass";
+        if (sourceLocationsExist)
+            sourceLocationProvider.TryGetSourceLocation(test, out sourceLocation).ShouldBe(false);
+        sourceLocation.ShouldBe(null);
         vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
         {
-            Test = TestClass + ".Pass"
+            Test = test,
+            SourceLocation = sourceLocation
         });
 
+        test = TestClass + ".Skip";
+        if (sourceLocationsExist)
+            sourceLocationProvider.TryGetSourceLocation(test, out sourceLocation).ShouldBe(true);
         vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
         {
-            Test = TestClass + ".Skip"
+            Test = test,
+            SourceLocation = sourceLocation
         });
 
+        test = GenericTestClass + ".ShouldBeString";
+        if (sourceLocationsExist)
+            sourceLocationProvider.TryGetSourceLocation(test, out sourceLocation).ShouldBe(true);
         vsDiscoveryRecorder.Record(new PipeMessage.TestDiscovered
         {
-            Test = GenericTestClass + ".ShouldBeString"
+            Test = test,
+            SourceLocation = sourceLocation
         });
     }
 

--- a/src/Fixie/Fixie.csproj
+++ b/src/Fixie/Fixie.csproj
@@ -15,4 +15,8 @@
     <None Include="..\..\buildMultiTargeting\**" Pack="true" PackagePath="buildMultiTargeting" Visible="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" />
+  </ItemGroup>
+
 </Project>

--- a/src/Fixie/Internal/EntryPoint.cs
+++ b/src/Fixie/Internal/EntryPoint.cs
@@ -44,7 +44,7 @@ public class EntryPoint
             pipeStream.Connect();
             pipeStream.ReadMode = PipeTransmissionMode.Byte;
                 
-            var testAdapterReport = new TestAdapterReport(pipe);
+            var testAdapterReport = new TestAdapterReport(environment, pipe);
 
             var exitCode = ExitCode.Success;
 

--- a/src/Fixie/Internal/PipeMessage.cs
+++ b/src/Fixie/Internal/PipeMessage.cs
@@ -31,6 +31,7 @@ static class PipeMessage
     public class TestDiscovered
     {
         public required string Test { get; init; }
+        public required SourceLocation? SourceLocation { get; init; }
     }
 
     public class TestStarted

--- a/src/Fixie/Internal/SourceLocation.cs
+++ b/src/Fixie/Internal/SourceLocation.cs
@@ -2,12 +2,6 @@
 
 class SourceLocation
 {
-    public SourceLocation(string codeFilePath, int lineNumber)
-    {
-        CodeFilePath = codeFilePath;
-        LineNumber = lineNumber;
-    }
-
-    public string CodeFilePath { get; }
-    public int LineNumber { get; }
+    public required string CodeFilePath { get; init; }
+    public required int LineNumber { get; init; }
 }

--- a/src/Fixie/Internal/SourceLocation.cs
+++ b/src/Fixie/Internal/SourceLocation.cs
@@ -1,4 +1,4 @@
-﻿namespace Fixie.TestAdapter;
+﻿namespace Fixie.Internal;
 
 class SourceLocation
 {

--- a/src/Fixie/Internal/SourceLocationProvider.cs
+++ b/src/Fixie/Internal/SourceLocationProvider.cs
@@ -4,7 +4,7 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
 
-namespace Fixie.TestAdapter;
+namespace Fixie.Internal;
 
 class SourceLocationProvider
 {

--- a/src/Fixie/Internal/SourceLocationProvider.cs
+++ b/src/Fixie/Internal/SourceLocationProvider.cs
@@ -80,7 +80,11 @@ class SourceLocationProvider
         var sequencePoint = FirstOrDefaultSequencePoint(method);
 
         if (sequencePoint != null)
-            return new SourceLocation(sequencePoint.Document.Url, sequencePoint.StartLine);
+            return new SourceLocation
+            {
+                CodeFilePath = sequencePoint.Document.Url,
+                LineNumber = sequencePoint.StartLine
+            };
             
         return null;
     }

--- a/src/Fixie/Reports/TestAdapterReport.cs
+++ b/src/Fixie/Reports/TestAdapterReport.cs
@@ -2,18 +2,38 @@
 
 namespace Fixie.Reports;
 
-class TestAdapterReport(TestAdapterPipe pipe) :
+class TestAdapterReport(TestEnvironment environment, TestAdapterPipe pipe) :
     IHandler<TestDiscovered>,
     IHandler<TestStarted>,
     IHandler<TestSkipped>,
     IHandler<TestPassed>,
     IHandler<TestFailed>
 {
+    readonly SourceLocationProvider sourceLocationProvider = new(environment.Assembly.Location);
+
     public Task Handle(TestDiscovered message)
     {
+        SourceLocation? sourceLocation = null;
+
+        try
+        {
+            sourceLocationProvider.TryGetSourceLocation(message.Test, out sourceLocation);
+        }
+        catch (Exception exception)
+        {
+            using (Foreground.Yellow)
+                environment.Console.WriteLine(
+                    $"{GetType().FullName} threw an exception while " +
+                    $"attempting to handle a message of type {typeof(TestDiscovered).FullName}:");
+            environment.Console.WriteLine();
+            environment.Console.WriteLine(exception.ToString());
+            environment.Console.WriteLine();
+        }
+
         pipe.Send(new PipeMessage.TestDiscovered
         {
-            Test = message.Test
+            Test = message.Test,
+            SourceLocation = sourceLocation
         });
 
         return Task.CompletedTask;


### PR DESCRIPTION
The upcoming pivot from the legacy MS Test SDK to the new MS Testing Platform involves dropping the deprecated `Fixie.TestAdapter` project in favor of the modern equivalent. Prior to dropping that project, though, we want to salvage the last useful aspect of it which may come in handy during the MS Testing Platform integration: `SourceLocationProvider`'s ability to infer line numbers for test methods.

Early experimentation with MS Testing Platform suggests that in at least some circumstances, we won't need to calculate line numbers ourselves anymore. However, some of that early testing against older builds of the MS Testing Platform revealed that allowing the test platform to do the work for us is inconsistent (as soon as we started to explicitly indicate which test method we discovered, instead of relying only on the implication of its name, the test platform would start dropping the ball and skipping line number inference). Ultimately we might be able to drop `SourceLocationProvider`, but during the pivot to the MS Testing Platform we need to assume that it'll be necessary.

`SourceLocationProvider` is the last remaining aspect of `Fixie.TestAdapter` worth salvaging, and so we move it and its `Mono.Cecil` dependency from `Fixie.TestAdapter` to `Fixie` proper.

Note that as long as the `Mono.Cecil` package had been referenced by `Fixie.TestAdapter.csproj`, we had to redundantly mention it in the project's `nuspec` file. Since `Fixie.csproj` is built with modern `dotnet pack` behavior without an explicit `nuspec`, the same effect is happening for us automatically and need not be replicated in that project. The resulting package contents do include corresponding changes to the `dependencies` section of the automatically generated `nuspec` within the package file.

`TestAdapterReport` in the primary `Fixie` project is responsible for attempting source location lookups now, instead of `VsDiscoveryRecorder` in the `Fixie.TestAdapter` project, because the test adapter project is deprecated. This is simply a move of the lookup from the receiver of test discovery messages to the sender of those messages.
